### PR TITLE
Add Handler for Extended Length Responses

### DIFF
--- a/insteon_mqtt/handler/ExtendedCmdResponse.py
+++ b/insteon_mqtt/handler/ExtendedCmdResponse.py
@@ -1,0 +1,116 @@
+#===========================================================================
+#
+# Device extended response message handler.
+#
+#===========================================================================
+# pylint: disable=too-many-return-statements
+from .. import log
+from .. import message as Msg
+from .Base import Base
+
+LOG = log.get_logger()
+
+
+class ExtendedCmdResponse(Base):
+    """Device extended response message handler.
+
+    This class handles responses from the device where an ACK is made
+    in the form of a standard length message and a subsequent extended
+    length message is sent with the requested payload.
+
+    The handler watches for the proper standard length ACK, returns
+    a continue and then waits for the extended length payload.
+    """
+    def __init__(self, msg, callback, on_done=None, num_retry=3):
+        """Constructor
+
+        The on_done callback has the signature on_done(success, msg, entry)
+        and will be called with success=True if the handler finishes
+        successfully or False if an error occurs or the handler times out.
+        The message input is a string to help with logging the result.
+
+        Args:
+          msg:       (OutStandard) The output message that was sent.  The
+                     reply must match the address and msg.cmd1 field to be
+                     processed by this handler.
+          callback:  Callback function to pass InpStandard messages that match
+                     the output to.  Signature: callback(message, on_done).
+          on_done:   Option finished callback.  This is called when the
+                     handler is finished for any reason.
+          num_retry: (int) The number of times to retry the message if the
+                     handler times out without returning Msg.FINISHED.
+                     This count does include the initial sending so a
+                     retry of 3 will send once and then retry 2 more times.
+        """
+        super().__init__(on_done, num_retry)
+        self.addr = msg.to_addr
+        self.cmd = msg.cmd1
+        self.callback = callback
+
+    #-----------------------------------------------------------------------
+    def msg_received(self, protocol, msg):
+        """See if we can handle the message.
+
+        See if the message is the expected ACK of our output or the expected
+        extended payload message.  If we get the payload, pass it to the
+        callback to handle.
+
+        Args:
+          protocol:  (Protocol) The Insteon Protocol object
+          msg:       Insteon message object that was read.
+
+        Returns:
+          Msg.UNKNOWN if we can't handle this message.
+          Msg.CONTINUE if we handled the message and expect more.
+          Msg.FINISHED if we handled the message and are done.
+        """
+        # Probably an echo back of our sent message.  See if the message
+        # matches the address we sent to and assume it's the ACK/NAK message.
+        # These seem to be either extended or standard message so allow for
+        # both.
+        if isinstance(msg, (Msg.OutExtended, Msg.OutStandard)):
+            if msg.to_addr == self.addr and msg.cmd1 == self.cmd:
+                if not msg.is_ack:
+                    LOG.error("%s NAK response", self.addr)
+                return Msg.CONTINUE
+
+            return Msg.UNKNOWN
+
+        # Probably an ACK/NAK from the device for our get command.
+        elif isinstance(msg, Msg.InpStandard):
+            # Filter by address and command.
+            if msg.from_addr != self.addr or msg.cmd1 != self.cmd:
+                return Msg.UNKNOWN
+
+            if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
+                LOG.info("%s device ACK response, waiting for ext payload",
+                         msg.from_addr)
+                return Msg.CONTINUE
+
+            elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
+                LOG.error("%s device NAK error: %s", msg.from_addr, msg)
+                self.on_done(False, "Device command NAK", None)
+                return Msg.FINISHED
+
+            else:
+                LOG.warning("%s device unexpected msg: %s", msg.from_addr, msg)
+                return Msg.UNKNOWN
+
+        # Process the payload reply.
+        elif isinstance(msg, Msg.InpExtended):
+            # Filter by address and command.
+            if msg.from_addr == self.addr and msg.cmd1 == self.cmd:
+                # Run the callback - it's up to the callback to check if this
+                # is really the ACK or not.
+                self.callback(msg, on_done=self.on_done)
+
+                # Indicate no more messages are expected.
+                return Msg.FINISHED
+            else:
+                LOG.info("Possible unexpected message from %s cmd %#04x but "
+                         "expected %s cmd %#04x", msg.from_addr, msg.cmd1,
+                         self.addr, self.cmd)
+
+        return Msg.UNKNOWN
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/__init__.py
+++ b/insteon_mqtt/handler/__init__.py
@@ -44,3 +44,4 @@ from .ModemLinkStart import ModemLinkStart
 from .ModemReset import ModemReset
 from .ModemScene import ModemScene
 from .StandardCmd import StandardCmd
+from .ExtendedCmdResponse import ExtendedCmdResponse

--- a/tests/handler/test_ExtendedCmdResponse.py
+++ b/tests/handler/test_ExtendedCmdResponse.py
@@ -1,0 +1,102 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/handler/ExtendedCmdResponse.py
+#
+#===========================================================================
+import insteon_mqtt as IM
+import insteon_mqtt.message as Msg
+
+
+class Test_ExtendedCmdResponse:
+    def test_cmd_from_msg(self):
+        # Tests matching the command from the outbound message.
+        proto = MockProto()
+        calls = []
+
+        def callback(msg, on_done=None):
+            calls.append(msg)
+
+        addr = IM.Address('0a.12.34')
+
+        # sent message, match input command
+        out = Msg.OutExtended.direct(addr, 0x2e, 0x00,
+                                     bytes([0x00] *2 + [0x01] + [0x00] * 11),
+                                     crc_type="CRC")
+        handler = IM.handler.ExtendedCmdResponse(out, callback)
+
+        r = handler.msg_received(proto, "dummy")
+        assert r == Msg.UNKNOWN
+
+        # ack back.
+        out.is_ack = False
+        r = handler.msg_received(proto, out)
+        assert r == Msg.CONTINUE
+
+        # wrong cmd
+        out.cmd1 = 0x13
+        r = handler.msg_received(proto, out)
+        assert r == Msg.UNKNOWN
+
+        # wrong addr
+        out.cmd1 = 0x11
+        out.to_addr = IM.Address('0a.12.33')
+        r = handler.msg_received(proto, out)
+        assert r == Msg.UNKNOWN
+
+        # Now pass in the input message.
+
+        # expected input meesage
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x2e, 0x00)
+
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.CONTINUE
+
+        # wrong cmd
+        msg.cmd1 = 0x13
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+        # wrong addr
+        msg.cmd1 = 0x11
+        msg.from_addr = IM.Address('0a.12.33')
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+        # direct NAK
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_NAK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x2e, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+
+        # unexpected
+        flags = Msg.Flags(Msg.Flags.Type.BROADCAST, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x2e, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+        # Test receipt of extended payloads
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, False)
+        msg = Msg.InpExtended(addr, addr, flags, 0x2e, 0x00, bytes([0x00] * 14))
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert len(calls) == 1
+        assert calls[0] == msg
+        
+        # Test receipt of bad payloads
+        msg.from_addr = IM.Address('0a.12.33')
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+
+#===========================================================================
+
+
+class MockProto:
+    def add_handler(self, *args):
+        pass
+
+
+class MockModem:
+    def __init__(self):
+        self.save_path = ''


### PR DESCRIPTION
These responses have a standard length ACK followed by an extended
lendth direct message with the requested payload.

These are used by the thermostat and likely by other devices as
well.