### PR TITLE
More leak sensor topic fix

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -351,7 +351,7 @@ mqtt:
   # In Home Assistant use MQTT binary sensor with a configuration like:
   #   binary_sensor:
   #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/leak'
+  #       state_topic: 'insteon/aa.bb.cc/wet'
   #       device_class: 'moisture'
   leak:
     # Output wet/dry change topic and payload.  This message is sent

--- a/doc/mqtt.md
+++ b/doc/mqtt.md
@@ -651,7 +651,7 @@ A sample leak sensor topic and payload configuration is:
 
    ```
    leak:
-     wet_dry_topic: 'insteon/{{address}}/leak'
+     wet_dry_topic: 'insteon/{{address}}/wet'
      wet_dry_payload: '{{state.upper()}}'
    ```
 

--- a/insteon_mqtt/mqtt/Leak.py
+++ b/insteon_mqtt/mqtt/Leak.py
@@ -24,7 +24,7 @@ class Leak(BatterySensor):
         super().__init__(mqtt, device)
 
         self.msg_wet = MsgTemplate(
-            topic='insteon/{{address}}/leak',
+            topic='insteon/{{address}}/wet',
             payload='{{state.upper()}}',
             )
 


### PR DESCRIPTION
Now target the dev branch to make sure the fix will also be in upcoming release.

I also saw that the /leak topic was used in insteon_mqtt/mqtt/Leak.py. To be honest, I don't know why the /leak topic was not working since it seems to be registered correctly.

In any case, everything should be on the /wet topic for now (config, Leak.py and documentation)