### PR TITLE
Keypadlinc disable toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+.*.sw*
 *.pyc
 .cache
 .coverage

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,7 +26,7 @@ against that.
 
    ```
    flake8 ./insteon_mqtt
-   pylint ./insteon-mqtt
+   pylint ./insteon_mqtt
    ```
 
 - Classes, functions, and methods must be documented with Python

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,7 +25,7 @@ against that.
   pylint.  These must be run from the top level directory of the repository.
 
    ```
-   flake8 ./insteon-mqtt
+   flake8 ./insteon_mqtt
    pylint ./insteon-mqtt
    ```
 

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -690,7 +690,7 @@ class Base:
 
     #-----------------------------------------------------------------------
     def handle_received(self, msg):
-        """Receives incomming message notifications from protocol
+        """Receives incoming message notifications from protocol
 
         This is called for every standard and extended message that is read
         from the modem from this device.  This is only used to track the hop
@@ -890,7 +890,7 @@ class Base:
             seq.add(self.refresh)
 
         # Get the data array to use.  See Github issue #7 for discussion.
-        # Use teh bytes() cast here so we can take a list as input.
+        # Use the bytes() cast here so we can take a list as input.
         local_data = self.link_data(is_controller, local_group, local_data)
 
         # Group number in the db is the group number of the controller since

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -649,7 +649,7 @@ class KeypadLinc(Base):
           led_bits (int): The LED bits that were set to the device.  If the
                    msg is an ACK, we'll set our state to this value.
         """
-        # If this it the ACK we're expecting, update the internal state and
+        # If this is the ACK we're expecting, update the internal state and
         # emit our signals.
         if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
             LOG.debug("KeypadLinc LED %s group %s ACK: %s", self.addr, group,
@@ -796,7 +796,7 @@ class KeypadLinc(Base):
           msg:  (message.InpStandard) The reply message from the device.
                 The on/off level will be in the cmd2 field.
         """
-        # If this it the ACK we're expecting, update the internal state and
+        # If this is the ACK we're expecting, update the internal state and
         # emit our signals.
         if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
             LOG.debug("KeypadLinc %s ACK: %s", self.addr, msg)

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -82,6 +82,7 @@ class KeypadLinc(Base):
             'scene' : self.scene,
             'set_flags' : self.set_flags,
             'set_button_led' : self.set_button_led,
+            'set_button_signal' : self.set_button_signal,
             })
 
         if self.is_dimmer:
@@ -102,6 +103,17 @@ class KeypadLinc(Base):
         # Since the non-load buttons have nothing to switch, the led state is
         # the state of the switch.
         self._led_bits = 0x00
+
+        # 8 bits representing the buttons on the keypad.  Bit0=button1, ...,
+        # Bit7=button8.  If a bit is set, then the button will no longer
+        # automatically 'toggle', it will only send a 'on' command.
+        self._non_toggle = 0x00
+
+        # A bitmask representing what signal is sent when a button is pressed
+        # and it is a non-toggle button.  A value of 0 means 'off' will be
+        # sent.  A value of 1 means 'on' will be sent.  Bit0=button1, ...,
+        # bit7=button8.
+        self._press_signal = 0x00
 
         # Button 1 level (0-255)
         self._level = 0
@@ -192,6 +204,14 @@ class KeypadLinc(Base):
         msg_handler = handler.DeviceRefresh(self, self.handle_refresh_led,
                                             force=False, num_retry=3,
                                             skip_db=True)
+        seq.add_msg(msg, msg_handler)
+
+        # get the state of which buttons 'toggle'.
+        data = bytes([0x01] + [0x00] * 13)
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+        msg_handler = handler.ExtendedCmdResponse(msg,
+                                                  self.handle_refresh_state,
+                                                  num_retry=3)
         seq.add_msg(msg, msg_handler)
 
         # If we get the LED state correctly, then have the base also get it's
@@ -498,6 +518,77 @@ class KeypadLinc(Base):
         self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
+    def set_button_signal(self, group, signal, on_done=None):
+        """Set whether or not a button toggles.
+
+        Args:
+           group (int):  The group number to modify
+           signal (bool):  If True, then pressing the specified group will
+                       send the 'on' signal.  If False, then it will emit the
+                       'off' signal.  If None, then pressing the group will
+                       toggle the state (this is the default behaviour).
+        """
+        on_done = util.make_callback(on_done)
+
+        msg = "toggle"
+        if signal is not None:
+            msg = "emit %s when pressed" % ("'on'" if signal else "'off'")
+        LOG.info("setting button %s to %s", group, msg)
+
+        if group < 1 or group > 8:
+            LOG.error("KeypadLinc group %s out of range [1,8]", group)
+            on_done(False, "Invalid group", None)
+            return
+
+        seq = CommandSeq(self.protocol, "KeypadLinc set_button_signal done",
+                         on_done)
+
+        toggle_off = False
+        if signal is not None:
+            toggle_off = True
+            LOG.debug("group %s - disable toggle", group)
+
+            # First specify what signal to send (if non-toggle enabled)
+            signal_bits = util.bit_set(self._press_signal, group - 1, signal)
+            LOG.debug("signal_bits: %s", "{:08b}".format(signal_bits))
+            data = bytes([
+                0x01,   # D1 must be group 0x01
+                0x0b,   # D2 set non-toggle signal
+                signal_bits,  # D3 non-toggle signal
+                ] + [0x00] * 11)
+
+            msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+
+            # Use the standard command handler which will notify us when the
+            # command is ACK'ed.
+            callback = functools.partial(self.handle_button_signal,
+                                         group=group, signal_bits=signal_bits)
+            msg_handler = handler.StandardCmd(msg, callback, on_done)
+
+            seq.add_msg(msg, msg_handler)
+
+        # next set the non-toggle flag
+        toggle_bits = util.bit_set(self._non_toggle, group - 1, toggle_off)
+        LOG.debug("toggle_bits: %s", "{:08b}".format(toggle_bits))
+        data = bytes([
+            0x01,   # D1 must be group 0x01
+            0x08,   # D2 set non-toggle enabled
+            toggle_bits,  # D3 non-toggle enabled
+            ] + [0x00] * 11)
+
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+
+        # Use the standard command handler which will notify us when the
+        # command is ACK'ed.
+        callback = functools.partial(self.handle_button_signal,
+                                     group=group, toggle_bits=toggle_bits)
+        msg_handler = handler.StandardCmd(msg, callback, on_done)
+
+        seq.add_msg(msg, msg_handler)
+
+        seq.run()
+
+    #-----------------------------------------------------------------------
     def set_on_level(self, level, on_done=None):
         """Set the device default on level.
 
@@ -554,19 +645,29 @@ class KeypadLinc(Base):
 
         # Check the input flags to make sure only ones we can understand were
         # passed in.
-        flags = set(["backlight", "on_level"])
+        flags = set(["backlight", "button_signal", "group", "on_level"])
         unknown = set(kwargs.keys()).difference(flags)
         if unknown:
             raise Exception("Unknown KeypadLinc flags input: %s.\n Valid "
-                            "flags are: %s" % unknown, flags)
+                            "flags are: %s" % (unknown, flags))
 
         # Start a command sequence so we can call the flag methods in series.
         seq = CommandSeq(self.protocol, "KeypadLinc set_flags complete",
                          on_done)
 
-        if "backlink" in kwargs:
+        group = util.input_integer(kwargs, "group")
+
+        if "backlight" in kwargs:
             backlight = util.input_byte(kwargs, "backlight")
             seq.add(self.set_backlight, backlight)
+
+        if "button_signal" in kwargs:
+            if group is None:
+                raise Exception("Must specify 'group=<group_number>' when "
+                                "setting the 'button_signal' flag")
+            signal = util.input_bool(kwargs, "button_signal")
+
+            seq.add(self.set_button_signal, group, signal)
 
         if "on_level" in kwargs:
             on_level = util.input_byte(kwargs, "on_level")
@@ -673,6 +774,55 @@ class KeypadLinc(Base):
                     None)
 
     #-----------------------------------------------------------------------
+    def handle_button_signal(self, msg, on_done, group, toggle_bits=None,
+                             signal_bits=None):
+        """Handle replies to setting the button signal.
+
+        This is called when we change what signal a button sends when it is
+        pressed.
+
+        Args:
+          msg (InpStandard):  The message reply.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+          group (int):  The group to send the command to.  This must be in the
+                range [1,8].
+          toggle_bits (int): The button bits that determine if the button
+                             toggles or not.  If the message is an ACK, then
+                             we store the state.
+          signal_bits (int):  The button bits that determine what signal is
+                              emitted if the button does not toggle.  If the
+                              mesaage is an ACK, then we store the state.
+        """
+        # If this is the ACK we're expecting, update the internal state and
+        # emit our signals.
+        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
+            LOG.debug("KeypadLinc toggle %s group %s ACK: %s", self.addr,
+                      group, msg)
+
+            if toggle_bits is not None:
+                # update with the new toggle bit mask
+                self._non_toggle = toggle_bits
+
+                LOG.ui("KeypadLinc %s non_toggle changed to %s", self.addr,
+                       "{:08b}".format(self._non_toggle))
+
+            if signal_bits is not None:
+                # update with the new signal bit mask
+                self._press_signal = signal_bits
+
+                LOG.ui("KeypadLinc %s press_signal changed to %s", self.addr,
+                       "{:08b}".format(self._press_signal))
+
+            msg = "KeypadLinc %s toggle flags updated" % self.addr
+            on_done(True, msg, None)
+
+        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
+            LOG.error("KeypadLinc toggle %s NAK error: %s", self.addr, msg)
+            msg = "KeypadLinc %s toggle update failed" % self.addr
+            on_done(False, msg, None)
+
+    #-----------------------------------------------------------------------
     def handle_refresh_led(self, msg):
         """Callback for handling getting the LED button states.
 
@@ -686,10 +836,44 @@ class KeypadLinc(Base):
         Args:
           msg (InpStandard):  The message reply.
         """
-        led_bits = msg.cmd2
+        pass
+        #TODO: delete this method
+        #led_bits = msg.cmd2
 
-        # Current the led speed is stored in cmd2 so update our speed to
-        # match.
+        ## Currently the led state is stored in cmd2 so update our state to
+        ## match.
+        #LOG.ui("KeypadLinc %s setting LED bits %s", self.addr,
+        #       "{:08b}".format(led_bits))
+
+        ## Loop over the bits and emit a signal for any that have been
+        ## changed.
+        #for i in range(8):
+        #    is_on = util.bit_get(led_bits, i)
+        #    was_on = util.bit_get(self._led_bits, i)
+
+        #    LOG.debug("Btn %d old: %d new %d", i + 1, is_on, was_on)
+        #    if is_on != was_on:
+        #        self._set_level(i + 1, 0xff if is_on else 0x00)
+
+        #self._led_bits = led_bits
+
+    #-----------------------------------------------------------------------
+    def handle_refresh_state(self, msg, on_done):
+        """Callback for handling getting the button states.
+
+        Args:
+          msg (InpExtended):  The message reply.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        #TODO: merge this with 'handle_refresh_led'
+        # - needs an updated refresh handler that can accept an extended reply
+        LOG.debug("KeypadLinc %s Get button state: %s", self.addr, msg)
+
+        non_toggle_mask = msg.data[9]
+        led_bits = msg.data[10]
+        signal_mask = msg.data[12]
+
         LOG.ui("KeypadLinc %s setting LED bits %s", self.addr,
                "{:08b}".format(led_bits))
 
@@ -704,6 +888,16 @@ class KeypadLinc(Base):
                 self._set_level(i + 1, 0xff if is_on else 0x00)
 
         self._led_bits = led_bits
+
+        LOG.ui("KeypadLinc %s setting non_toggle_mask %s",
+               self.addr, "{:08b}".format(non_toggle_mask))
+        self._non_toggle = non_toggle_mask
+
+        LOG.ui("KeypadLinc %s setting signal_mask %s", self.addr,
+               "{:08b}".format(signal_mask))
+        self._press_signal = signal_mask
+
+        on_done(True, "Refreshed keypad state", None)
 
     #-----------------------------------------------------------------------
     def handle_broadcast(self, msg):

--- a/insteon_mqtt/util.py
+++ b/insteon_mqtt/util.py
@@ -221,13 +221,20 @@ def input_integer(inputs, field):
     if value is None:
         return None
 
-    if isinstance(value, str):
-        lv = value.lower()
-        if lv == 'none':
-            return None
-
     try:
-        return int(value)
+        if isinstance(value, str):
+            lv = value.lower()
+            if lv == 'none':
+                return None
+
+            if '0x' in value:
+                return int(value, 16)
+            elif '0b' in value:
+                return int(value, 2)
+            else:
+                return int(value)
+        else:
+            return int(value)
     except ValueError:
         msg = "Invalid %s input.  Valid inputs are integer values." % input
         raise ValueError(msg)

--- a/insteon_mqtt/util.py
+++ b/insteon_mqtt/util.py
@@ -166,7 +166,8 @@ def input_choice(inputs, field, choices):
 def input_bool(inputs, field):
     """Convert an input field to a boolean.
 
-    Valid boolean inputs are 'true', 'false', 'on', 'off', 1, 0, True, or False.
+    Valid boolean inputs are 'true', 'false', 'on', 'off', 1, 0, True,
+    or False.
 
     Raises:
       If the input is not a valid bool, an exception is thrown.

--- a/insteon_mqtt/util.py
+++ b/insteon_mqtt/util.py
@@ -166,7 +166,7 @@ def input_choice(inputs, field, choices):
 def input_bool(inputs, field):
     """Convert an input field to a boolean.
 
-    Valid boolean inputs are 'true', 'false', 1, 0, True, or False.
+    Valid boolean inputs are 'true', 'false', 'on', 'off', 1, 0, True, or False.
 
     Raises:
       If the input is not a valid bool, an exception is thrown.
@@ -185,10 +185,12 @@ def input_bool(inputs, field):
 
     if isinstance(value, str):
         lv = value.lower()
-        if lv == "true":
+        if lv in ["true", 'on']:
             value = True
-        elif lv == "false":
+        elif lv in ["false", 'off']:
             value = False
+        elif lv == 'none':
+            return None
 
     try:
         # Use int() because bool("asdf") also returns true.  This ensures
@@ -200,11 +202,42 @@ def input_bool(inputs, field):
 
 
 #===========================================================================
+def input_integer(inputs, field):
+    """Convert an input field to an integer.
+
+    Raises:
+      If the input is not a valid integer, an exception is thrown.
+
+    Args:
+      inputs (dict):  Key/value pairs of user inputs.
+      field (str): The field to get.
+
+    Returns:
+      Returns None if field is not in inputs.  Otherwise the input field
+      is converted to an integer and returned.
+    """
+    value = inputs.pop(field, None)
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        lv = value.lower()
+        if lv == 'none':
+            return None
+
+    try:
+        return int(value)
+    except ValueError:
+        msg = "Invalid %s input.  Valid inputs are integer values." % input
+        raise ValueError(msg)
+
+
+#===========================================================================
 def input_byte(inputs, field):
     """Convert an input field to a byte.
 
     Valid byte inputs are integers or strings leading with '0x' (base 16 hex
-    value).
+    value) or '0b' (base 2 binary value).
 
     Raises:
       If the input is not a valid byte, an exception is thrown.
@@ -222,8 +255,13 @@ def input_byte(inputs, field):
         return None
 
     try:
-        if isinstance(value, str) and '0x' in value:
-            v = int(value, 16)
+        if isinstance(value, str):
+            if '0x' in value:
+                v = int(value, 16)
+            elif '0b' in value:
+                v = int(value, 2)
+            else:
+                v = int(value)
         else:
             v = int(value)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -147,7 +147,7 @@ class Test_util:
         inputs = {'key1' : '1', 'key2' : 2,
                   'key3' : '0x03', 'key4' : 0x04,
                   'key5' : None, 'key6' : 'None',
-                  'key7' : 'bad'}
+                  'key7' : '0b101', 'key8' : 'bad'}
 
         v = IM.util.input_integer(inputs, 'key1')
         assert v is 1
@@ -167,11 +167,14 @@ class Test_util:
         v = IM.util.input_integer(inputs, 'key6')
         assert v is None
 
+        v = IM.util.input_integer(inputs, 'key7')
+        assert v is 5
+
         v = IM.util.input_integer(inputs, 'invalid')
         assert v is None
 
         with pytest.raises(ValueError):
-            v = IM.util.input_integer(inputs, 'key7')
+            v = IM.util.input_integer(inputs, 'key8')
 
     #-----------------------------------------------------------------------
     def test_input_byte(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -108,7 +108,9 @@ class Test_util:
     def test_input_bool(self):
         inputs = {'key1' : 'TRUE', 'key2' : 'FALSE',
                   'key3' : 1, 'key4': 0,
-                  'key5' : 'bad'}
+                  'key5' : 'On', 'key6' : 'Off',
+                  'key7' : None, 'key8' : 'None',
+                  'key9' : 'bad'}
 
         v = IM.util.input_bool(inputs, 'key1')
         assert v is True
@@ -122,17 +124,61 @@ class Test_util:
         v = IM.util.input_bool(inputs, 'key4')
         assert v is False
 
+        v = IM.util.input_bool(inputs, 'key5')
+        assert v is True
+
+        v = IM.util.input_bool(inputs, 'key6')
+        assert v is False
+
+        v = IM.util.input_bool(inputs, 'key7')
+        assert v is None
+
+        v = IM.util.input_bool(inputs, 'key8')
+        assert v is None
+
         v = IM.util.input_bool(inputs, 'invalid')
         assert v is None
 
         with pytest.raises(ValueError):
-            v = IM.util.input_bool(inputs, 'key5')
+            v = IM.util.input_bool(inputs, 'key9')
+
+    #-----------------------------------------------------------------------
+    def test_input_integer(self):
+        inputs = {'key1' : '1', 'key2' : 2,
+                  'key3' : '0x03', 'key4' : 0x04,
+                  'key5' : None, 'key6' : 'None',
+                  'key7' : 'bad'}
+
+        v = IM.util.input_integer(inputs, 'key1')
+        assert v is 1
+
+        v = IM.util.input_integer(inputs, 'key2')
+        assert v is 2
+
+        v = IM.util.input_integer(inputs, 'key3')
+        assert v is 3
+
+        v = IM.util.input_integer(inputs, 'key4')
+        assert v is 4
+
+        v = IM.util.input_integer(inputs, 'key5')
+        assert v is None
+
+        v = IM.util.input_integer(inputs, 'key6')
+        assert v is None
+
+        v = IM.util.input_integer(inputs, 'invalid')
+        assert v is None
+
+        with pytest.raises(ValueError):
+            v = IM.util.input_integer(inputs, 'key7')
 
     #-----------------------------------------------------------------------
     def test_input_byte(self):
         inputs = {'key1' : 0, 'key2' : '10',
-                  'key3' : '0x2f', 'key4' : 256,
-                  'key5' : 'bad'}
+                  'key3' : '0x2f', 'key4' : '0b11',
+                  'key5' : 256, 'key6' : '257',
+                  'key7' : 'bad'}
 
         v = IM.util.input_byte(inputs, 'missing')
         assert v is None
@@ -146,11 +192,17 @@ class Test_util:
         v = IM.util.input_byte(inputs, 'key3')
         assert v == 0x2f
 
-        with pytest.raises(ValueError):
-            v = IM.util.input_byte(inputs, 'key4')
+        v = IM.util.input_byte(inputs, 'key4')
+        assert v == 0x03
 
         with pytest.raises(ValueError):
             v = IM.util.input_byte(inputs, 'key5')
+
+        with pytest.raises(ValueError):
+            v = IM.util.input_byte(inputs, 'key6')
+
+        with pytest.raises(ValueError):
+            v = IM.util.input_byte(inputs, 'key7')
 
 
 #===========================================================================


### PR DESCRIPTION
Added capability to change keypadlinc button behavior so that pushing a button does not toggle the state but will emit a user defined signal of either 'on' or 'off'.