### PR TITLE
Catch and Ignore Duplicate Incoming Messages

### DIFF
--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -304,7 +304,7 @@ class Protocol:
         index = 0
         for check_msg in self._inp_msg_log:
             if check_msg.expire_time < current_time:
-                keys_to_delete.insert(0,index)
+                keys_to_delete.insert(0, index)
             index += 1
         for key in keys_to_delete:
             del self._inp_msg_log[key]

--- a/insteon_mqtt/message/InpStandard.py
+++ b/insteon_mqtt/message/InpStandard.py
@@ -4,6 +4,7 @@
 #
 #===========================================================================
 import io
+import time
 from ..Address import Address
 from .Base import Base
 from .Flags import Flags
@@ -74,6 +75,9 @@ class InpStandard(Base):
         elif (self.flags.type == Flags.Type.ALL_LINK_CLEANUP or
               self.flags.type == Flags.Type.CLEANUP_ACK):
             self.group = self.cmd2
+        # This is the time by which the final hop would arrive, used to
+        # detect duplicates.
+        self.expire_time = time.time() + ((self.flags.hops_left * 87)/1000)
 
     #-----------------------------------------------------------------------
     def __str__(self):
@@ -84,6 +88,27 @@ class InpStandard(Base):
         else:
             return "Std: %s %s grp: %02x cmd: %02x %02x" % \
                 (self.from_addr, self.flags, self.group, self.cmd1, self.cmd2)
+
+    #-----------------------------------------------------------------------
+    def is_duplicate(self,msg):
+        """Checks if a message is the same as this one
+
+        Ignores differences in the hops_left and max_hops field, but if a
+        message is otherwise the same, it is a duplicate.
+
+        Args:
+          msg:    (Message) The message to compare to this one
+        Returns:
+          True if the message is a duplicate false otherwise
+        """
+        if isinstance(msg, InpStandard):
+            if (self.from_addr  == msg.from_addr and
+                self.flags.type == msg.flags.type and
+                self.group      == msg.group and
+                self.cmd1       == msg.cmd1 and
+                self.cmd2       == msg.cmd2):
+                return True
+        return False
 
     #-----------------------------------------------------------------------
 
@@ -155,6 +180,9 @@ class InpExtended(Base):
         elif (self.flags.type == Flags.Type.ALL_LINK_CLEANUP or
               self.flags.type == Flags.Type.CLEANUP_ACK):
             self.group = self.cmd2
+        # This is the time by which the final hop would arrive, used to
+        # detect duplicates.
+        self.expire_time = time.time() + ((self.flags.hops_left * 183)/1000)
 
     #-----------------------------------------------------------------------
     def __str__(self):
@@ -171,6 +199,28 @@ class InpExtended(Base):
         for i in self.data:
             o.write("%02x " % i)
         return o.getvalue()
+
+    #-----------------------------------------------------------------------
+    def is_duplicate(self,msg):
+        """Checks if a message is the same as this one
+
+        Ignores differences in the hops_left and max_hops field, but if a
+        message is otherwise the same, it is a duplicate.
+
+        Args:
+          msg:    (Message) The message to compare to this one
+        Returns:
+          True if the message is a duplicate false otherwise
+        """
+        if isinstance(msg, InpExtended):
+            if (self.from_addr  == msg.from_addr and
+                self.flags.type == msg.flags.type and
+                self.group      == msg.group and
+                self.cmd1       == msg.cmd1 and
+                self.cmd2       == msg.cmd2 and
+                self.data       == msg.data):
+                return True
+        return False
 
     #-----------------------------------------------------------------------
 

--- a/insteon_mqtt/message/InpStandard.py
+++ b/insteon_mqtt/message/InpStandard.py
@@ -77,7 +77,7 @@ class InpStandard(Base):
             self.group = self.cmd2
         # This is the time by which the final hop would arrive, used to
         # detect duplicates.
-        self.expire_time = time.time() + ((self.flags.hops_left * 87)/1000)
+        self.expire_time = time.time() + ((self.flags.hops_left * 87) / 1000)
 
     #-----------------------------------------------------------------------
     def __str__(self):
@@ -90,7 +90,7 @@ class InpStandard(Base):
                 (self.from_addr, self.flags, self.group, self.cmd1, self.cmd2)
 
     #-----------------------------------------------------------------------
-    def is_duplicate(self,msg):
+    def is_duplicate(self, msg):
         """Checks if a message is the same as this one
 
         Ignores differences in the hops_left and max_hops field, but if a
@@ -102,11 +102,11 @@ class InpStandard(Base):
           True if the message is a duplicate false otherwise
         """
         if isinstance(msg, InpStandard):
-            if (self.from_addr  == msg.from_addr and
-                self.flags.type == msg.flags.type and
-                self.group      == msg.group and
-                self.cmd1       == msg.cmd1 and
-                self.cmd2       == msg.cmd2):
+            if (self.from_addr == msg.from_addr and
+                    self.flags.type == msg.flags.type and
+                    self.group == msg.group and
+                    self.cmd1 == msg.cmd1 and
+                    self.cmd2 == msg.cmd2):
                 return True
         return False
 
@@ -182,7 +182,7 @@ class InpExtended(Base):
             self.group = self.cmd2
         # This is the time by which the final hop would arrive, used to
         # detect duplicates.
-        self.expire_time = time.time() + ((self.flags.hops_left * 183)/1000)
+        self.expire_time = time.time() + ((self.flags.hops_left * 183) / 1000)
 
     #-----------------------------------------------------------------------
     def __str__(self):
@@ -201,7 +201,7 @@ class InpExtended(Base):
         return o.getvalue()
 
     #-----------------------------------------------------------------------
-    def is_duplicate(self,msg):
+    def is_duplicate(self, msg):
         """Checks if a message is the same as this one
 
         Ignores differences in the hops_left and max_hops field, but if a
@@ -213,12 +213,12 @@ class InpExtended(Base):
           True if the message is a duplicate false otherwise
         """
         if isinstance(msg, InpExtended):
-            if (self.from_addr  == msg.from_addr and
-                self.flags.type == msg.flags.type and
-                self.group      == msg.group and
-                self.cmd1       == msg.cmd1 and
-                self.cmd2       == msg.cmd2 and
-                self.data       == msg.data):
+            if (self.from_addr == msg.from_addr and
+                    self.flags.type == msg.flags.type and
+                    self.group == msg.group and
+                    self.cmd1 == msg.cmd1 and
+                    self.cmd2 == msg.cmd2 and
+                    self.data == msg.data):
                 return True
         return False
 

--- a/tests/message/test_InpExtended.py
+++ b/tests/message/test_InpExtended.py
@@ -94,5 +94,30 @@ class Test_InpExtended:
 
         str(obj)
 
+    #-----------------------------------------------------------------------
+    def test_is_duplicate(self):
+        b = bytes([0x02, 0x51,  # code
+                   0x3e, 0xe2, 0xc4,  # from addr
+                   0x23, 0x9b, 0x65,  # to addr
+                   0x7f,  # flags 3 max_hops and 3 hops_left
+                   0x11, 0x01,  # cmd1, cmd2
+                   # extended bytes
+                   0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+                   0x0a, 0x0b, 0x0c, 0x0d, 0x0e])
+        obj = Msg.InpExtended.from_bytes(b)
+
+        b2 = bytes([0x02, 0x51,  # code
+                   0x3e, 0xe2, 0xc4,  # from addr
+                   0x23, 0x9b, 0x65,  # to addr
+                   0x75,  # flags 1 max_hops and 1 hops_left
+                   0x11, 0x01,  # cmd1, cmd2
+                   # extended bytes
+                   0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+                   0x0a, 0x0b, 0x0c, 0x0d, 0x0e])
+        obj2 = Msg.InpExtended.from_bytes(b2)
+
+        assert obj.is_duplicate(obj2) is True
+
+        str(obj)
 
 #===========================================================================

--- a/tests/message/test_InpStandard.py
+++ b/tests/message/test_InpStandard.py
@@ -76,5 +76,24 @@ class Test_InpStandard:
 
         str(obj)
 
+    #-----------------------------------------------------------------------
+    def test_is_duplicate(self):
+        b = bytes([0x02, 0x50,  # code
+                   0x3e, 0xe2, 0xc4,  # from addr
+                   0x23, 0x9b, 0x65,  # to addr
+                   0x6f,  # flags 3 max_hops and 3 hops_left
+                   0x11, 0x01])  # cmd1, cmd2
+        obj = Msg.InpStandard.from_bytes(b)
+
+        b2 = bytes([0x02, 0x50,  # code
+                   0x3e, 0xe2, 0xc4,  # from addr
+                   0x23, 0x9b, 0x65,  # to addr
+                   0x65,  # flags 1 max_hops and 1 hops_left
+                   0x11, 0x01])  # cmd1, cmd2
+        obj2 = Msg.InpStandard.from_bytes(b2)
+
+        assert obj.is_duplicate(obj2) is True
+
+        str(obj)
 
 #===========================================================================


### PR DESCRIPTION
Keeps a list of messages that have not expired.  A non-expired message is one in which the time for the remaining hops to occur has not yet passed.

If a subsequent incoming message matches one of these, it is ignored with an info message to the log.

Fixes #42