### PR TITLE
Call Base handle_broadcast; Revert change to Thermo Mode enum

### DIFF
--- a/insteon_mqtt/device/Thermostat.py
+++ b/insteon_mqtt/device/Thermostat.py
@@ -446,7 +446,6 @@ class Thermostat(Base):
                     status = Thermostat.Status.COOLING
 
                 self.signal_status_change.emit(self, status)
-                return  # TODO: should these be here?
 
         # As long as there is no errors (which return above), call
         # handle_broadcast for any device that we're the controller of.

--- a/insteon_mqtt/handler/ThermostatCmd.py
+++ b/insteon_mqtt/handler/ThermostatCmd.py
@@ -24,6 +24,16 @@ class ThermostatCmd(Base):
     NOTE: This handler is designed to always be active - it never returns
     FINISHED.
     """
+
+    # This mapping is different from the mapping used in response to a
+    # get_status message.
+    class Mode(enum.IntEnum):
+        off = 0x00
+        heat = 0x01
+        cool = 0x02
+        auto = 0x03
+        program = 0x04
+
     def __init__(self, device):
         """Constructor
 
@@ -89,7 +99,7 @@ class ThermostatCmd(Base):
             mode_nibble = int(msg.cmd2) & 0b00001111
             self.device.set_fan_mode_state(fan_nibble)
             try:
-                hvac_mode = self.device.Mode(mode_nibble)
+                hvac_mode = ThermostatCmd.Mode(mode_nibble)
             except ValueError:
                 LOG.exception("Unknown mode broadcast state %s.", mode_nibble)
             else:


### PR DESCRIPTION
Should always call handle_broadcast() in base to make sure linked
devices are updated.

The Mode enum in ThermostatCmd is necessary, the mapping of the
values are not the same for the various Insteon functions.

Fixes #107 