### PR TITLE
Fix topic example for leak sensor and Home-Assistant

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -351,7 +351,7 @@ mqtt:
   # In Home Assistant use MQTT binary sensor with a configuration like:
   #   binary_sensor:
   #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/leak'
+  #       state_topic: 'insteon/aa.bb.cc/wet'
   #       device_class: 'moisture'
   leak:
     # Output wet/dry change topic and payload.  This message is sent


### PR DESCRIPTION
The leak topic example for Home Assistant does not work as it seems /leak is not valid. I got it to work by using /wet instead.

Sorry for the previous PR, I selected the wrong branch.