### PR TITLE
Add Support for Insteon Thermostat

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -433,6 +433,56 @@ mqtt:
     error_payload: '{{on_str.upper()}}'
 
   #------------------------------------------------------------------------
+  # Thermostat
+  #------------------------------------------------------------------------
+
+  # The thermostat has a lot of available states and commands
+  # 
+  #
+  # In Home Assistant use MQTT climate sensor with a configuration like:
+  # climate:
+  #   - platform: mqtt
+  #     name: Study
+  #     mode_state_topic: "insteon/aa.bb.cc/mode_state"
+  #     modes: ["OFF", "AUTO", "HEAT", "COOL", "PROGRAM"]
+  #     current_temperature_topic: "insteon/aa.bb.cc/ambient_temp"
+  #     fan_mode_state_topic: "insteon/aa.bb.cc/fan_state"
+  #     fan_modes: ["AUTO", "ON"]
+  #
+  # The current Home Assistant mqtt hvac component is not great.  It lacks
+  # a lot of functionality offered by the thermostat.  At some point I will
+  # submit a PR to Home Assistant to try and fix this.
+  # Major issues: 
+  #   - no concept of separate heat and cool set points
+  #   - no humidity state
+  #   - no status state
+  
+  thermostat:
+    # Output state change topic and payload.  Available
+    # variables for templating are:
+    #   address = 'aa.bb.cc'
+    #   name = 'device name'
+    #   temp_c = temperature in celsius
+    #   temp_f = temperature in farenheit
+    #   mode = 'OFF', 'AUTO', 'HEAT', 'COOL', 'PROGRAM'
+    #   humid = humidity percentage
+    #   status = "OFF", "HEATING", "COOLING"
+    ambient_temp_topic: 'insteon/{{address}}/ambient_temp'
+    ambient_temp_payload: ''{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}''
+    fan_state_topic: 'insteon/{{address}}/fan_state'
+    fan_state_payload: '{{mode}}'
+    mode_state_topic: 'insteon/{{address}}/mode_state'
+    mode_state_payload: '{{mode}}'
+    cool_sp_state_topic: 'insteon/{{address}}/cool_sp_state'
+    cool_sp_state_payload: ''{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}''
+    heat_sp_state_topic: 'insteon/{{address}}/heat_sp_state'
+    heat_sp_state_payload: ''{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}''
+    humid_state_topic: 'insteon/{{address}}/humid_state'
+    humid_state_payload: ''{{humid}}''
+    status_state_topic: 'insteon/{{address}}/status_state'
+    status_state_payload: ''{{status}}''
+
+  #------------------------------------------------------------------------
   # Mini remotes
   #------------------------------------------------------------------------
 

--- a/config.yaml
+++ b/config.yaml
@@ -458,29 +458,74 @@ mqtt:
   #   - no status state
   
   thermostat:
-    # Output state change topic and payload.  Available
-    # variables for templating are:
+    # Output state change topic and payload.  Available variables for 
+    # templating in all cases are:
     #   address = 'aa.bb.cc'
     #   name = 'device name'
+    # The following specific variables only apply to the topics listed
+    # directly below
     #   temp_c = temperature in celsius
     #   temp_f = temperature in farenheit
-    #   mode = 'OFF', 'AUTO', 'HEAT', 'COOL', 'PROGRAM'
-    #   humid = humidity percentage
-    #   status = "OFF", "HEATING", "COOLING"
     ambient_temp_topic: 'insteon/{{address}}/ambient_temp'
     ambient_temp_payload: ''{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}''
-    fan_state_topic: 'insteon/{{address}}/fan_state'
-    fan_state_payload: '{{mode}}'
-    mode_state_topic: 'insteon/{{address}}/mode_state'
-    mode_state_payload: '{{mode}}'
     cool_sp_state_topic: 'insteon/{{address}}/cool_sp_state'
     cool_sp_state_payload: ''{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}''
     heat_sp_state_topic: 'insteon/{{address}}/heat_sp_state'
     heat_sp_state_payload: ''{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}''
+    #   fan_mode = "ON", "AUTO"
+    #   is_fan_on = 0/1
+    fan_state_topic: 'insteon/{{address}}/fan_state'
+    fan_state_payload: '{{fan_mode}}'
+    #   mode = 'OFF', 'AUTO', 'HEAT', 'COOL', 'PROGRAM'
+    mode_state_topic: 'insteon/{{address}}/mode_state'
+    mode_state_payload: '{{mode}}'
+    #   humid = humidity percentage
     humid_state_topic: 'insteon/{{address}}/humid_state'
     humid_state_payload: ''{{humid}}''
+    #   status = "OFF", "HEATING", "COOLING"
+    #   is_heating = 0/1
+    #   is_cooling = 0/1
     status_state_topic: 'insteon/{{address}}/status_state'
     status_state_payload: ''{{status}}''
+    # Caution, there is no push update for the hold or energy state.  ie, if 
+    # you press hold on the physical device, you will not get any notice of 
+    # this unless you run get_status().  There is also no way to programatically 
+    # change the hold state or energy state 
+    #   hold_str = 'OFF', 'TEMP'
+    #   is_hold = 0/1
+    hold_state_topic: 'insteon/{{address}}/hold_state'
+    hold_state_payload: '{{hold_str}}'
+    # See caution in hold state above
+    #   energy_str = 'OFF', 'ON'
+    #   is_energy = 0/1
+    energy_state_topic: 'insteon/{{address}}/energ_state'
+    energy_state_payload: '{{energy_str}}'
+
+    # Command Topics
+    # Available variables for templating all of these commands are:
+    #   address = 'aa.bb.cc'
+    #   name = 'device name'
+    #   value = the input payload
+    #   json = the input payload converted to json.  Use json.VAR to extract
+    #          a variable from a json payload.
+    #
+    # Mode state command.  The output of passing the payload through the 
+    # template must match the following:
+    #   { "cmd" : "auto"/"off"/"heat"/"cool","program" }
+    mode_command_topic: 'insteon/{{address}}/mode_command'
+    mode_command_payload: '{ "cmd" : "{{value.lower()}}" }'
+    # Fan state command.  The output of passing the payload through the 
+    # template must match the following:
+    #   { "cmd" : "auto"/"on" }
+    fan_command_topic: 'insteon/{{address}}/fan_command'
+    fan_command_payload: '{ "cmd" : "{{value.lower()}}" }'
+    # Temp setpoint commands. The payloads should be in the form of {temp_c:
+    # float, temp_f: float} Only one unit needs to be present.  If temp_f is
+    # present it will be used regardless
+    heat_sp_command_topic: 'insteon/{{address}}/heat_sp_command'
+    heat_sp_payload: '{ "temp_f" : {{value}} }'
+    cool_sp_command_topic: 'insteon/{{address}}/cool_sp_command'
+    cool_sp_payload: '{ "temp_f" : {{value}} }'
 
   #------------------------------------------------------------------------
   # Mini remotes

--- a/insteon_mqtt/config.py
+++ b/insteon_mqtt/config.py
@@ -29,6 +29,7 @@ devices = {
     'outlet' : (device.Outlet, {}),
     'smoke_bridge' : (device.SmokeBridge, {}),
     'switch' : (device.Switch, {}),
+    'thermostat' : (device.Thermostat, {}),
     }
 
 

--- a/insteon_mqtt/device/Thermostat.py
+++ b/insteon_mqtt/device/Thermostat.py
@@ -1,0 +1,371 @@
+#===========================================================================
+#
+# Thermostat module
+#
+#===========================================================================
+import enum
+from .Base import Base
+from ..CommandSeq import CommandSeq
+from .. import log
+from .. import message as Msg
+from .. import handler
+from ..Signal import Signal
+
+LOG = log.get_logger()
+
+
+class Thermostat(Base):
+    """Insteon Thermostat
+
+    This works with the 2441TH line of Insteon Thermostats.  It will not work
+    with the older Venstar Thermostats.
+
+    The Thermostat 'broadcasts' alerts for a series of conditions using
+    different broadcast group and direct messages.  This requires pairing
+    the modem as a responder for all of the groups that the Thermostat
+    uses.  The pair() method will do this automatically after
+    the Thermostat is set as a responder to the modem (set modem, then
+    Thermostat).
+
+    When the thermostat alert is triggered, it will emit a signal
+    using Thermostat.signal_*.
+
+    Sample configuration input:
+
+        insteon:
+          devices:
+            - thermostat:
+              address: 44.a3.79
+    """
+
+    # broadcast group ID alert description
+    class Groups(enum.IntEnum):
+        COOLING = 0x01
+        HEATING = 0x02
+        HUMID_HIGH = 0x03
+        HUMID_LOW = 0x04
+        BROADCAST = 0xEF
+
+    # Mapping of fan states
+    class Fan(enum.IntEnum):
+        AUTO = 0x00
+        ON = 0x01
+
+    # Irritatingly, this mapping is different for broadcast messages.
+    # Insteon loves to be irritating like that.
+    class Mode(enum.IntEnum):
+        OFF = 0x00
+        AUTO = 0x01
+        HEAT = 0x02
+        COOL = 0x03
+        PROGRAM = 0x04
+
+    # A few constants to make thing easier to read
+    FARENHEIT = 0
+    CELSIUS = 1
+
+    def __init__(self, protocol, modem, address, name=None):
+        """Constructor
+
+        Args:
+          protocol:    (Protocol) The Protocol object used to communicate
+                       with the Insteon network.  This is needed to allow
+                       the device to send messages to the PLM modem.
+          modem:       (Modem) The Insteon modem used to find other devices.
+          address:     (Address) The address of the device.
+          name         (str) Nice alias name to use for the device.
+        """
+        # Set default values to attributes, may be overwritten by saved
+        # values
+        self.units = Thermostat.FARENHEIT
+
+        super().__init__(protocol, modem, address, name)
+
+        self.cmd_map.update({
+            'get_status' : self.get_status
+            })
+
+        self.signal_ambient_temp_change = Signal()  # emit(device, Int temp_c)
+        self.signal_fan_mode_change = Signal()  # emit(device, Fan fan mode)
+        self.signal_mode_change = Signal()  # emit(device, Mode mode)
+        self.signal_cool_sp_change = Signal()  # emit(device, Int cool_sp in c)
+        self.signal_heat_sp_change = Signal()  # emit(device, Int heat_sp in c)
+        self.signal_ambient_humid_change = Signal()  # emit(device, Int humid)
+        self.signal_status_change = Signal() #emit(device, Str status)
+
+        # Add handler for processing direct Messages
+        protocol.add_handler(handler.ThermostatCmd(self))
+
+    #-----------------------------------------------------------------------
+    def pair(self, on_done=None):
+        """Pair the device with the modem.
+
+        This only needs to be called one time.  It will set the device
+        as a controller and the modem as a responder for all of the
+        groups that the device can alert on.
+
+        This will also run the enable_broadcast command to ensure that
+        the direct 'broadcast' messages are sent by the device.
+
+        The device must already be a responder to the modem (such as by
+        running the linking command) so we can update it's database.
+        """
+        LOG.info("Thermostat %s pairing", self.addr)
+
+        # Build a sequence of calls to the do the pairing.  This insures each
+        # call finishes and works before calling the next one.  We have to do
+        # this for device db manipulation because we need to know the memory
+        # layout on the device before making changes.
+        seq = CommandSeq(self.protocol, "Thermostat paired", on_done)
+
+        # Start with a refresh command - since we're changing the db, it must
+        # be up to date or bad things will happen.
+        seq.add(self.refresh)
+
+        # Add the device as a responder to the modem on group 1.  This is
+        # probably already there - and maybe needs to be there before we can
+        # even issue any commands but this check insures that the link is
+        # present on the device and the modem.
+        seq.add(self.db_add_resp_of, 0x01, self.modem.addr, 0x01,
+                refresh=False)
+
+        # Now add the device as the controller of the modem for all the alert
+        # types.
+        for group_map in Thermostat.Groups:
+            group = group_map.value
+            seq.add(self.db_add_ctrl_of, group, self.modem.addr, group,
+                    refresh=False)
+
+        # Ask the device to enable the broadcast messages, otherwise the
+        # direct messages such as temp changes are not sent to the modem
+        seq.add(self.enable_broadcast)
+
+        # Finally start the sequence running.  This will return so the
+        # network event loop can process everything and the on_done callbacks
+        # will chain everything together.
+        seq.run()
+
+    #-----------------------------------------------------------------------
+    def get_status(self, on_done=None):
+        """Request the status of the common attributes of the thermostat
+
+        Gets the mode state, current temp, heating/cooling state, fan mode,
+        cool setpoint, heat setpoint, and ambient humidity.  Will then emit
+        all necessary signal_* events to cause mqtt messages to be sent
+
+        Args:
+          on_done:  Optional callback run when the commands are finished.
+        """
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x02,
+                                     bytes([0x00] * 14), crc_type="CRC")
+        msg_handler = handler.ExtendedCmdResponse(msg, self.handle_status,
+                                                  on_done, num_retry=3)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def handle_status(self, msg, on_done=None):
+        """Handle the response to the get_status message.
+        
+        Gets the mode state, current temp, heating/cooling state, fan mode,
+        cool setpoint, heat setpoint, and ambient humidity.  Will then emit
+        all necessary signal_* events to cause mqtt messages to be sent                            
+
+        Args:
+          msg:   (InptStandard) Broadcast message from the device.
+        """
+        # The response contains the following data payload
+
+        # D11 - Status Flag
+        # Processed first, because we need to know Units to calculate
+        # some of this.
+        # I have not figured out what all of these bits are
+        # This also seems like a messy way to handle this, is there a better
+        # way?  Would enum.flag be better? We don't every use this code
+        # again.
+        status_flag = int.from_bytes(msg.data[10:11], byteorder='big')
+        print("Status Flag", msg.data[10:11], status_flag, format(status_flag, '0>8b'))
+        Cooling = status_flag & 0b0000001
+        Heating = status_flag & 0b0000010
+        Energy =  status_flag & 0b0000100
+        self.units =   status_flag & 0b0001000
+        Hold =    status_flag & 0b0010000
+
+        # Signal status change
+        status = "OFF"
+        if Cooling:
+            status = "COOLING"
+        elif Heating:
+            status = "HEATING"
+        self.signal_status_change.emit(self, status)
+
+        # D2 - Day
+        # D3 - Hour
+        # D4 - Minute
+        # D5 - Second
+
+        # D6 - Sys Mode*16 + Fanmode
+        sys_byte = int.from_bytes(msg.data[5:6], byteorder='big')
+        # Fan first bit only
+        fan_nibble = sys_byte & 0b1
+        self.set_fan_mode_state(fan_nibble)
+        # Mode
+        mode_nibble = sys_byte >> 4
+        try:
+            HVAC_mode = Thermostat.Mode(mode_nibble)
+        except ValueError:
+            LOG.exception("Unknown mode status state %s.", mode_nibble)
+        else:
+            self.signal_mode_change.emit(self, HVAC_mode)
+
+        # D7 - Cool Set Point in the Units specified on the device
+        cool_sp = int.from_bytes(msg.data[6:7], byteorder='big')
+        if self.units == Thermostat.FARENHEIT:
+            cool_sp = (cool_sp - 32) * 5/9
+        self.signal_cool_sp_change.emit(self, cool_sp)
+
+        # D8 - Humidity
+        humid = int.from_bytes(msg.data[7:8], byteorder='big')
+        self.signal_ambient_humid_change.emit(self, humid)
+
+        # D9 - Temp high byte - Celsius *10
+        # D10 - Temp low byte - Celsius *10
+        temp_c = int.from_bytes(msg.data[8:10], byteorder='big') / 10
+        self.signal_ambient_temp_change.emit(self, temp_c)
+
+        # D12 - Heat Set Point in the Units specified on the device
+        heat_sp = int.from_bytes(msg.data[11:12], byteorder='big')
+        if self.units == Thermostat.FARENHEIT:
+            heat_sp = (heat_sp - 32) * 5/9
+        self.signal_heat_sp_change.emit(self, heat_sp)
+
+        on_done(True, "Status recevied", None)
+
+    #-----------------------------------------------------------------------
+    def set_fan_mode_state(self, mode):
+        """Signals a change in the fan mode
+
+        The mode is deciphered using the Thermostat.Mode enum class
+
+        Args:
+          mode:  An int which matches the options in Thermostat.Fanmode
+        """
+        try:
+            fan_mode = Thermostat.Fan(mode)
+        except ValueError:
+            LOG.exception("Unknown fan mode state %s.", mode)
+        else:
+            self.signal_fan_mode_change.emit(self, fan_mode)
+
+    #-----------------------------------------------------------------------
+    def get_humidity_setpoints(self, on_done=None):
+        """Requests an extended message which has details about the
+        humidity setpoints.  No other known way to obtain them.
+
+        Not currently enabled, the handle_humidity_status function
+        needs to be fleshed out for this to work.
+
+        Args:
+          on_done:  Optional callback run when the commands are finished.
+        """
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00,
+                                     bytes([0x00] *2 + [0x01] + [0x00] * 11), crc_type="CRC")
+        msg_handler = handler.ExtendedCmdResponse(msg, self.handle_humidity_status,
+                                                  on_done, num_retry=3)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def handle_humidity_status(self, msg, on_done=None):
+        """Handle the humidity status request, contains a lot of duplicate
+        data which is already present in a get_status() request.
+
+        Not currently enabled
+
+        Args:
+          msg:   (InptStandard) Broadcast message from the device.
+        """
+        # The response looks like
+        # D4 - High Humid Set Point
+        # D5 - Low Humid Set Point
+        # D6 - Firmware
+        # D7 - Cool Set Point
+        # D8 - Heat Set Point
+        # D9 - RF Offset
+        # D10 - Energy Saving Setback
+        # D11 - External Temp Offset
+        # D12 - Is Status Report Enabled
+        #
+        # Not coded up yet
+        pass
+
+    #-----------------------------------------------------------------------
+    def enable_broadcast(self, on_done=None):
+        """Request the thermostat to broadcast changes in setpoints, temp,
+        mode, and humidity
+
+        Requires a 0xEF group responder entry to be in the device's link
+        database to have any effect.  This is called automatically anytime
+        pair() is run.
+
+        Args:
+          on_done:  Optional callback run when the commands are finished.
+        """
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00,
+                                     bytes([0x00] + [0x08] + [0x00] * 12))
+        msg_handler = handler.StandardCmd(msg, self.handle_enable_broadcast,
+                                          on_done, num_retry=3)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def handle_enable_broadcast(self, msg, on_done=None):
+        """Handles the enable broadcast response.  Nothing to do.
+
+        Args:
+          on_done:  Optional callback run when the commands are finished.
+        """
+        LOG.info("Thermostat %s broadcast enabled", self.addr)
+        on_done(True, "Thermostat broadcast enabled", None)
+
+
+    #-----------------------------------------------------------------------
+    def handle_broadcast(self, msg):
+        """Handle broadcast messages from this device.
+
+        Group broadcast messages are sent for Cooling, Heating, humidifying
+        and de-humidifying.  This handles those messages and emits the
+        appropriate signal to cause the mqtt message to be sentself.
+
+        Currently we don't do anything with the humidifying messages.
+
+        Args:
+          msg:   (InptStandard) Broadcast message from the device.
+        """
+        # 0x11 is ON 0x13 is OFF.
+        if msg.cmd1 in [0x11, 0x13]:
+            LOG.info("Thermostat %s broadcast %s grp: %s", self.addr, msg.cmd1,
+                     msg.group)
+
+            try:
+                condition = Thermostat.Groups(msg.group)
+            except TypeError:
+                LOG.exception("Unknown thermostat group %s.", msg.group)
+                return
+
+            LOG.info("Thermostat %s signaling condition %s", self.addr,
+                     condition)
+
+            # Only handling Heating and Cooling, not humidifying yet
+            if condition in [Thermostat.Groups.HEATING,
+                             Thermostat.Groups.COOLING]:
+                if msg.cmd1 == 0x13:
+                    self.signal_status_change.emit(self, "OFF")
+                    return
+                else:
+                    self.signal_status_change.emit(self, condition.name)
+                    return
+
+        # As long as there is no errors (which return above), call
+        # handle_broadcast for any device that we're the controller
+        # of.
+        super().handle_broadcast(msg)
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/__init__.py
+++ b/insteon_mqtt/device/__init__.py
@@ -39,3 +39,4 @@ from .Outlet import Outlet
 from .Remote import Remote
 from .SmokeBridge import SmokeBridge
 from .Switch import Switch
+from .Thermostat import Thermostat

--- a/insteon_mqtt/handler/ThermostatCmd.py
+++ b/insteon_mqtt/handler/ThermostatCmd.py
@@ -1,0 +1,122 @@
+#===========================================================================
+#
+# Thermostat direct message handler.
+#
+#===========================================================================
+import enum
+from .. import log
+from .. import message as Msg
+from .Base import Base
+
+LOG = log.get_logger()
+
+
+class ThermostatCmd(Base):
+    """Thermostat direct message handler.
+
+    The thermostats send direct messages concerning changes in their
+    temp, humid, mode, and status.  This catches those messages,
+    confirms they are sent from a thermostat and processes them
+    accordingly.
+
+    This hander is added to the protocol handlers whenever a thermostat is 
+    loaded.
+
+    NOTE: This handler is designed to always be active - it never returns
+    FINISHED.
+    """
+    # Irritatingly, this mapping is different for direct status messages.
+    # Insteon loves to be irritating like that
+    class Mode(enum.IntEnum):
+        OFF = 0x00
+        HEAT = 0x01
+        COOL = 0x02
+        AUTO = 0x03
+        PROGRAM = 0x04
+
+    def __init__(self, device):
+        """Constructor
+
+        Args
+          device:   (Device) The Insteon thermostat object.
+        """
+        super().__init__()
+        self.device = device
+
+    #-----------------------------------------------------------------------
+    def msg_received(self, protocol, msg):
+        """See if we can handle the message.
+
+        Try and process the message.
+
+        Args:
+          protocol:  (Protocol) The Insteon Protocol object
+          msg:       Insteon message object that was read.
+
+        Returns:
+          Msg.UNKNOWN if we can't handle this message.
+          Msg.CONTINUE if we handled the message and expect more.
+          Msg.FINISHED if we handled the message and are done.
+        """
+        STATUS_TEMP     = 0x6e
+        STATUS_HUMID    = 0x6f
+        STATUS_MODE     = 0x70
+        STATUS_COOL_SP  = 0x71
+        STATUS_HEAT_SP  = 0x72
+
+        # Confirm this is a message we can handle
+        if not isinstance(msg, Msg.InpStandard):
+            return Msg.UNKNOWN
+
+        # Make sure this is the right device and message type
+        device = self.device.modem.find(msg.from_addr)
+        if not device:
+            LOG.debug("Unknown direct device %s", msg.from_addr)
+            return Msg.UNKNOWN
+        elif device != self.device:
+            LOG.debug("This handler doesn't handle this device %s",
+                      msg.from_addr)
+            return Msg.UNKNOWN
+        elif msg.flags.type != Msg.Flags.Type.DIRECT:
+            LOG.debug("This handler doesn't handle this type of message %s",
+                      Msg.Flags.Type)
+            return Msg.UNKNOWN
+
+        # Pull out and process the commands that this handler handles
+        if msg.cmd1 == STATUS_TEMP:
+            temp = int(msg.cmd2)
+            if self.device.units == self.device.FARENHEIT:
+                temp = (temp - 32) * 5/9
+            self.device.signal_ambient_temp_change.emit(self.device, temp)
+            return Msg.CONTINUE
+        elif msg.cmd1 == STATUS_HUMID:
+            self.device.signal_humid_change.emit(self.device, int(msg.cmd2))
+            return Msg.CONTINUE
+        elif msg.cmd1 == STATUS_MODE:
+            fan_nibble = int(msg.cmd2) >> 4
+            mode_nibble = int(msg.cmd2) & 0b00001111
+            self.device.set_fan_mode_state(fan_nibble)
+            try:
+                hvac_mode = ThermostatCmd.Mode(mode_nibble)
+            except ValueError:
+                LOG.exception("Unknown mode broadcast state %s.", mode_nibble)
+            else:
+                self.device.signal_mode_change.emit(self.device, hvac_mode)
+            return Msg.CONTINUE
+        elif msg.cmd1 == STATUS_COOL_SP:
+            cool_sp = int(msg.cmd2)
+            if self.device.units == self.device.FARENHEIT:
+                cool_sp = (cool_sp - 32) * 5/9
+            self.device.signal_cool_sp_change.emit(self.device, cool_sp)
+            return Msg.CONTINUE
+        elif msg.cmd1 == STATUS_HEAT_SP:
+            heat_sp = int(msg.cmd2)
+            if self.device.units == self.device.FARENHEIT:
+                heat_sp = (heat_sp - 32) * 5/9
+            self.device.signal_heat_sp_change.emit(self.device, heat_sp)
+            return Msg.CONTINUE
+        else:
+            return Msg.UNKNOWN
+
+        # Different message flags than we exepcted.
+        return Msg.UNKNOWN

--- a/insteon_mqtt/handler/ThermostatCmd.py
+++ b/insteon_mqtt/handler/ThermostatCmd.py
@@ -28,11 +28,11 @@ class ThermostatCmd(Base):
     # Irritatingly, this mapping is different for direct status messages.
     # Insteon loves to be irritating like that
     class Mode(enum.IntEnum):
-        OFF = 0x00
-        HEAT = 0x01
-        COOL = 0x02
-        AUTO = 0x03
-        PROGRAM = 0x04
+        off = 0x00
+        heat = 0x01
+        cool = 0x02
+        auto = 0x03
+        program = 0x04
 
     def __init__(self, device):
         """Constructor

--- a/insteon_mqtt/handler/__init__.py
+++ b/insteon_mqtt/handler/__init__.py
@@ -45,3 +45,4 @@ from .ModemReset import ModemReset
 from .ModemScene import ModemScene
 from .StandardCmd import StandardCmd
 from .ExtendedCmdResponse import ExtendedCmdResponse
+from .ThermostatCmd import ThermostatCmd

--- a/insteon_mqtt/mqtt/Thermostat.py
+++ b/insteon_mqtt/mqtt/Thermostat.py
@@ -1,0 +1,274 @@
+#===========================================================================
+#
+# MQTT thermostat sensor device
+#
+#===========================================================================
+from .. import log
+from .. import device as IDev
+from .MsgTemplate import MsgTemplate
+
+LOG = log.get_logger()
+
+
+class Thermostat:
+    """MQTT Thermostat object.
+
+    This class links an Insteon Thermostat object to MQTT.  Any
+    change in the Insteon device will trigger an MQTT message.
+    """
+    def __init__(self, mqtt, device):
+        """Constructor
+
+        Args:
+          mqtt:    (Mqtt) the main MQTT interface object.
+          device:  The insteon thermostat device object.
+        """
+        self.mqtt = mqtt
+        self.device = device
+
+        # Set up the default templates for the MQTT messages and payloads.
+        self.ambient_temp = MsgTemplate(
+            topic='insteon/{{address}}/ambient_temp',
+            payload='{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}',
+            )
+        self.fan_state = MsgTemplate(
+            topic='insteon/{{address}}/fan_state',
+            payload='{{mode}}',
+            )
+        self.mode_state = MsgTemplate(
+            topic='insteon/{{address}}/mode_state',
+            payload='{{mode}}',
+            )
+        self.cool_sp_state = MsgTemplate(
+            topic='insteon/{{address}}/cool_sp_state',
+            payload='{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}',
+            )
+        self.heat_sp_state = MsgTemplate(
+            topic='insteon/{{address}}/heat_sp_state',
+            payload='{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}',
+            )
+        self.humid_state = MsgTemplate(
+            topic='insteon/{{address}}/humid_state',
+            payload='{{humid}}',
+            )
+        self.status_state = MsgTemplate(
+            topic='insteon/{{address}}/status_state',
+            payload='{{status}}',
+            )
+
+        # Receive notifications from the Insteon device when it changes.
+        device.signal_ambient_temp_change.connect(self.handle_ambient_temp_change)
+        device.signal_fan_mode_change.connect(self.handle_fan_mode_change)
+        device.signal_mode_change.connect(self.handle_mode_change)
+        device.signal_cool_sp_change.connect(self.handle_cool_sp_change)
+        device.signal_heat_sp_change.connect(self.handle_heat_sp_change)
+        device.signal_ambient_humid_change.connect(self.handle_ambient_humid_change)
+        device.signal_status_change.connect(self.handle_status_change)
+
+    #-----------------------------------------------------------------------
+    def load_config(self, config, qos=None):
+        """Load values from a configuration data object.
+
+        Args:
+          config:   The configuration dictionary to load from.  The object
+                    config is stored in config['thermostat'].
+          qos:      The default quality of service level to use.
+        """
+        data = config.get("thermostat", None)
+        if not data:
+            return
+
+        # Update the MQTT topics and payloads from the config file.
+        self.ambient_temp.load_config(data, 'ambient_temp_topic', 'ambient_temp_payload', qos)
+        self.fan_state.load_config(data, 'fan_state_topic', 'fan_state_payload', qos)
+        self.mode_state.load_config(data, 'mode_state_topic', 'mode_state_payload', qos)
+        self.cool_sp_state.load_config(data, 'cool_sp_state_topic', 'cool_sp_state_payload', qos)
+        self.heat_sp_state.load_config(data, 'heat_sp_state_topic', 'heat_sp_state_payload', qos)
+        self.humid_state.load_config(data, 'humid_state_topic', 'humid_state_payload', qos)
+        self.status_state.load_config(data, 'status_state_topic', 'status_state_payload', qos)
+
+    #-----------------------------------------------------------------------
+    def subscribe(self, link, qos):
+        """Subscribe to any MQTT topics the object needs.
+
+        Args:
+          link:   The MQTT network client to use.
+          qos:    The quality of service to use.
+        """
+        # Not handling input messages yet
+        pass
+
+    #-----------------------------------------------------------------------
+    def unsubscribe(self, link):
+        """Unsubscribe to any MQTT topics the object was subscribed to.
+
+        Args:
+          link:   The MQTT network client to use.
+        """
+        pass
+
+    #-----------------------------------------------------------------------
+    def handle_ambient_temp_change(self, device, temp_c):
+        """Posts to mqtt changes in ambient temperature
+
+        This is triggered via signal when the ambient temp changes.
+
+        Args:
+          device:    (device.Base) The Insteon device that changed.
+          temp_c:    the temp in Celsius.
+        """
+        LOG.info("MQTT received temp change %s = %s C", device.label,
+                 temp_c)
+
+        # Set up the variables that can be used in the templates.
+        data = {
+            "address" : device.addr.hex,
+            "name" : device.name if device.name else device.addr.hex,
+            "temp_c": temp_c,
+            "temp_f": round((temp_c * 9) / 5 + 32, 1)
+            }
+
+        # Publish topic
+        self.ambient_temp.publish(self.mqtt, data)
+
+    #-----------------------------------------------------------------------
+    def handle_fan_mode_change(self, device, fan_mode):
+        """Posts to mqtt changes in fan mode
+
+        This is triggered via signal when the fan mode change.
+
+        Args:
+          device:    (device.Base) The Insteon device that changed.
+          fan_mode:  Thermostat.Fan state.
+        """
+        LOG.info("MQTT received fan mode change %s = %s C", device.label,
+                 fan_mode)
+
+        # Set up the variables that can be used in the templates.
+        data = {
+            "address" : device.addr.hex,
+            "name" : device.name if device.name else device.addr.hex,
+            "mode": fan_mode.name,
+            }
+
+        # Publish topic
+        self.fan_state.publish(self.mqtt, data)
+
+    #-----------------------------------------------------------------------
+    def handle_mode_change(self, device, mode):
+        """Posts to mqtt changes in the hvac mode
+
+        This is triggered via signal when the mode changes.
+
+        Args:
+          device:    (device.Base) The Insteon device that changed.
+          mode:      Thermostat.Mode state.
+        """
+        LOG.info("MQTT received mode change %s = %s C", device.label,
+                 mode)
+
+        # Set up the variables that can be used in the templates.
+        data = {
+            "address" : device.addr.hex,
+            "name" : device.name if device.name else device.addr.hex,
+            "mode": mode.name,
+            }
+
+        # Publish topic
+        self.mode_state.publish(self.mqtt, data)
+
+    #-----------------------------------------------------------------------
+    def handle_cool_sp_change(self, device, temp_c):
+        """Posts to mqtt when the cool setpoint changes
+
+        This is triggered via signal when the cool setpoint changes.
+
+        Args:
+          device:    (device.Base) The Insteon device that changed.
+          temp_c:    the temp in Celsius.
+        """
+        LOG.info("MQTT received cool setpoint change %s = %s", device.label,
+                 temp_c)
+
+        # Set up the variables that can be used in the templates.
+        data = {
+            "address" : device.addr.hex,
+            "name" : device.name if device.name else device.addr.hex,
+            "temp_c": round(temp_c, 1),
+            "temp_f": round((temp_c * 9) / 5 + 32, 1)
+            }
+
+        # Publish topic
+        self.cool_sp_state.publish(self.mqtt, data)
+
+    #-----------------------------------------------------------------------
+    def handle_heat_sp_change(self, device, temp_c):
+        """Posts to mqtt changes in the heat setpoint
+
+        This is triggered via signal when the heat setpoint changes.
+
+        Args:
+          device:    (device.Base) The Insteon device that changed.
+          temp_c:    the temp in Celsius.
+        """
+        LOG.info("MQTT received heat setpoint change %s = %s", device.label,
+                 temp_c)
+
+        # Set up the variables that can be used in the templates.
+        data = {
+            "address" : device.addr.hex,
+            "name" : device.name if device.name else device.addr.hex,
+            "temp_c": round(temp_c, 1),
+            "temp_f": round((temp_c * 9) / 5 + 32, 1)
+            }
+
+        # Publish topic
+        self.heat_sp_state.publish(self.mqtt, data)
+
+    #-----------------------------------------------------------------------
+    def handle_ambient_humid_change(self, device, humid):
+        """Posts to mqtt changes in the ambient humidity
+
+        This is triggered via signal when the ambient humidity changes.
+
+        Args:
+          device:    (device.Base) The Insteon device that changed.
+          humid:     (int) the humidity percentage.
+        """
+        LOG.info("MQTT received humidity change %s = %s", device.label,
+                 humid)
+
+        # Set up the variables that can be used in the templates.
+        data = {
+            "address" : device.addr.hex,
+            "name" : device.name if device.name else device.addr.hex,
+            "humid": humid
+            }
+
+        # Publish topic
+        self.humid_state.publish(self.mqtt, data)
+
+    #-----------------------------------------------------------------------
+    def handle_status_change(self, device, status):
+        """Posts to mqtt changes in the hvac status
+
+        This is triggered via signal when the hvac status changes.
+
+        Args:
+          device:    (device.Base) The Insteon device that changed.
+          status:    (str)  OFF, HEATING, COOLING
+        """
+        LOG.info("MQTT received status change %s = %s", device.label,
+                 status)
+
+        # Set up the variables that can be used in the templates.
+        data = {
+            "address" : device.addr.hex,
+            "name" : device.name if device.name else device.addr.hex,
+            "status": status
+            }
+
+        # Publish topic
+        self.status_state.publish(self.mqtt, data)
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Thermostat.py
+++ b/insteon_mqtt/mqtt/Thermostat.py
@@ -27,13 +27,14 @@ class Thermostat:
         self.device = device
 
         # Set up the default templates for the MQTT messages and payloads.
+        # Templates for states
         self.ambient_temp = MsgTemplate(
             topic='insteon/{{address}}/ambient_temp',
             payload='{"temp_f" : {{temp_f}}, "temp_c" : {{temp_c}}}',
             )
         self.fan_state = MsgTemplate(
             topic='insteon/{{address}}/fan_state',
-            payload='{{mode}}',
+            payload='{{fan_mode}}',
             )
         self.mode_state = MsgTemplate(
             topic='insteon/{{address}}/mode_state',
@@ -55,6 +56,32 @@ class Thermostat:
             topic='insteon/{{address}}/status_state',
             payload='{{status}}',
             )
+        self.hold_state = MsgTemplate(
+            topic='insteon/{{address}}/hold_state',
+            payload='{{hold_str}}',
+            )
+        self.energy_state = MsgTemplate(
+            topic='insteon/{{address}}/energy_state',
+            payload='{{energy_str}}',
+            )
+
+        # Templates for Commands
+        self.mode_command = MsgTemplate(
+            topic='insteon/{{address}}/mode_command',
+            payload='{ "cmd" : "{{value.lower()}}" }',
+            )
+        self.fan_command = MsgTemplate(
+            topic='insteon/{{address}}/fan_command',
+            payload='{ "cmd" : "{{value.lower()}}" }',
+            )
+        self.heat_sp_command = MsgTemplate(
+            topic='insteon/{{address}}/heat_sp_command',
+            payload='{ "temp_f" : {{value}} }',
+            )
+        self.cool_sp_command = MsgTemplate(
+            topic='insteon/{{address}}/cool_sp_command',
+            payload='{ "temp_f" : {{value}} }',
+            )
 
         # Receive notifications from the Insteon device when it changes.
         device.signal_ambient_temp_change.connect(self.handle_ambient_temp_change)
@@ -64,6 +91,8 @@ class Thermostat:
         device.signal_heat_sp_change.connect(self.handle_heat_sp_change)
         device.signal_ambient_humid_change.connect(self.handle_ambient_humid_change)
         device.signal_status_change.connect(self.handle_status_change)
+        device.signal_hold_change.connect(self.handle_hold_change)
+        device.signal_energy_change.connect(self.handle_energy_change)
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
@@ -79,13 +108,32 @@ class Thermostat:
             return
 
         # Update the MQTT topics and payloads from the config file.
-        self.ambient_temp.load_config(data, 'ambient_temp_topic', 'ambient_temp_payload', qos)
-        self.fan_state.load_config(data, 'fan_state_topic', 'fan_state_payload', qos)
-        self.mode_state.load_config(data, 'mode_state_topic', 'mode_state_payload', qos)
-        self.cool_sp_state.load_config(data, 'cool_sp_state_topic', 'cool_sp_state_payload', qos)
-        self.heat_sp_state.load_config(data, 'heat_sp_state_topic', 'heat_sp_state_payload', qos)
-        self.humid_state.load_config(data, 'humid_state_topic', 'humid_state_payload', qos)
-        self.status_state.load_config(data, 'status_state_topic', 'status_state_payload', qos)
+        self.ambient_temp.load_config(data, 'ambient_temp_topic',
+                                      'ambient_temp_payload', qos)
+        self.fan_state.load_config(data, 'fan_state_topic',
+                                   'fan_state_payload', qos)
+        self.mode_state.load_config(data, 'mode_state_topic',
+                                    'mode_state_payload', qos)
+        self.cool_sp_state.load_config(data, 'cool_sp_state_topic',
+                                       'cool_sp_state_payload', qos)
+        self.heat_sp_state.load_config(data, 'heat_sp_state_topic',
+                                       'heat_sp_state_payload', qos)
+        self.humid_state.load_config(data, 'humid_state_topic',
+                                     'humid_state_payload', qos)
+        self.status_state.load_config(data, 'status_state_topic',
+                                      'status_state_payload', qos)
+        self.hold_state.load_config(data, 'hold_state_topic',
+                                    'hold_state_payload', qos)
+        self.energy_state.load_config(data, 'energy_state_topic',
+                                      'energy_state_payload', qos)
+        self.mode_command.load_config(config, 'mode_command_topic',
+                                      'mode_command_payload', qos)
+        self.fan_command.load_config(config, 'fan_command_topic',
+                                     'fan_command_payload', qos)
+        self.heat_sp_command.load_config(config, 'heat_sp_command_topic',
+                                         'heat_sp_command_payload', qos)
+        self.cool_sp_command.load_config(config, 'cool_sp_command_topic',
+                                         'cool_sp_command_payload', qos)
 
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
@@ -95,8 +143,17 @@ class Thermostat:
           link:   The MQTT network client to use.
           qos:    The quality of service to use.
         """
-        # Not handling input messages yet
-        pass
+        topic = self.mode_command.render_topic(self.template_data())
+        link.subscribe(topic, qos, self.handle_mode_command)
+
+        topic = self.fan_command.render_topic(self.template_data())
+        link.subscribe(topic, qos, self.handle_fan_command)
+
+        topic = self.heat_sp_command.render_topic(self.template_data())
+        link.subscribe(topic, qos, self.handle_heat_sp_command)
+
+        topic = self.cool_sp_command.render_topic(self.template_data())
+        link.subscribe(topic, qos, self.handle_cool_sp_command)
 
     #-----------------------------------------------------------------------
     def unsubscribe(self, link):
@@ -105,7 +162,32 @@ class Thermostat:
         Args:
           link:   The MQTT network client to use.
         """
-        pass
+        topic = self.mode_command.render_topic(self.template_data())
+        self.mqtt.unsubscribe(topic)
+
+        topic = self.fan_command.render_topic(self.template_data())
+        self.mqtt.unsubscribe(topic)
+
+        topic = self.heat_sp_command.render_topic(self.template_data())
+        self.mqtt.unsubscribe(topic)
+
+        topic = self.cool_sp_command.render_topic(self.template_data())
+        self.mqtt.unsubscribe(topic)
+
+    #-----------------------------------------------------------------------
+    def template_data(self):
+        """Provides the data common to all templates
+
+        Returns:
+          (str) A json string of the data.
+        """
+        data = {
+            "address" : self.device.addr.hex,
+            "name" : self.device.name if self.device.name
+                     else self.device.addr.hex
+            }
+
+        return data
 
     #-----------------------------------------------------------------------
     def handle_ambient_temp_change(self, device, temp_c):
@@ -122,11 +204,10 @@ class Thermostat:
 
         # Set up the variables that can be used in the templates.
         data = {
-            "address" : device.addr.hex,
-            "name" : device.name if device.name else device.addr.hex,
             "temp_c": temp_c,
             "temp_f": round((temp_c * 9) / 5 + 32, 1)
             }
+        data.update(self.template_data())
 
         # Publish topic
         self.ambient_temp.publish(self.mqtt, data)
@@ -144,12 +225,16 @@ class Thermostat:
         LOG.info("MQTT received fan mode change %s = %s C", device.label,
                  fan_mode)
 
+        is_fan_on = 0
+        if fan_mode.name == "on":
+            is_fan_on = 1
+
         # Set up the variables that can be used in the templates.
         data = {
-            "address" : device.addr.hex,
-            "name" : device.name if device.name else device.addr.hex,
-            "mode": fan_mode.name,
+            "fan_mode": fan_mode.name.upper(),
+            "is_fan_on": is_fan_on
             }
+        data.update(self.template_data())
 
         # Publish topic
         self.fan_state.publish(self.mqtt, data)
@@ -169,10 +254,9 @@ class Thermostat:
 
         # Set up the variables that can be used in the templates.
         data = {
-            "address" : device.addr.hex,
-            "name" : device.name if device.name else device.addr.hex,
-            "mode": mode.name,
+            "mode": mode.name.upper(),
             }
+        data.update(self.template_data())
 
         # Publish topic
         self.mode_state.publish(self.mqtt, data)
@@ -192,11 +276,10 @@ class Thermostat:
 
         # Set up the variables that can be used in the templates.
         data = {
-            "address" : device.addr.hex,
-            "name" : device.name if device.name else device.addr.hex,
             "temp_c": round(temp_c, 1),
             "temp_f": round((temp_c * 9) / 5 + 32, 1)
             }
+        data.update(self.template_data())
 
         # Publish topic
         self.cool_sp_state.publish(self.mqtt, data)
@@ -216,11 +299,10 @@ class Thermostat:
 
         # Set up the variables that can be used in the templates.
         data = {
-            "address" : device.addr.hex,
-            "name" : device.name if device.name else device.addr.hex,
             "temp_c": round(temp_c, 1),
             "temp_f": round((temp_c * 9) / 5 + 32, 1)
             }
+        data.update(self.template_data())
 
         # Publish topic
         self.heat_sp_state.publish(self.mqtt, data)
@@ -240,10 +322,9 @@ class Thermostat:
 
         # Set up the variables that can be used in the templates.
         data = {
-            "address" : device.addr.hex,
-            "name" : device.name if device.name else device.addr.hex,
             "humid": humid
             }
+        data.update(self.template_data())
 
         # Publish topic
         self.humid_state.publish(self.mqtt, data)
@@ -258,17 +339,177 @@ class Thermostat:
           device:    (device.Base) The Insteon device that changed.
           status:    (str)  OFF, HEATING, COOLING
         """
+        status = status.upper()
         LOG.info("MQTT received status change %s = %s", device.label,
                  status)
 
+        is_heating = is_cooling = 0
+        if status == "HEATING":
+            is_heating = 1
+        elif status == "COOLING":
+            is_cooling = 1
+
         # Set up the variables that can be used in the templates.
         data = {
-            "address" : device.addr.hex,
-            "name" : device.name if device.name else device.addr.hex,
-            "status": status
+            "status": status,
+            "is_heating": is_heating,
+            "is_cooling": is_cooling
             }
+        data.update(self.template_data())
 
         # Publish topic
         self.status_state.publish(self.mqtt, data)
 
     #-----------------------------------------------------------------------
+    def handle_hold_change(self, device, hold):
+        """Posts to mqtt changes in the hold status
+
+        This is triggered via signal when the hold status changes.
+
+        Args:
+          device:    (device.Base) The Insteon device that changed.
+          hold:      (bool)  Hold Status
+        """
+        LOG.info("MQTT received hold change %s = %s", device.label,
+                 hold)
+
+        # Set up the variables that can be used in the templates.
+        hold_str = "OFF"
+        is_hold = 0
+        if hold:
+            hold_str = "TEMP"
+            is_hold = 1
+        data = {
+            "hold_str": hold_str,
+            "is_hold": is_hold
+            }
+        data.update(self.template_data())
+
+        # Publish topic
+        self.hold_state.publish(self.mqtt, data)
+
+    #-----------------------------------------------------------------------
+    def handle_energy_change(self, device, energy):
+        """Posts to mqtt changes in the energy status
+
+        This is triggered via signal when the energy status changes.
+
+        Args:
+          device:    (device.Base) The Insteon device that changed.
+          energy:    (bool)  Energy Status
+        """
+        LOG.info("MQTT received energy change %s = %s", device.label,
+                 energy)
+
+        # Set up the variables that can be used in the templates.
+        energy_str = "OFF"
+        is_energy = 0
+        if energy:
+            energy_str = "ON"
+            is_energy = 1
+        data = {
+            "energy_str": energy_str,
+            "is_energy": is_energy
+            }
+        data.update(self.template_data())
+
+        # Publish topic
+        self.energy_state.publish(self.mqtt, data)
+
+    #-----------------------------------------------------------------------
+    def handle_mode_command(self, client, data, message):
+        """Command a change in the thermostat mode
+
+        Options are [off, auto, heat, cool, program]
+
+        """
+        LOG.info("Thermostat message %s %s", message.topic, message.payload)
+
+        data = self.mode_command.to_json(message.payload)
+        if not data:
+            return
+
+        LOG.info("Thermostat mode command: %s", data)
+        try:
+            mode_member = self.device.ModeCommands[data['cmd']]
+        except KeyError:
+            LOG.exception("Unknown thermostat mode %s.", data['cmd'])
+            return
+
+        self.device.mode_command(mode_member)
+
+    #-----------------------------------------------------------------------
+    def handle_fan_command(self, client, data, message):
+        """Command a change in the thermostat fan mode
+
+        Options are [on, auto]
+
+        """
+        LOG.info("Thermostat message %s %s", message.topic, message.payload)
+
+        data = self.fan_command.to_json(message.payload)
+        if not data:
+            return
+
+        LOG.info("Thermostat fan mode command: %s", data)
+        try:
+            mode_member = self.device.FanCommands[data['cmd']]
+        except KeyError:
+            LOG.exception("Unknown thermostat fan mode %s.", data['cmd'])
+            return
+
+        self.device.fan_command(mode_member)
+
+    #-----------------------------------------------------------------------
+    def handle_heat_sp_command(self, client, data, message):
+        """Command a change in the thermostat heat setpoint
+
+        Value should be in the form of:
+        { temp_f: float,
+          temp_c: float}
+
+        If temp_f is present, it will be used, regardless of if temp_c is also
+        present
+
+        """
+        LOG.info("Thermostat message %s %s", message.topic, message.payload)
+
+        data = self.heat_sp_command.to_json(message.payload)
+        if not data:
+            return
+
+        LOG.info("Thermostat heat setpoint command: %s", data)
+        if 'temp_f' in data:
+            temp_c = (data['temp_f'] -32) * 5/9
+            self.device.heat_sp_command(temp_c)
+        elif 'temp_c' in data:
+            self.device.heat_sp_command(data['temp_c'])
+        else:
+            LOG.error("Unknown thermostat heat setpoint %s.", data)
+
+    #-----------------------------------------------------------------------
+    def handle_cool_sp_command(self, client, data, message):
+        """Command a change in the thermostat cool setpoint
+
+        Value should be in the form of:
+        { temp_f: float,
+          temp_c: float}
+
+        If temp_f is present, it will be used, regardless of if temp_c is also
+        present
+
+        """
+        LOG.info("Thermostat message %s %s", message.topic, message.payload)
+
+        data = self.cool_sp_command.to_json(message.payload)
+        if not data:
+            return
+
+        LOG.info("Thermostat cool setpoint command: %s", data)
+        if 'temp_f' in data:
+            temp_c = (data['temp_f'] -32) * 5/9
+            self.device.cool_sp_command(temp_c)
+        elif 'temp_c' in data:
+            self.device.cool_sp_command(data['temp_c'])
+        else:
+            LOG.error("Unknown thermostat cool setpoint %s.", data)

--- a/insteon_mqtt/mqtt/__init__.py
+++ b/insteon_mqtt/mqtt/__init__.py
@@ -33,3 +33,4 @@ from .Remote import Remote
 from .Reply import Reply
 from .SmokeBridge import SmokeBridge
 from .Switch import Switch
+from .Thermostat import Thermostat

--- a/insteon_mqtt/mqtt/config.py
+++ b/insteon_mqtt/mqtt/config.py
@@ -25,6 +25,7 @@ from .Outlet import Outlet
 from .Remote import Remote
 from .SmokeBridge import SmokeBridge
 from .Switch import Switch
+from .Thermostat import Thermostat
 
 # Map Insteon device classes to MQTT classes.
 devices = {
@@ -40,6 +41,7 @@ devices = {
     device.Remote : Remote,
     device.SmokeBridge : SmokeBridge,
     device.Switch : Switch,
+    device.Thermostat : Thermostat,
     }
 
 

--- a/tests/device/test_Thermostat.py
+++ b/tests/device/test_Thermostat.py
@@ -1,0 +1,299 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/device/Thermostat.py
+#
+#===========================================================================
+import insteon_mqtt as IM
+import insteon_mqtt.device.Thermostat as Thermo
+import insteon_mqtt.message as Msg
+
+class Test_Thermostat:
+    def test_basic(self):
+        protocol = MockProto()
+        modem = MockModem()
+        addr = IM.Address(0x01, 0x02, 0x03)
+        thermo = Thermo(protocol, modem, addr)
+        
+        # setup signal tracking
+        thermo.signal_ambient_temp_change.connect(self.handle_ambient_temp_change)
+        thermo.signal_fan_mode_change.connect(self.handle_fan_mode_change)
+        thermo.signal_mode_change.connect(self.handle_mode_change)
+        thermo.signal_cool_sp_change.connect(self.handle_cool_sp_change)
+        thermo.signal_heat_sp_change.connect(self.handle_heat_sp_change)
+        thermo.signal_ambient_humid_change.connect(self.handle_ambient_humid_change)
+        thermo.signal_status_change.connect(self.handle_status_change)
+        thermo.signal_hold_change.connect(self.handle_hold_change)
+        thermo.signal_energy_change.connect(self.handle_energy_change)
+
+        # Lightly test pairing and I mean light.  Most of this testing is 
+        # handled by other tests
+        thermo.pair()
+        msg = Msg.OutStandard.direct(addr, 0x19, 0x00)
+        test_msg = protocol.msgs.pop(0)
+        assert test_msg.to_bytes() == msg.to_bytes()
+
+        # test get_status
+        thermo.get_status()
+        msg = Msg.OutExtended.direct(addr, 0x2e, 0x02,
+                                     bytes([0x00] * 14), crc_type="CRC")
+        test_msg = protocol.msgs.pop(0)
+        assert test_msg.to_bytes() == msg.to_bytes()
+
+        # test handling of get_status response CELSIUS
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
+        msg = Msg.InpExtended(addr, addr, flags, 0x2e, 0x02,
+                              bytes([0x01, 0x04, 0x0a, 0x21, 0x05, 0x11, 0x1b,
+                                     0x1e, 0x00, 0xe0, 0x88, 0x0e, 0x0f, 0xde]))
+        thermo.handle_status(msg, on_done=self.done)
+        assert self.status == 'off'
+        assert self.hold is False
+        assert self.energy is False
+        assert self.fan == Thermo.Fan.on
+        assert self.mode == Thermo.Mode.auto
+        assert self.humid == 30
+        assert self.cool_sp == 27
+        assert self.heat_sp == 14
+        assert self.ambient == 22.4
+        assert thermo.units == Thermo.CELSIUS
+
+        # Test FARENHEIT
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
+        msg = Msg.InpExtended(addr, addr, flags, 0x2e, 0x02,
+                              bytes([0x01, 0x04, 0x0a, 0x21, 0x05, 0x11, 0x50,
+                                     0x1e, 0x00, 0xe0, 0x80, 0x39, 0x0f, 0xde]))
+        thermo.handle_status(msg, on_done=self.done)
+        assert round(self.cool_sp, 0) == 27
+        assert round(self.heat_sp, 0) == 14
+        assert self.ambient, 1 == 22.4
+        assert thermo.units == Thermo.FARENHEIT
+
+        # Test cooling w/ hold
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
+        msg = Msg.InpExtended(addr, addr, flags, 0x2e, 0x02,
+                              bytes([0x01, 0x04, 0x0a, 0x21, 0x05, 0x11, 0x50,
+                                     0x1e, 0x00, 0xe0, 0x91, 0x39, 0x0f, 0xde]))
+        thermo.handle_status(msg, on_done=self.done)
+        assert self.status == 'cooling'
+        assert self.hold == True
+
+        # Test heating w/ energy
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
+        msg = Msg.InpExtended(addr, addr, flags, 0x2e, 0x02,
+                              bytes([0x01, 0x04, 0x0a, 0x21, 0x05, 0x11, 0x50,
+                                     0x1e, 0x00, 0xe0, 0x86, 0x39, 0x0f, 0xde]))
+        thermo.handle_status(msg, on_done=self.done)
+        assert self.status == 'heating'
+        assert self.energy == True
+
+        # Test bad status response
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
+        msg = Msg.InpExtended(addr, addr, flags, 0x2e, 0x02,
+                              bytes([0x01, 0x04, 0x0a, 0x21, 0x05, 0xFF, 0x1b,
+                                     0x1e, 0x00, 0xe0, 0x88, 0x0e, 0x0f, 0xde]))
+        thermo.handle_status(msg, on_done=self.done)
+
+        # force a bad fan command, currently no way for this to happen
+        # in the code, so just fake it here
+        thermo.set_fan_mode_state(2)
+        assert self.fan == Thermo.Fan.on
+
+        # test humidity setpoints, not enabled in code yet so this is just a
+        # shell
+        msg = Msg.OutExtended.direct(addr, 0x2e, 0x00,
+                                     bytes([0x00] *2 + [0x01] + [0x00] * 11),
+                                     crc_type="CRC")
+        thermo.get_humidity_setpoints()
+        assert msg.to_bytes() == protocol.msgs.pop(0).to_bytes()
+        thermo.handle_humidity_setpoints(msg)
+
+        # Test enabling broadcast messages
+        msg = Msg.OutExtended.direct(addr, 0x2e, 0x00,
+                                     bytes([0x00] + [0x08] + [0x00] * 12))
+        thermo.enable_broadcast()
+        assert msg.to_bytes() == protocol.msgs.pop(0).to_bytes()
+        
+        thermo.handle_generic_ack(msg, on_done=self.done)
+        
+        # test thermo broadcast Messages
+        flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
+        cool = IM.Address(0x00, 0x00, 0x01)
+        msg = Msg.InpStandard(addr, cool, flags, 0x11, 0x00)
+        thermo.handle_broadcast(msg)
+        assert self.status == 'COOLING'
+        msg = Msg.InpStandard(addr, cool, flags, 0x13, 0x00)
+        thermo.handle_broadcast(msg)
+        assert self.status == 'OFF'
+        # test of bad group, shouldn't change status
+        cool = IM.Address(0x00, 0x00, 0x07)
+        msg = Msg.InpStandard(addr, cool, flags, 0x11, 0x00)
+        thermo.handle_broadcast(msg)
+        assert self.status == 'OFF'
+        # Test non-thermo broadcast
+        cool = IM.Address(0x00, 0x00, 0x01)
+        msg = Msg.InpStandard(addr, cool, flags, 0x20, 0x00)
+        thermo.handle_broadcast(msg)
+
+        # Test mode command
+        msg = Msg.OutExtended.direct(addr, 0x6b, thermo.ModeCommands(0x04),
+                                     bytes([0x00] * 14))
+        thermo.mode_command(thermo.ModeCommands.heat)
+        assert msg.to_bytes() == protocol.msgs.pop(0).to_bytes()
+
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x6b,
+                              thermo.ModeCommands.heat.value)
+        thermo.handle_mode_command(msg, on_done=self.done)
+        assert self.mode == thermo.ModeCommands.heat
+        # Test bad ack
+        msg = Msg.InpStandard(addr, addr, flags, 0x6c,
+                              thermo.ModeCommands.heat.value)
+        thermo.handle_mode_command(msg, on_done=self.done)
+        assert self.mode == thermo.ModeCommands.heat
+
+        # Test fan command
+        msg = Msg.OutExtended.direct(addr, 0x6b, thermo.FanCommands(0x07),
+                                     bytes([0x00] * 14))
+        thermo.fan_command(thermo.FanCommands.on)
+        assert msg.to_bytes() == protocol.msgs.pop(0).to_bytes()
+
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x6b,
+                              thermo.FanCommands.on.value)
+        thermo.handle_fan_command(msg, on_done=self.done)
+        assert self.fan == thermo.FanCommands.on
+        # Test bad ack
+        msg = Msg.InpStandard(addr, addr, flags, 0x6c,
+                              thermo.FanCommands.on.value)
+        thermo.handle_fan_command(msg, on_done=self.done)
+        assert self.fan == thermo.FanCommands.on
+
+        # test heat setpoint command CELSIUS
+        thermo.units = thermo.CELSIUS
+        temp = 25
+        msg = Msg.OutExtended.direct(addr, 0x6d, int(temp*2),
+                                     bytes([0x00] * 14))
+        thermo.heat_sp_command(temp)
+        assert msg.to_bytes() == protocol.msgs.pop(0).to_bytes()
+
+        # test response handler
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x6d,
+                              int(temp*2))
+        thermo.handle_heat_sp_command(msg, on_done=self.done)
+        assert self.heat_sp == temp
+
+        # Test FARENHEIT
+        thermo.units = thermo.FARENHEIT
+        temp_c = 25
+        temp = (temp_c * 9/5) + 32
+        msg = Msg.OutExtended.direct(addr, 0x6d, int(temp*2),
+                                     bytes([0x00] * 14))
+        thermo.heat_sp_command(temp_c)
+        assert msg.to_bytes() == protocol.msgs.pop(0).to_bytes()
+
+        # test response handler
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x6d,
+                              int(temp*2))
+        thermo.handle_heat_sp_command(msg, on_done=self.done)
+        assert self.heat_sp == temp_c
+
+        # BAd Ack
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x6a,
+                              int(temp*2))
+        thermo.handle_heat_sp_command(msg, on_done=self.done)
+        assert self.heat_sp == temp_c
+
+        # test cool setpoint command CELSIUS
+        thermo.units = thermo.CELSIUS
+        temp = 25
+        msg = Msg.OutExtended.direct(addr, 0x6c, int(temp*2),
+                                     bytes([0x00] * 14))
+        thermo.cool_sp_command(temp)
+        assert msg.to_bytes() == protocol.msgs.pop(0).to_bytes()
+
+        # test response handler
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x6c,
+                              int(temp*2))
+        thermo.handle_cool_sp_command(msg, on_done=self.done)
+        assert self.cool_sp == temp
+
+        # Test FARENHEIT
+        thermo.units = thermo.FARENHEIT
+        temp_c = 25
+        temp = (temp_c * 9/5) + 32
+        msg = Msg.OutExtended.direct(addr, 0x6c, int(temp*2),
+                                     bytes([0x00] * 14))
+        thermo.cool_sp_command(temp_c)
+        assert msg.to_bytes() == protocol.msgs.pop(0).to_bytes()
+
+        # test response handler
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x6c,
+                              int(temp*2))
+        thermo.handle_cool_sp_command(msg, on_done=self.done)
+        assert self.cool_sp == temp_c
+        
+        # bad ack
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x6a,
+                              int(temp*2))
+        thermo.handle_cool_sp_command(msg, on_done=self.done)
+        assert self.cool_sp == temp_c
+
+    def done(self, *args, **kwargs):
+        pass
+
+    #-----------------------------------------------------------------------
+    def handle_ambient_temp_change(self, device, temp_c):
+        self.ambient = temp_c
+
+    #-----------------------------------------------------------------------
+    def handle_fan_mode_change(self, device, fan_mode):
+        self.fan = fan_mode
+
+    #-----------------------------------------------------------------------
+    def handle_mode_change(self, device, mode):
+        self.mode = mode
+
+    #-----------------------------------------------------------------------
+    def handle_cool_sp_change(self, device, temp_c):
+        self.cool_sp = temp_c
+
+    #-----------------------------------------------------------------------
+    def handle_heat_sp_change(self, device, temp_c):
+        self.heat_sp = temp_c
+
+    #-----------------------------------------------------------------------
+    def handle_ambient_humid_change(self, device, humid):
+        self.humid = humid
+
+    #-----------------------------------------------------------------------
+    def handle_status_change(self, device, status):
+        self.status = status
+
+    #-----------------------------------------------------------------------
+    def handle_hold_change(self, device, hold):
+        self.hold = hold
+
+    #-----------------------------------------------------------------------
+    def handle_energy_change(self, device, energy):
+        self.energy = energy
+
+
+class MockModem:
+    def __init__(self):
+        self.save_path = ''
+        self.addr = IM.Address(0x0A, 0x0B, 0x0C)
+
+class MockProto:
+    def __init__(self):
+        self.msgs = []
+
+    def add_handler(self, *args):
+        pass
+
+    def send(self, msg, msg_handler, high_priority=False, after=None):
+        self.msgs.append(msg)

--- a/tests/mqtt/test_ThermostatMqtt.py
+++ b/tests/mqtt/test_ThermostatMqtt.py
@@ -1,0 +1,238 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/mqtt/Thermostat.py
+#
+#===========================================================================
+import enum
+import insteon_mqtt as IM
+from insteon_mqtt.Signal import Signal
+import insteon_mqtt.mqtt.Thermostat as Thermo
+from insteon_mqtt.mqtt.MsgTemplate import MsgTemplate
+
+class Test_ThermostatMqtt:
+    def test_basic(self):
+        mqtt = MockMqtt()
+        device = MockDevice()
+        thermo = Thermo(mqtt, device)
+
+        #Ambient temperature
+        device.signal_ambient_temp_change.emit(device, 22)
+        assert mqtt.last_topic == 'insteon/01.02.03/ambient_temp'
+        assert mqtt.last_payload == '{"temp_f" : 71.6, "temp_c" : 22}'
+
+        # Fan mode
+        device.signal_fan_mode_change.emit(device, device.Fan.auto)
+        assert mqtt.last_topic == 'insteon/01.02.03/fan_state'
+        assert mqtt.last_payload == 'AUTO'
+
+        # Mode change
+        device.signal_mode_change.emit(device, device.ModeCommands.auto)
+        assert mqtt.last_topic == 'insteon/01.02.03/mode_state'
+        assert mqtt.last_payload == 'AUTO'
+
+        # Cool setpoint
+        device.signal_cool_sp_change.emit(device, 22)
+        assert mqtt.last_topic == 'insteon/01.02.03/cool_sp_state'
+        assert mqtt.last_payload == '{"temp_f" : 71.6, "temp_c" : 22}'
+
+        # heat setpoint
+        device.signal_heat_sp_change.emit(device, 24)
+        assert mqtt.last_topic == 'insteon/01.02.03/heat_sp_state'
+        assert mqtt.last_payload == '{"temp_f" : 75.2, "temp_c" : 24}'
+
+        # Humid Change
+        device.signal_ambient_humid_change.emit(device, 50)
+        assert mqtt.last_topic == 'insteon/01.02.03/humid_state'
+        assert mqtt.last_payload == '50'
+
+        # Status modify default payload to see all values
+        thermo.status_state = MsgTemplate(
+                    topic='insteon/{{address}}/status_state',
+                    payload='{"status": "{{status}}", "is_heating": {{is_heating}}, "is_cooling": {{is_cooling}}}',
+                    )
+        # Test cooling
+        device.signal_status_change.emit(device, 'cooling')
+        assert mqtt.last_topic == 'insteon/01.02.03/status_state'
+        assert mqtt.last_payload == '{"status": "COOLING", "is_heating": 0, "is_cooling": 1}'
+        # Test heating
+        device.signal_status_change.emit(device, 'heating')
+        assert mqtt.last_topic == 'insteon/01.02.03/status_state'
+        assert mqtt.last_payload == '{"status": "HEATING", "is_heating": 1, "is_cooling": 0}'
+
+        # hold modify default payload to see all values
+        thermo.hold_state = MsgTemplate(
+                    topic='insteon/{{address}}/hold_state',
+                    payload='{"hold": "{{hold_str}}", "is_hold": {{is_hold}}}',
+                    )
+        # Test no hold
+        device.signal_hold_change.emit(device, False)
+        assert mqtt.last_topic == 'insteon/01.02.03/hold_state'
+        assert mqtt.last_payload == '{"hold": "OFF", "is_hold": 0}'
+        # Test hold
+        device.signal_hold_change.emit(device, True)
+        assert mqtt.last_topic == 'insteon/01.02.03/hold_state'
+        assert mqtt.last_payload == '{"hold": "TEMP", "is_hold": 1}'
+
+        # energy modify default payload to see all values
+        thermo.energy_state = MsgTemplate(
+                    topic='insteon/{{address}}/energy_state',
+                    payload='{"energy": "{{energy_str}}", "is_energy": {{is_energy}}}',
+                    )
+        # Test no energy
+        device.signal_energy_change.emit(device, False)
+        assert mqtt.last_topic == 'insteon/01.02.03/energy_state'
+        assert mqtt.last_payload == '{"energy": "OFF", "is_energy": 0}'
+        # Test energy
+        device.signal_energy_change.emit(device, True)
+        assert mqtt.last_topic == 'insteon/01.02.03/energy_state'
+        assert mqtt.last_payload == '{"energy": "ON", "is_energy": 1}'
+
+        # Test commands
+        # test mode
+        message = MockMessage(
+            topic='insteon/01.02.03/mode_command',
+            payload='auto',
+            )
+        thermo.handle_mode_command(None, None, message)
+        assert device.mode == device.ModeCommands.auto
+
+        # test fan
+        message = MockMessage(
+            topic='insteon/01.02.03/fan_command',
+            payload='on',
+            )
+        thermo.handle_fan_command(None, None, message)
+        assert device.fan == device.FanCommands.on
+
+        # test heat sp
+        # sent in F
+        message = MockMessage(
+            topic='insteon/01.02.03/heat_sp_command',
+            payload='80',
+            )
+        thermo.handle_heat_sp_command(None, None, message)
+        assert round(device.heat_sp, 1) == 26.7
+
+        # temp sent in C
+        thermo.heat_sp_command = MsgTemplate(
+                    topic='insteon/{{address}}/heat_sp_command',
+                    payload='{ "temp_c" : {{value}} }',
+                    )
+        message = MockMessage(
+            topic='insteon/01.02.03/heat_sp_command',
+            payload='26.6666',
+            )
+        thermo.handle_heat_sp_command(None, None, message)
+        assert round(device.heat_sp, 1) == 26.7
+
+        # temp sent in both should default to F
+        thermo.heat_sp_command = MsgTemplate(
+                    topic='insteon/{{address}}/heat_sp_command',
+                    payload='{ "temp_c" : {{json.temp_c}}, "temp_f" : {{json.temp_f}} }',
+                    )
+        message = MockMessage(
+            topic='insteon/01.02.03/heat_sp_command',
+            payload='{"temp_f": 80, "temp_c": 30}',
+            )
+        thermo.handle_heat_sp_command(None, None, message)
+        assert round(device.heat_sp, 1) == 26.7
+
+        # test cool sp
+        # sent in F
+        message = MockMessage(
+            topic='insteon/01.02.03/cool_sp_command',
+            payload='80',
+            )
+        thermo.handle_cool_sp_command(None, None, message)
+        assert round(device.cool_sp, 1) == 26.7
+
+        # temp sent in C
+        thermo.cool_sp_command = MsgTemplate(
+                    topic='insteon/{{address}}/cool_sp_command',
+                    payload='{ "temp_c" : {{value}} }',
+                    )
+        message = MockMessage(
+            topic='insteon/01.02.03/cool_sp_command',
+            payload='26.6666',
+            )
+        thermo.handle_cool_sp_command(None, None, message)
+        assert round(device.cool_sp, 1) == 26.7
+
+        # temp sent in both should default to F
+        thermo.cool_sp_command = MsgTemplate(
+                    topic='insteon/{{address}}/cool_sp_command',
+                    payload='{ "temp_c" : {{json.temp_c}}, "temp_f" : {{json.temp_f}} }',
+                    )
+        message = MockMessage(
+            topic='insteon/01.02.03/cool_sp_command',
+            payload='{"temp_f": 80, "temp_c": 30}',
+            )
+        thermo.handle_cool_sp_command(None, None, message)
+        assert round(device.cool_sp, 1) == 26.7
+
+class MockMqtt:
+    def __init__(self):
+        self.last_payload = None
+        self.last_topic = None
+        self.mode_command = None
+
+    def publish(self, topic, payload, qos):
+        self.last_topic = topic
+        self.last_payload = payload
+
+class MockDevice:
+    # mock thermostat device
+    FARENHEIT = 0
+    CELSIUS = 1
+
+    class ModeCommands(enum.IntEnum):
+        off = 0x09
+        heat = 0x04
+        cool = 0x05
+        auto = 0x06
+        program = 0x0a
+
+    class Fan(enum.IntEnum):
+        auto = 0x00
+        on = 0x01
+
+    class FanCommands(enum.IntEnum):
+        on = 0x07
+        auto = 0x08
+
+    def __init__(self):
+        self.addr = IM.Address(0x01, 0x02, 0x03)
+        self.name = "mock_thermo"
+        self.label = "mock_thermo"
+        self.mode = None
+        self.fan = None
+        self.heat_sp = None
+        self.cool_sp = None
+        self.units = MockDevice.FARENHEIT
+        self.signal_ambient_temp_change = Signal()  # emit(device, Int temp_c)
+        self.signal_fan_mode_change = Signal()  # emit(device, Fan fan mode)
+        self.signal_mode_change = Signal()  # emit(device, Mode mode)
+        self.signal_cool_sp_change = Signal()  # emit(device, Int cool_sp in c)
+        self.signal_heat_sp_change = Signal()  # emit(device, Int heat_sp in c)
+        self.signal_ambient_humid_change = Signal()  # emit(device, Int humid)
+        self.signal_status_change = Signal() #emit(device, Str status)
+        self.signal_hold_change = Signal() #emit(device, bool)
+        self.signal_energy_change = Signal() #emit(device, bool)
+
+    def mode_command(self, mode_member):
+        self.mode = mode_member
+
+    def fan_command(self, mode_member):
+        self.fan = mode_member
+
+    def heat_sp_command(self, mode_member):
+        self.heat_sp = mode_member
+
+    def cool_sp_command(self, mode_member):
+        self.cool_sp = mode_member
+
+class MockMessage:
+    # A mock versio of a paho mqtt message
+    def __init__(self, topic, payload):
+        self.topic = topic
+        self.payload = payload.encode('utf-8')


### PR DESCRIPTION
This adds a good level of support for the Insteon Thermostat.  It works reasonably well with the MQTT Climate component in Home Assistant, however the MQTT Climate doesn't distinguish between heat and cool setpoints.  These are really necessary to make auto and program work correctly.  Hopefully in the next day or so I will be able to submit a PR to Home Assistant to make those changes to MQTT Climate.

This should be merged after Meta_Storage #92 as this includes that PR.