### PR TITLE
Add Get Model Command; Run on Refresh if not Known

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -127,8 +127,10 @@ Supported: modem, devices
 If this is sent to the modem, it will trigger an all link database
 download.  If it's sent to a device, the device state (on/off, dimmer
 level, etc) will be updated and the database will be downloaded if
-it's out of date.  Setting the force flag to true will download the
-database even if it's not out of date.  The command payload is:
+it's out of date.  The model information of the device will also be 
+queried if it is not known. Setting the force flag to true will download
+the database even if it's not out of date and will recheck the model
+information even if known.  The command payload is:
 
 
    ```
@@ -147,6 +149,19 @@ is:
    ```
    { "cmd" : "refresh_all", ["force" : true/false] }
    ```
+
+
+### Get device model information
+
+Supported: device
+
+Will send a command to the device to get the device category, sub-category,
+and firmware version.  This information may be used to determine what 
+features are available on the device:
+
+  ```
+  { "cmd" : "get_model" }
+  ```
 
 
 ### Add the device as a controller of another device.

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -84,6 +84,16 @@ def get_engine(args, config):
 
 
 #===========================================================================
+def get_model(args, config):
+    topic = "%s/%s" % (args.topic, args.address)
+    payload = {
+        "cmd" : "get_model",
+        }
+
+    reply = util.send(config, topic, payload, False)
+    return reply["status"]
+
+#===========================================================================
 def print_db(args, config):
     topic = "%s/%s" % (args.topic, args.address)
     payload = {

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -97,6 +97,12 @@ def parse_args(args):
     sp.set_defaults(func=device.get_engine)
 
     #---------------------------------------
+    # device.get_model command
+    sp = sub.add_parser("get-model", help="Get device model information.")
+    sp.add_argument("address", help="Device address or name.")
+    sp.set_defaults(func=device.get_model)
+
+    #---------------------------------------
     # device.on command
     sp = sub.add_parser("on", help="Turn a device on.")
     sp.add_argument("-l", "--level", metavar="level", type=int, default=255,

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -59,6 +59,9 @@ class Device:
         # Extract the various files from the JSON data.
         obj.delta = data['delta']
         obj.engine = data.get('engine', None)
+        obj.dev_cat = data.get('dev_cat', None)
+        obj.sub_cat = data.get('sub_cat', None)
+        obj.firmware = data.get('firmware', None)
         obj._meta = data.get('meta', {})
 
         for d in data['used']:
@@ -106,7 +109,12 @@ class Device:
         # here to show that we haven't checked the engine version yet.
         self.engine = None
 
-        # Metadata storage.  Used for saving device data to persistent 
+        # Device model information
+        self.dev_cat = None
+        self.sub_cat = None
+        self.firmware = None
+
+        # Metadata storage.  Used for saving device data to persistent
         # storage for access across reboots
         self._meta = {}
 
@@ -178,6 +186,104 @@ class Device:
         """
         self.engine = engine
         if engine is not None:
+            self.save()
+
+    #-----------------------------------------------------------------------
+    def set_dev_cat(self, dev_cat):
+        """Saves the device category to file.
+
+        Insteon devices are each assigned to a broad device category.  The
+        known device categories include:
+            0x00 Generalized Controllers ControLinc, RemoteLinc, SignaLinc,
+                 etc.
+            0x01 Dimmable Lighting Control Dimmable Light Switches, Dimmable
+                 Plug-In Modules
+            0x02 Switched Lighting Control Relay Switches, Relay Plug-In
+                 Modules
+            0x03 Network Bridges PowerLinc Controllers, TRex, Lonworks,
+                 ZigBee, etc.
+            0x04 Irrigation Control Irrigation Management, Sprinkler
+                 Controllers
+            0x05 Climate Control Heating, Air conditioning, Exhausts Fans,
+                 Ceiling Fans, Indoor Air Quality
+            0x06 Pool and Spa Control Pumps, Heaters, Chemicals
+            0x07 Sensors and Actuators Sensors, Contact Closures
+            0x08 Home Entertainment Audio/Video Equipment
+            0x09 Energy Management Electricity, Water, Gas Consumption,
+                 Leak Monitors
+            0x0A Built-In Appliance Control White Goods, Brown Goods
+            0x0B Plumbing Faucets, Showers, Toilets
+            0x0C Communication Telephone System Controls, Intercoms
+            0x0D Computer Control PC On/Off, UPS Control, App Activation,
+                 Remote Mouse, Keyboards
+            0x0E Window Coverings Drapes, Blinds, Awnings
+            0x0F Access Control Automatic Doors, Gates, Windows, Locks
+            0x10 Security, Health, Safety Door and Window Sensors, Motion
+                 Sensors, Scales
+            0x11 Surveillance Video Camera Control, Time-lapse Recorders,
+                 Security System Links
+            0x12 Automotive Remote Starters, Car Alarms, Car Door Locks
+            0x13 Pet Care Pet Feeders, Trackers
+            0x14 Toys Model Trains, Robots
+            0x15 Timekeeping Clocks, Alarms, Timers
+            0x16 Holiday Christmas Lights, Displays
+
+        Args:
+          dev_cat:  (int) The device category.  None to clear the value.
+        """
+        self.dev_cat = dev_cat
+        if dev_cat is not None:
+            self.save()
+
+    #-----------------------------------------------------------------------
+    def set_sub_cat(self, sub_cat):
+        """Saves the device sub-category to file.
+
+        Within the broad device category, insteon devices are assigned to a
+        more narrow sub category.  Generally a sub-category remains consistent
+        throughout a single model number of a a product, however not always.
+        Smart Labs has done a poor job of publishing the details of the
+        sub-categories.  Some resources for determining the details of a
+        sub-category are:
+
+        http://cache.insteon.com/pdf/INSTEON_DevCats_and_Product_Keys_20081008.pdf
+        http://madreporite.com/insteon/Insteon_device_list.htm
+
+        Generally knowing the Dev_Cat and Sub_Cat is sufficient for determining
+        the features that are available on a device.  Additionally knowing the
+        engine version of the device is also another good indicator.
+
+        Args:
+          sub_cat:  (int) The device sub-category.  None to clear the value.
+        """
+        self.sub_cat = sub_cat
+        if sub_cat is not None:
+            self.save()
+
+    #-----------------------------------------------------------------------
+    def set_firmware(self, firmware):
+        """Saves the firmware of the device to file.
+
+        The firmware version of a device is just that, the version number of
+        the embedded code on the device.  In theory, this firmware is
+        updatable (although not by a casual user), however Smart Labs has never
+        published an update for any device.
+
+        That said, it does seem that Smart Labs routinely updates the firmware
+        that is installed on devices before they are sold.  However, Smart Labs
+        does not publish changelogs, nor does it discuss what changes have been
+        made.
+
+        Based on anecdotal evidence, few if any changes in firmware have added
+        any features to a device.  Generally knowing the Dev_Cat and Sub_Cat
+        is sufficient for determining the features that are available on a
+        device.
+
+        Args:
+          sub_cat:  (int) The device sub-category.  None to clear the value.
+        """
+        self.firmware = firmware
+        if firmware is not None:
             self.save()
 
     #-----------------------------------------------------------------------
@@ -469,6 +575,9 @@ class Device:
             'address' : self.addr.to_json(),
             'delta' : self.delta,
             'engine' : self.engine,
+            'dev_cat' : self.dev_cat,
+            'sub_cat' : self.sub_cat,
+            'firmware' : self.firmware,
             'used' : used,
             'unused' : unused,
             'last' : self.last.to_json(),

--- a/insteon_mqtt/handler/BroadcastCmdResponse.py
+++ b/insteon_mqtt/handler/BroadcastCmdResponse.py
@@ -1,0 +1,110 @@
+#===========================================================================
+#
+# Insteon broadcast command response handerl
+#
+#===========================================================================
+from .. import log
+from .. import message as Msg
+from .Base import Base
+
+LOG = log.get_logger()
+
+
+class BroadcastCmdResponse(Base):
+    """Handles Broadcast Messages Received in Response to a Direct Request`.
+
+    This class handles responses from the device where the device sends an
+    ACK but a subsequent broadcast message is sent with the requested payload.
+
+    The handler watches for the proper standard length ACK, returns
+    a continue and then waits for the broadcast payload.
+    """
+    def __init__(self, msg, callback, on_done=None, num_retry=3):
+        """Constructor
+
+        Args
+          msg:       (OutStandard) The output message that was sent.
+          callback:  Callback function to pass the broadcast messages with
+                     that match the desired parameters to.  Signature:
+                     callback(message, on_done).
+          num_retry: (int) The number of times to retry the message if the
+                     handler times out without returning Msg.FINISHED.
+                     This count does include the initial sending so a
+                     retry of 3 will send once and then retry 2 more times.
+        """
+        super().__init__(on_done, num_retry)
+
+        self.addr = msg.to_addr
+        self.cmd = msg.cmd1
+        self.callback = callback
+
+    #-----------------------------------------------------------------------
+    def msg_received(self, protocol, msg):
+        """See if we can handle the message.
+
+        See if the message is the expected ACK of our output or the broadcast
+        reply message.  If we get a reply, pass it to the callback.
+
+        Args:
+          protocol:  (Protocol) The Insteon Protocol object
+          msg:       Insteon message object that was read.
+
+        Returns:
+          Msg.UNKNOWN if we can't handle this message.
+          Msg.CONTINUE if we handled the message and expect more.
+          Msg.FINISHED if we handled the message and are done.
+        """
+        # Probably an echo back of our sent message.
+        if isinstance(msg, Msg.OutStandard):
+            # If the message is the echo back of our message, then continue
+            # waiting for a reply.
+            if msg.to_addr == self.addr and msg.cmd1 == self.cmd:
+                if not msg.is_ack:
+                    LOG.error("%s NAK response", self.addr)
+
+                LOG.debug("%s got msg ACK", self.addr)
+                return Msg.CONTINUE
+
+            # Message didn't match the expected addr/cmd.
+            LOG.debug("%s handler unknown msg", self.addr)
+            return Msg.UNKNOWN
+
+        # Probably an ACK/NAK from the device for our get command.
+        elif (isinstance(msg, Msg.InpStandard) and
+              msg.flags.type != Msg.Flags.Type.BROADCAST):
+            # Filter by address and command.
+            if msg.from_addr != self.addr or msg.cmd1 != self.cmd:
+                return Msg.UNKNOWN
+
+            if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
+                LOG.info("%s device ACK response, waiting for broadcast " +
+                         "payload", msg.from_addr)
+                return Msg.CONTINUE
+
+            elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
+                LOG.error("%s device NAK error: %s", msg.from_addr, msg)
+                self.on_done(False, "Device command NAK", None)
+                return Msg.FINISHED
+
+            else:
+                LOG.warning("%s device unexpected msg: %s", msg.from_addr, msg)
+                return Msg.UNKNOWN
+
+        # Process the payload reply.
+        elif (isinstance(msg, Msg.InpStandard) and
+              msg.flags.type == Msg.Flags.Type.BROADCAST):
+            # Filter by address and command.
+            if msg.from_addr == self.addr:
+                # Run the callback - it's up to the callback to check if this
+                # is really the ACK or not.
+                self.callback(msg, on_done=self.on_done)
+
+                # Indicate no more messages are expected.
+                return Msg.FINISHED
+            else:
+                LOG.info("Possible unexpected broadcast message from %s",
+                         msg.from_addr)
+
+        return Msg.UNKNOWN
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/__init__.py
+++ b/insteon_mqtt/handler/__init__.py
@@ -46,4 +46,5 @@ from .ModemReset import ModemReset
 from .ModemScene import ModemScene
 from .StandardCmd import StandardCmd
 from .ThermostatCmd import ThermostatCmd
+from .BroadcastCmdResponse import BroadcastCmdResponse
 

--- a/tests/db/test_Device.py
+++ b/tests/db/test_Device.py
@@ -23,6 +23,18 @@ class Test_Device:
         obj.set_engine(1)
         assert obj.engine == 1
 
+        assert obj.dev_cat is None
+        obj.set_dev_cat(1)
+        assert obj.dev_cat == 1
+
+        assert obj.sub_cat is None
+        obj.set_sub_cat(1)
+        assert obj.sub_cat == 1
+
+        assert obj.firmware is None
+        obj.set_firmware(1)
+        assert obj.firmware == 1
+
         addr = IM.Address(0x10, 0xab, 0x1c)
         flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
         db_flags = Msg.DbFlags(in_use=True, is_controller=True,

--- a/tests/handler/test_BroadcastCmdResponse.py
+++ b/tests/handler/test_BroadcastCmdResponse.py
@@ -1,0 +1,101 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/handler/BroadcastCmdResponse.py
+#
+#===========================================================================
+import insteon_mqtt as IM
+import insteon_mqtt.message as Msg
+
+
+class Test_BroadcastCmdResponse:
+    def test_cmd_from_msg(self):
+        # Tests matching the command from the outbound message.
+        proto = MockProto()
+        calls = []
+
+        def callback(msg, on_done=None):
+            calls.append(msg)
+
+        addr = IM.Address('0a.12.34')
+
+        # sent message, match input command
+        out = Msg.OutStandard.direct(addr, 0x10, 0x00)
+        handler = IM.handler.BroadcastCmdResponse(out, callback)
+
+        r = handler.msg_received(proto, "dummy")
+        assert r == Msg.UNKNOWN
+
+        # ack back.
+        out.is_ack = False
+        r = handler.msg_received(proto, out)
+        assert r == Msg.CONTINUE
+
+        # wrong cmd
+        out.cmd1 = 0x13
+        r = handler.msg_received(proto, out)
+        assert r == Msg.UNKNOWN
+
+        # wrong addr
+        out.cmd1 = 0x11
+        out.to_addr = IM.Address('0a.12.33')
+        r = handler.msg_received(proto, out)
+        assert r == Msg.UNKNOWN
+
+        # Now pass in the input message.
+
+        # expected input meesage
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x10, 0x00)
+
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.CONTINUE
+
+        # wrong cmd
+        msg.cmd1 = 0x13
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+        # wrong addr
+        msg.cmd1 = 0x11
+        msg.from_addr = IM.Address('0a.12.33')
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+        # direct NAK
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_NAK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x10, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+
+        # unexpected
+        flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x10, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+        # Test receipt of broadcast payloads
+        flags = Msg.Flags(Msg.Flags.Type.BROADCAST, False)
+        # cmd1 doesn't have to match cmd1 of sent message
+        msg = Msg.InpStandard(addr, addr, flags, 0x01, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert len(calls) == 1
+        assert calls[0] == msg
+        
+        # Test receipt of bad payloads
+        msg.from_addr = IM.Address('0a.12.33')
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+
+#===========================================================================
+
+
+class MockProto:
+    def add_handler(self, *args):
+        pass
+
+
+class MockModem:
+    def __init__(self):
+        self.save_path = ''


### PR DESCRIPTION
Get Model command will query the device for its device category, sub-category, and firmware version.

This information is usually sufficient to determine the device model and its full set of capabilities.

A Get Model command will run on refresh if:
1. The model number is not currently known; OR
2. Force on refresh is true

The Get Model command can also be run independently via mqtt or the command line.

Adds testing for the function and documentation as well.

Required a "Broadcast Command Handler" as the model information is returned in a broadcast packet (thanks smart labs).

Fixes #55 