### PR TITLE
Add on_done Callback to allow for calling by a Sequence

### DIFF
--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -614,8 +614,9 @@ class Device:
         # try and update w/ the new data record.
         if self.engine == 0:
             i1_entry = last.to_i1_bytes()
+            # on_done is passed by the sequence manager inside seq.add()
             modify_manager = DeviceModifyManagerI1(device, self,
-                                                   i1_entry, on_done=on_done,
+                                                   i1_entry, on_done=None,
                                                    num_retry=3)
             seq.add(modify_manager.start_modify)
         else:
@@ -631,8 +632,9 @@ class Device:
 
         if self.engine == 0:
             i1_entry = entry.to_i1_bytes()
+            # on_done is passed by the sequence manager inside seq.add()
             modify_manager = DeviceModifyManagerI1(device, self,
-                                                   i1_entry, on_done=on_done,
+                                                   i1_entry, on_done=None,
                                                    num_retry=3)
             seq.add(modify_manager.start_modify)
         else:

--- a/insteon_mqtt/db/DeviceModifyManagerI1.py
+++ b/insteon_mqtt/db/DeviceModifyManagerI1.py
@@ -72,9 +72,16 @@ class DeviceModifyManagerI1:
         self._num_retry = num_retry
 
     #-------------------------------------------------------------------
-    def start_modify(self):
+    def start_modify(self, on_done=None):
         """Start a managed manipulation of a i1 device database
+
+        Args:
+          on_done: Finished callback to be called when the modify entire
+                   operation is done.  If not NONE it will replace the
+                   the on_done specified in the __init__()
         """
+        if on_done is not None:
+            self.on_done = util.make_callback(on_done)
         # Set the starting MSB
         self._set_msb(self.msb)
 


### PR DESCRIPTION
Fixes a subtle bug.  In some instances the start_modify function
needs to be called by a command sequence.  In those cases, it
needs to accept an on_done argument and needs to call that
on_done function (the command sequence callback) when complete.