### PR TITLE
Only Remove DeviceEntry from Group if Matches Memory Location

### DIFF
--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -479,7 +479,7 @@ class Device:
             if entry.db_flags.is_controller and entry.group in self.groups:
                 responders = self.groups[entry.group]
                 for i in range(len(responders)):
-                    if responders[i].addr == entry.addr:
+                    if responders[i].mem_loc == entry.mem_loc:
                         del responders[i]
                         break
 


### PR DESCRIPTION
Chalk this up to Pytest catching an error that might have slipped
through for a while.

I don't see any reason why a db couldn't have two entries for the
same thing, one in use and one not.  I think the Pytest was right
here.