### PR TITLE
Add Join Command a Batch Linking Command

### DIFF
--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -19,6 +19,17 @@ def linking(args, config):
 
 
 #===========================================================================
+def join(args, config):
+    topic = "%s/%s" % (args.topic, args.address)
+    payload = {
+        "cmd" : "join",
+        }
+
+    reply = util.send(config, topic, payload, args.quiet)
+    return reply["status"]
+
+
+#===========================================================================
 def set_button_led(args, config):
     topic = "%s/%s" % (args.topic, args.address)
     payload = {

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -56,6 +56,15 @@ def parse_args(args):
     sp.set_defaults(func=device.linking)
 
     #---------------------------------------
+    # device.join command
+    sp = sub.add_parser("join", help="Join the device to the modem. "
+                        "Allows the modem to talk to the device.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.add_argument("address", help="Device address or name.")
+    sp.set_defaults(func=device.join)
+
+    #---------------------------------------
     # device.refresh command
     sp = sub.add_parser("refresh", help="Refresh device/modem state and "
                         "all link database.")

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -102,6 +102,7 @@ class Base:
             'print_db' : self.print_db,
             'refresh' : self.refresh,
             'linking' : self.linking,
+            'join': self.join,
             'pair' : self.pair,
             'get_flags' : self.get_flags,
             'get_engine' : self.get_engine
@@ -195,6 +196,61 @@ class Base:
         LOG.ui("%s device database", self.label)
         LOG.ui("%s", self.db)
         on_done(True, "Complete", None)
+
+    #-----------------------------------------------------------------------
+    def join(self, on_done=None):
+        """Joins the Device to the Modem, Enabling Communication
+
+        Creates the Modem->Device Link that is Necessary for I2CS Devices.
+
+        I2CS devices (Nearly all Insteon devices made since ~2012) will not
+        respond to most messages sent to them unless they have a responder
+        entry in their db for the device communicating with them.  Older
+        devices that use I1 or I2 protocols do not have this limitation.
+
+        This command can be run on any device version.  It will first check
+        the engine version and then perform any steps necessary after that
+        using the join_seq function.
+        """
+        LOG.info("Join Device %s", self.addr)
+
+        # Using a sequence so we can pass the on_done function through.
+        seq = CommandSeq(self.protocol, "Operation Complete", on_done)
+
+        # Get Engine Version.  This process only works and is necessary on
+        # I2CS devices.
+        seq.add(self.get_engine)
+
+        # Then run join_seq which checks to see if anything further is needed
+        seq.add(self.join_seq)
+
+        seq.run()
+
+    #-----------------------------------------------------------------------
+    def join_seq(self, on_done=None):
+        """Join Sequence Called By Join Command
+
+        This command is only required for I2CS devices.  This function is
+        called after get_engine and will only perform a link sequence if
+        the engine version requires it.
+        """
+        if self.db.engine < 0x02:
+            on_done = util.make_callback(on_done)
+            LOG.info("Device %s is not I2CS, join is unnecessary.", self.addr)
+            on_done(True, "Operation Complete.", None)
+            return
+        else:
+            # Build a sequence of calls to do the link.
+            seq = CommandSeq(self.protocol, "Operation Complete", on_done)
+
+            # Put Modem in linking mode first
+            seq.add(self.modem.linking)
+
+            # Now put this device in linking mode
+            seq.add(self.linking)
+
+            # Finally start the sequence running.
+            seq.run()
 
     #-----------------------------------------------------------------------
     def linking(self, group=0x01, on_done=None):
@@ -502,10 +558,20 @@ class Base:
           msg:  (message.InpStandard) The engine message reply.  The engine
                 version state is in the msg.cmd2 field.
         """
-        self.db.set_engine(msg.cmd2)
+        ver_num = 0x00
+        if msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
+            # If we get a NAK it is almost certainly because this is an I2CS
+            # device that lacks a responder link.
+            ver_num = 0x02
+            LOG.debug("Device %s sent NAK to get engine: %s", self.addr,
+                      msg.cmd2)
+        else:
+            ver_num = msg.cmd2
+
+        self.db.set_engine(ver_num)
 
         labels = {0 : "i1", 1 : "i2", 2 : "i2c"}
-        version = labels.get(msg.cmd2, "Unknown")
+        version = labels.get(msg.cmd2, "Unknown, using I2CS")
         LOG.ui("Device %s engine version: %s", self.addr, version)
         on_done(True, "Operation complete", msg.cmd2)
 


### PR DESCRIPTION
Mostly a command sequence.  Checks to see what the engine version
is, since linking will not work on i1 devices and is not required
for i2 devices.

If the device is i2cs, creates the modem->device link which is
the only one required for the modem to talk to the device.

Join is an idempotent (what a word!) function.  It will not
alter the state of the device more than necessary if run
multiple times.

I chose the word JOIN as I think it gives the right connotation
to the user even though it isn't an insteon term.  But this way
it won't be confused with a link or pair operation.  So new users
can quickly be instructed to join without leading to confusion.

Closes #97 