### PR TITLE
Fix KeypadLinc command doc

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -305,7 +305,7 @@ Button is an integer in the range [1,8].  In the 6 button version, buttons
 commands.
 
    ```
-   { "cmd": "set_button_led", "button" : button, "is_on" : true/false }
+   { "cmd": "set_button_led", "group" : button, "is_on" : true/false }
    ```
 
 ### Get and set operating flags.


### PR DESCRIPTION
The `set_button_led` command uses `group`, not button.
> TypeError: set_button_led() got an unexpected keyword argument 'button'