### PR TITLE
Parse Config Scenes into DB_Config

### DIFF
--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -595,6 +595,30 @@ class Device:
             self.save()
 
     #-----------------------------------------------------------------------
+    def add_from_config(self, addr, group, is_controller, data):
+        """Add an entry to the config database from the config file.
+
+        Is called by _load_scenes() on the modem.  Adds an entry to the next
+        available mem_loc from an entry specified in the config file.  This
+        should only be used to add an entry to a db_config database, which is
+        then compared with the actual database using diff().
+
+        Args:
+          TODO
+        """
+        # Get the mem_loc and move last entry down 1 position
+        mem_loc = self.last.mem_loc
+        self.last.mem_loc -= 0x08
+
+        # Generate the entry
+        db_flags = Msg.DbFlags(in_use=True, is_controller=is_controller,
+                               is_last_rec=False)
+        entry = DeviceEntry(addr, group, mem_loc, db_flags, data)
+
+        # Add the Entry to the DB
+        self.add_entry(entry, save=False)
+
+    #-----------------------------------------------------------------------
     def _add_using_unused(self, device, addr, group, is_controller, data,
                           on_done, entry=None):
         """Add an entry using an existing, unused entry.

--- a/insteon_mqtt/db/DeviceEntry.py
+++ b/insteon_mqtt/db/DeviceEntry.py
@@ -21,6 +21,22 @@ class DeviceEntry:
     entry.
 
     The entry can be converted to/from JSON with to_json() and from_json().
+
+    Notes on the values for Data 1-3 in links:
+      Responder Records
+        Data 1    Link-specific data (e.g. On-Level)
+        Data 2    Link-specific data (e.g. Ramp Rates, Setpoints, etc.)
+        Data 3    Link-specific data (listed by Insteon as "normally unused"
+                             but for multi-function items, we know that this
+                             is set to the linked "group" on the responding
+                             device)
+
+      Controller Records
+        Data 1    Number of retries (Normally set to 03, FF = no retries,
+                  00 = Broadcast for cleanup)
+        Data 2    Listed as Ignored?
+        Data 3    Listed as 00 for switchlinc type devices and 01-08 for KPL
+                  type devices
     """
 
     @staticmethod

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -90,6 +90,9 @@ class Base:
         self.db = db.Device(self.addr)
         self.load_db()
 
+        # Prepare the config db
+        self.db_config = db.Device(self.addr)
+
         # Remove (mqtt) commands mapped to methods calls.  These are
         # handled in run_command().  Derived classes can add more
         # commands to the dict to expand the list.  Commands should


### PR DESCRIPTION
This only deals with the device level db, not the modem yet.

Handles three variations of config file defintions.

Adds the concept of data_1, data_2, and data_3 keys in a definition.