### PR TITLE
Add Support for Engine Version

### DIFF
--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -71,6 +71,7 @@ def get_engine(args, config):
     reply = util.send(config, topic, payload, False)
     return reply["status"]
 
+
 #===========================================================================
 def print_db(args, config):
     topic = "%s/%s" % (args.topic, args.address)

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -62,6 +62,16 @@ def set_flags(args, config):
 
 
 #===========================================================================
+def get_engine(args, config):
+    topic = "%s/%s" % (args.topic, args.address)
+    payload = {
+        "cmd" : "get_engine",
+        }
+
+    reply = util.send(config, topic, payload, False)
+    return reply["status"]
+
+#===========================================================================
 def print_db(args, config):
     topic = "%s/%s" % (args.topic, args.address)
     payload = {

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -82,6 +82,12 @@ def parse_args(args):
     sp.set_defaults(func=device.set_flags)
 
     #---------------------------------------
+    # device.get_engine command
+    sp = sub.add_parser("get-engine", help="Get device engine version.")
+    sp.add_argument("address", help="Device address or name.")
+    sp.set_defaults(func=device.get_engine)
+
+    #---------------------------------------
     # device.on command
     sp = sub.add_parser("on", help="Turn a device on.")
     sp.add_argument("-l", "--level", metavar="level", type=int, default=255,

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -57,6 +57,8 @@ class Device:
 
         # Extract the various files from the JSON data.
         obj.delta = data['delta']
+        if 'engine' in data:
+            obj.engine = data['engine']
 
         for d in data['used']:
             obj.add_entry(DeviceEntry.from_json(d), save=False)
@@ -96,6 +98,10 @@ class Device:
         # call to the device so we can check it against the version we have
         # stored.
         self.delta = None
+
+        # Engine version.  0 is i1, 1 is i2, 2 is i2cs.  It is obtained from
+        # a get_engine request (cmd=0x0D)
+        self.engine = None
 
         # Map of memory address (int) to DeviceEntry objects that are active
         # and in use.
@@ -151,6 +157,20 @@ class Device:
         """
         self.delta = delta
         if delta is not None:
+            self.save()
+
+    #-----------------------------------------------------------------------
+    def set_engine(self, engine):
+        """Set the device engine version.
+
+        This records the engine version of the device. 0 is i1, 1 is i2 and
+        2 is i2cs
+
+        Args:
+          engine:  (int) The engine version.  None to clear the engine.
+        """
+        self.engine = engine
+        if engine is not None:
             self.save()
 
     #-----------------------------------------------------------------------
@@ -408,6 +428,7 @@ class Device:
         return {
             'address' : self.addr.to_json(),
             'delta' : self.delta,
+            'engine' : self.engine,
             'used' : used,
             'unused' : unused,
             'last' : self.last.to_json(),

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -197,12 +197,9 @@ class Base:
 
     #-----------------------------------------------------------------------
     def refresh(self, force=False, on_done=None):
-        """Refresh the current device state, engine version, and database if
-        needed.
+        """Refresh the current device state and database if needed.
 
-        If the device engine version is not known, this sends a
-        get_engine request to the device. This will also
-        send a ping to the device.  The reply has the current
+        This sends a ping to the device.  The reply has the current
         device state (on/off, level, etc) and the current db delta
         value which is checked against the current db value.  If the
         current db is out of date, it will trigger a download of the
@@ -212,16 +209,10 @@ class Base:
         status whenever possible (like dimmer levels).
 
         Args:
-          force:    If true, will force a refresh of the engine version
-                    even if already known and will also force a refresh
-                    of the device database even if the delta value
-                    matches
+          force:    If true, will force a refresh of the device 
+                    database even if the delta value matches
           on_done:  Optional callback run when the commands are finished.
         """
-
-        if self.db.engine is None:
-            self.get_engine()
-
         LOG.info("Device %s cmd: status refresh", self.label)
 
         # This sends a refresh ping which will respond w/ the current

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -99,6 +99,7 @@ class Base:
             'linking' : self.linking,
             'pair' : self.pair,
             'get_flags' : self.get_flags,
+            'get_engine' : self.get_engine
             }
 
         # Device database delta.  The delta tells us if the database
@@ -196,9 +197,12 @@ class Base:
 
     #-----------------------------------------------------------------------
     def refresh(self, force=False, on_done=None):
-        """Refresh the current device state and database if needed.
+        """Refresh the current device state, engine version, and database if
+        needed.
 
-        This sends a ping to the device.  The reply has the current
+        If the device engine version is not known, this sends a
+        get_engine request to the device. This will also
+        send a ping to the device.  The reply has the current
         device state (on/off, level, etc) and the current db delta
         value which is checked against the current db value.  If the
         current db is out of date, it will trigger a download of the
@@ -207,8 +211,17 @@ class Base:
         This will send out an updated signal for the current device
         status whenever possible (like dimmer levels).
 
-        TODO: doc force
+        Args:
+          force:    If true, will force a refresh of the engine version
+                    even if already known and will also force a refresh
+                    of the device database even if the delta value
+                    matches
+          on_done:  Optional callback run when the commands are finished.
         """
+
+        if self.db.engine is None:
+            self.get_engine()
+
         LOG.info("Device %s cmd: status refresh", self.label)
 
         # This sends a refresh ping which will respond w/ the current
@@ -232,6 +245,21 @@ class Base:
         # download command to the device to update the database.
         msg = Msg.OutStandard.direct(self.addr, 0x1f, 0x00)
         msg_handler = handler.StandardCmd(msg, self.handle_flags, on_done)
+        self.protocol.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def get_engine(self, on_done=None):
+        """ Request the engine version of the device
+
+        The engine version can be i1, i2, or i2cs.  The engine version defines
+        what type of messages can be used with a device and the type of all
+        link database used by a device.
+        """
+        LOG.info("Device %s cmd: get engine version", self.label)
+
+        # Send the get_engine_version request.
+        msg = Msg.OutStandard.direct(self.addr, 0x0D, 0x00)
+        msg_handler = handler.StandardCmd(msg, self.handle_engine, on_done)
         self.protocol.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
@@ -418,6 +446,26 @@ class Base:
         """
         LOG.ui("Device %s operating flags: %s", self.addr,
                "{:08b}".format(msg.cmd2))
+        on_done(True, "Operation complete", msg.cmd2)
+
+    #-----------------------------------------------------------------------
+    def handle_engine(self, msg, on_done):
+        """Handle replies to the get engine command.
+
+        The engine command reply will contain the device engine
+        version in cmd2 and this updates the device with that value.
+
+        Args:
+          msg:  (message.InpStandard) The engine message reply.  The engine
+                version state is in the msg.cmd2 field.
+        """
+        self.db.set_engine(msg.cmd2)
+        version = "i1"
+        if msg.cmd2 == 1:
+            version = "i2"
+        elif msg.cmd2 == 2:
+            version = "i2cs"
+        LOG.ui("Device %s engine version: %s", self.addr, version)
         on_done(True, "Operation complete", msg.cmd2)
 
     #-----------------------------------------------------------------------

--- a/tests/db/test_Device.py
+++ b/tests/db/test_Device.py
@@ -19,6 +19,10 @@ class Test_Device:
         obj.set_delta(None)
         assert obj.is_current(1) is False
 
+        assert obj.engine is None
+        obj.set_engine(1)
+        assert obj.engine == 1
+
         addr = IM.Address(0x10, 0xab, 0x1c)
         flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
         db_flags = Msg.DbFlags(in_use=True, is_controller=True,

--- a/tests/handler/test_StandardCmd.py
+++ b/tests/handler/test_StandardCmd.py
@@ -122,6 +122,38 @@ class Test_StandardCmd:
         assert len(calls) == 1
         assert calls[0] == msg
 
+    #-----------------------------------------------------------------------
+    def test_engine_version(self):
+        # Tests response to get engine version
+        proto = MockProto()
+        modem = MockModem()
+        calls = []
+        addr = IM.Address('0a.12.34')
+        device = IM.device.Base(proto, modem, addr)
+
+        def callback(success, msg, data):
+            calls.append(msg)
+
+        # i1 test
+        out = Msg.OutStandard.direct(addr, 0x0D, 0x00)
+        handler = IM.handler.StandardCmd(out, device.handle_engine, callback)
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x0D, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert calls[0] == "Operation complete"
+        assert device.db.engine == 0
+        
+        #i2
+        msg = Msg.InpStandard(addr, addr, flags, 0x0D, 0x01)
+        r = handler.msg_received(proto, msg)
+        assert device.db.engine == 1
+        
+        #i2cs
+        msg = Msg.InpStandard(addr, addr, flags, 0x0D, 0x02)
+        r = handler.msg_received(proto, msg)
+        assert device.db.engine == 2
+
 
 #===========================================================================
 
@@ -129,3 +161,7 @@ class Test_StandardCmd:
 class MockProto:
     def add_handler(self, *args):
         pass
+
+class MockModem:
+    def __init__(self):
+        self.save_path = ''


### PR DESCRIPTION
Adds a get_engine command that can be used to get the engine
version which is saved in the device.db.

~~When refresh is called, if the engine version is not known,
it will be requested.~~

One step in process to fix https://github.com/TD22057/insteon-mqtt/issues/17