### PR TITLE
KeypadLinc uses correct handler for scene commands

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 - Fixed a bug where the MQTT client might close in an area that triggered an
   exception instead of a reconnect ([Issue #32][I32]).
 
+- KeypadLinc was using the wrong handler for scene commands ([Issue #34][I34]).
 
 ## [0.6.1]
 

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -90,6 +90,7 @@ class KeypadLinc(Dimmer):
             topic = self.msg_btn_on_off.render_topic(data)
             link.subscribe(topic, qos, handler)
 
+            handler = functools.partial(self.handle_scene, group=group)
             topic = self.msg_btn_scene.render_topic(data)
             link.subscribe(topic, qos, handler)
 
@@ -158,15 +159,18 @@ class KeypadLinc(Dimmer):
             return
 
     #-----------------------------------------------------------------------
-    def handle_scene(self, client, data, message):
+    def handle_scene(self, client, data, message, group):
         """TODO: doc
         """
-        LOG.debug("KeypadLinc message %s %s", message.topic, message.payload)
+        LOG.debug("KeypadLinc scene %s message %s %s", group, message.topic,
+                  message.payload)
 
         # Parse the input MQTT message.
         data = self.msg_scene_on_off.to_json(message.payload)
-        LOG.info("KeypadLinc input command: %s", data)
+        if not data:
+            return
 
+        LOG.info("KeypadLinc input command: %s", data)
         try:
             cmd = data.get('cmd')
             if cmd == 'on':
@@ -175,8 +179,6 @@ class KeypadLinc(Dimmer):
                 is_on = False
             else:
                 raise Exception("Invalid KeypadLinc cmd input '%s'" % cmd)
-
-            group = int(data.get('group', 0x01))
         except:
             LOG.exception("Invalid KeypadLinc command: %s", data)
             return


### PR DESCRIPTION
Fixes #34.  There are other issues remaining with scenes.  This is a very targeted update that does not address all of them.  One item to check:  I don't understand the extraction of `group` from `data` that some devices are doing.  I templated these changes from the working `handle_set()` method.  I noticed that Switch and Dimmer also attempt to get `group` from `data` in their `handle_scene()` methods.  Is this really correct?  Should KeypadLinc also do this?  ...only if the `group` argument to the method is `None`?