### PR TITLE
Parse and Report I2CS NAK Error Codes

### DIFF
--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -486,8 +486,10 @@ class Dimmer(Base):
                     msg.cmd2)
 
         elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Dimmer %s NAK error: %s", self.addr, msg)
-            on_done(False, "Dimmer state update failed", None)
+            LOG.error("Dimmer %s NAK error: %s, Message: %s", self.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "Dimmer state update failed. " + msg.nak_str(),
+                    None)
 
     #-----------------------------------------------------------------------
     def handle_scene(self, msg, on_done):
@@ -508,8 +510,10 @@ class Dimmer(Base):
             on_done(True, "Scene triggered", None)
 
         elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Dimmer %s NAK error: %s", self.addr, msg)
-            on_done(False, "Scene trigger failed failed", None)
+            LOG.error("Dimmer %s NAK error: %s, Message: %s", self.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "Scene trigger failed failed. " + msg.nak_str(),
+                    None)
 
     #-----------------------------------------------------------------------
     def handle_increment(self, msg, on_done, delta):
@@ -528,9 +532,11 @@ class Dimmer(Base):
             s = "Dimmer %s state updated to %s" % (self.addr, self._level)
             on_done(True, s, msg.cmd2)
 
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Dimmer %s NAK error: %s", self.addr, msg)
-            on_done(False, "Dimmer %s state update failed", None)
+        elif msg.flags.Dimmer == Msg.Flags.Type.DIRECT_NAK:
+            LOG.error("Dimmer %s NAK error: %s, Message: %s", self.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "Dimmer %s state update failed. " + msg.nak_str(),
+                    None)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, group, cmd):

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -254,9 +254,11 @@ class FanLinc(Dimmer):
                 on_done(True, s, msg.cmd2)
 
         elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("FanLinc fan %s NAK error: %s", self.addr, msg)
+            LOG.error("FanLinc fan %s NAK error: %s, Message: %s", self.addr,
+                      msg.nak_str(), msg)
             if on_done:
-                on_done(False, "Fan %s state update failed", None)
+                on_done(False, "Fan %s state update failed. " + msg.nak_str(),
+                        None)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, group, cmd):

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -517,8 +517,9 @@ class IOLinc(Base):
             on_done(True, "IOLinc command complete", None)
 
         elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("IOLinc %s NAK error: %s", self.addr, msg)
-            on_done(False, "IOLinc command failed", None)
+            LOG.error("IOLinc %s NAK error: %s, Message: %s", self.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "IOLinc command failed. " + msg.nak_str(), None)
 
     #-----------------------------------------------------------------------
     def handle_scene(self, msg, on_done):
@@ -539,8 +540,10 @@ class IOLinc(Base):
             on_done(True, "Scene triggered", None)
 
         elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("IOLinc %s NAK error: %s", self.addr, msg)
-            on_done(False, "Scene trigger failed failed", None)
+            LOG.error("IOLinc %s NAK error: %s, Message: %s", self.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "Scene trigger failed failed. " + msg.nak_str(),
+                    None)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, group, cmd):

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -518,8 +518,10 @@ class KeypadLinc(Base):
             on_done(True, msg, is_on)
 
         elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("KeypadLinc LED %s NAK error: %s", self.addr, msg)
-            on_done(False, "KeypadLinc %s LED update failed", None)
+            LOG.error("KeypadLinc LED %s NAK error: %s, Message: %s",
+                      self.addr, msg.nak_str(), msg)
+            on_done(False, "KeypadLinc %s LED update failed. " + msg.nak_str(),
+                    None)
 
     #-----------------------------------------------------------------------
     def handle_led_refresh(self, msg):

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -384,8 +384,10 @@ class Switch(Base):
                     self._is_on)
 
         elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Switch %s NAK error: %s", self.addr, msg)
-            on_done(False, "Switch state update failed", None)
+            LOG.error("Switch %s NAK error: %s, Message: %s", self.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "Switch state update failed. " + msg.nak_str(),
+                    None)
 
     #-----------------------------------------------------------------------
     def handle_scene(self, msg, on_done):
@@ -406,8 +408,10 @@ class Switch(Base):
             on_done(True, "Scene triggered", None)
 
         elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Switch %s NAK error: %s", self.addr, msg)
-            on_done(False, "Scene trigger failed failed", None)
+            LOG.error("Switch %s NAK error: %s, Message: %s", self.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "Scene trigger failed failed. " + msg.nak_str(),
+                    None)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, group, cmd):

--- a/insteon_mqtt/device/Thermostat.py
+++ b/insteon_mqtt/device/Thermostat.py
@@ -392,8 +392,13 @@ class Thermostat(Base):
           msg:   (InptStandard) Direct ACK message from the device.
           on_done:  Optional callback run when the commands are finished.
         """
-        LOG.debug("Thermostat %s generic ack recevied", self.addr)
-        if on_done is not None:
+        if msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
+            LOG.error("%s NAK: %s, Message: %s", self.db.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "Thermostat command NAK. " +
+                    msg.nak_str(), None)
+        else:
+            LOG.debug("Thermostat %s generic ack recevied", self.addr)
             on_done(True, "Thermostat generic ack recevied", None)
 
     #-----------------------------------------------------------------------
@@ -467,7 +472,12 @@ class Thermostat(Base):
           msg:   (InptStandard) Direct ACK message from the device.
           on_done:  Optional callback run when the commands are finished.
         """
-        if msg.cmd1 == 0x6b:
+        if msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
+            LOG.error("%s mode command NAK: %s, Message: %s", self.db.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "Thermostat mode command NAK. " +
+                    msg.nak_str(), None)
+        elif msg.cmd1 == 0x6b:
             self.signal_mode_change.emit(self,
                                          Thermostat.ModeCommands(msg.cmd2))
             if on_done is not None:
@@ -507,7 +517,12 @@ class Thermostat(Base):
           msg:   (InptStandard) Direct ACK message from the device.
           on_done:  Optional callback run when the commands are finished.
         """
-        if msg.cmd1 == 0x6b:
+        if msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
+            LOG.error("%s fan command NAK: %s, Message: %s", self.db.addr,
+                      msg.nak_str(), msg)
+            on_done(False, "Thermostat fan command NAK. " +
+                    msg.nak_str(), None)
+        elif msg.cmd1 == 0x6b:
             self.signal_fan_mode_change.emit(self,
                                              Thermostat.FanCommands(msg.cmd2))
             if on_done is not None:

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -86,8 +86,10 @@ class DeviceDbGet(Base):
                 return Msg.CONTINUE
 
             elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                LOG.error("%s device NAK error: %s", msg.from_addr, msg)
-                self.on_done(False, "Database command NAK", None)
+                LOG.error("%s device NAK error: %s, Message: %s", msg.from_addr,
+                          msg.nak_str(), msg)
+                self.on_done(False, "Database command NAK. " + msg.nak_str(),
+                             None)
                 return Msg.FINISHED
 
             else:

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -77,8 +77,10 @@ class DeviceDbModify(Base):
                                  self.entry)
 
                 elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                    LOG.error("%s db mod NAK: %s", self.db.addr, msg)
-                    self.on_done(False, "Device database update failed", None)
+                    LOG.error("%s db mod NAK: %s, Message: %s", self.db.addr,
+                              msg.nak_str(), msg)
+                    self.on_done(False, "Device database update failed. " +
+                                 msg.nak_str(), None)
 
                 else:
                     LOG.error("%s db mod unexpected msg type: %s",

--- a/insteon_mqtt/handler/ExtendedCmdResponse.py
+++ b/insteon_mqtt/handler/ExtendedCmdResponse.py
@@ -88,8 +88,10 @@ class ExtendedCmdResponse(Base):
                 return Msg.CONTINUE
 
             elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                LOG.error("%s device NAK error: %s", msg.from_addr, msg)
-                self.on_done(False, "Device command NAK", None)
+                LOG.error("%s device NAK error: %s, Message: %s",
+                          msg.from_addr, msg.nak_str(), msg)
+                self.on_done(False, "Device command NAK. " + msg.nak_str(),
+                             None)
                 return Msg.FINISHED
 
             else:

--- a/insteon_mqtt/message/InpStandard.py
+++ b/insteon_mqtt/message/InpStandard.py
@@ -222,36 +222,6 @@ class InpExtended(Base):
         self.expire_time = time.time() + self.flags.hops_left * 0.183
 
     #-----------------------------------------------------------------------
-    def nak_str(self):
-        """Get NAK Explanation String
-
-        Cmd2 of an I2CS NAK response may contain an explanation for the nak,
-        according to Insteon these are:
-
-            0xFF = Senders device ID not in responders database
-            0xFE = Load sense detects no load
-            0xFD = Checksum is incorrect
-            0xFC = Pre NAK in case database search takes too long
-            0xFB = illegal value in command
-
-        Returns:
-          (str) Returns a string NAK explanation if one exists otherwise an
-                empty string
-        """
-        ret = ""
-        naks = {
-            0xFF: "Senders ID not in responders db. Try linking again.",
-            0xFE: "Load sense detects no load",
-            0xFD: "Checksum is incorrect",
-            0xFC: "Pre NAK in case database search takes too long",
-            0xFB: "Illegal value in command"
-        }
-        if (self.flags.type == Flags.Type.DIRECT_NAK and
-                self.cmd2 in naks.keys()):
-            ret = naks[self.cmd2]
-        return ret
-
-    #-----------------------------------------------------------------------
     def __str__(self):
         o = io.StringIO()
         if self.group is None:

--- a/insteon_mqtt/message/InpStandard.py
+++ b/insteon_mqtt/message/InpStandard.py
@@ -83,6 +83,36 @@ class InpStandard(Base):
         self.expire_time = time.time() + self.flags.hops_left * 0.087
 
     #-----------------------------------------------------------------------
+    def nak_str(self):
+        """Get NAK Explanation String
+
+        Cmd2 of an I2CS NAK response may contain an explanation for the nak,
+        according to Insteon these are:
+
+            0xFF = Sender’s device ID not in responder’s database
+            0xFE = Load sense detects no load
+            0xFD = Checksum is incorrect
+            0xFC = Pre NAK in case database search takes too long
+            0xFB = illegal value in command
+
+        Returns:
+          (str) Returns a string NAK explanation if one exists otherwise an
+                empty string
+        """
+        ret = ""
+        naks = {
+            0xFF: "Senders ID not in responders db. Try linking again.",
+            0xFE: "Load sense detects no load",
+            0xFD: "Checksum is incorrect",
+            0xFC: "Pre NAK in case database search takes too long",
+            0xFB: "Illegal value in command"
+        }
+        if (self.flags.type == Flags.Type.DIRECT_NAK and
+                self.cmd2 in naks.keys()):
+            ret = naks[self.cmd2]
+        return ret
+
+    #-----------------------------------------------------------------------
     def __str__(self):
         if self.group is None:
             return "Std: %s->%s %s cmd: %02x %02x" % \
@@ -190,6 +220,36 @@ class InpExtended(Base):
         # value to use with extended length messages in other Insteon
         # software (misterhouse?)
         self.expire_time = time.time() + self.flags.hops_left * 0.183
+
+    #-----------------------------------------------------------------------
+    def nak_str(self):
+        """Get NAK Explanation String
+
+        Cmd2 of an I2CS NAK response may contain an explanation for the nak,
+        according to Insteon these are:
+
+            0xFF = Senders device ID not in responders database
+            0xFE = Load sense detects no load
+            0xFD = Checksum is incorrect
+            0xFC = Pre NAK in case database search takes too long
+            0xFB = illegal value in command
+
+        Returns:
+          (str) Returns a string NAK explanation if one exists otherwise an
+                empty string
+        """
+        ret = ""
+        naks = {
+            0xFF: "Senders ID not in responders db. Try linking again.",
+            0xFE: "Load sense detects no load",
+            0xFD: "Checksum is incorrect",
+            0xFC: "Pre NAK in case database search takes too long",
+            0xFB: "Illegal value in command"
+        }
+        if (self.flags.type == Flags.Type.DIRECT_NAK and
+                self.cmd2 in naks.keys()):
+            ret = naks[self.cmd2]
+        return ret
 
     #-----------------------------------------------------------------------
     def __str__(self):

--- a/tests/message/test_InpStandard.py
+++ b/tests/message/test_InpStandard.py
@@ -3,6 +3,7 @@
 # Tests for: insteont_mqtt/message/InpStandard.py
 #
 #===========================================================================
+import insteon_mqtt as IM
 import insteon_mqtt.message as Msg
 
 
@@ -125,6 +126,29 @@ class Test_InpStandard:
         assert obj != obj5
 
         assert obj != [1, 2, 3]
+
+    #-----------------------------------------------------------------------
+    def test_nak_str(self):
+        from_addr = IM.Address(0x01, 0x02, 0x03)
+        to_addr = IM.Address(0x03, 0x05, 0x07)
+
+        # ID not in DB error
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_NAK, False)
+        obj = Msg.InpStandard(from_addr, to_addr, flags, 0x00, 0xFF)
+        nak_str = obj.nak_str()
+        assert len(nak_str) > 0
+
+        # unknow error type
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_NAK, False)
+        obj = Msg.InpStandard(from_addr, to_addr, flags, 0x00, 0x10)
+        nak_str = obj.nak_str()
+        assert len(nak_str) == 0
+
+        # not a nak
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        obj = Msg.InpStandard(from_addr, to_addr, flags, 0x00, 0xFF)
+        nak_str = obj.nak_str()
+        assert len(nak_str) == 0
 
 
 #===========================================================================


### PR DESCRIPTION
Decode and report available error codes.  Should help users solve some issues.

I wish there was some central place to do this, but in order to get the proper messaging out to the user this has to be reported rather high up in the stack.

Closes #95 