### PR TITLE
Save Writes to i1 Device DB to Software Database

### DIFF
--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -414,9 +414,8 @@ class Device:
         new_entry.db_flags.in_use = False
 
         if self.engine == 0:
-            i1_entry = new_entry.to_i1_bytes()
             modify_manager = DeviceModifyManagerI1(device, self,
-                                                   i1_entry, on_done=on_done,
+                                                   new_entry, on_done=on_done,
                                                    num_retry=3)
             modify_manager.start_modify()
         else:
@@ -637,9 +636,8 @@ class Device:
         entry.update_from(addr, group, is_controller, data)
 
         if self.engine == 0:
-            i1_entry = entry.to_i1_bytes()
             modify_manager = DeviceModifyManagerI1(device, self,
-                                                   i1_entry, on_done=on_done,
+                                                   entry, on_done=on_done,
                                                    num_retry=3)
             modify_manager.start_modify()
         else:
@@ -679,10 +677,9 @@ class Device:
         # Start by writing the last record - that way if it fails, we don't
         # try and update w/ the new data record.
         if self.engine == 0:
-            i1_entry = last.to_i1_bytes()
             # on_done is passed by the sequence manager inside seq.add()
             modify_manager = DeviceModifyManagerI1(device, self,
-                                                   i1_entry, on_done=None,
+                                                   last, on_done=None,
                                                    num_retry=3)
             seq.add(modify_manager.start_modify)
         else:
@@ -697,10 +694,9 @@ class Device:
         entry = DeviceEntry(addr, group, self.last.mem_loc, db_flags, data)
 
         if self.engine == 0:
-            i1_entry = entry.to_i1_bytes()
             # on_done is passed by the sequence manager inside seq.add()
             modify_manager = DeviceModifyManagerI1(device, self,
-                                                   i1_entry, on_done=None,
+                                                   entry, on_done=None,
                                                    num_retry=3)
             seq.add(modify_manager.start_modify)
         else:

--- a/tests/db/test_DeviceModifyManagerI1.py
+++ b/tests/db/test_DeviceModifyManagerI1.py
@@ -24,7 +24,7 @@ class Test_Device:
 
         manager = IM.db.DeviceModifyManagerI1(device,
                                               device.db,
-                                              i1_entry.to_i1_bytes())
+                                              i1_entry)
 
         db_msg = Msg.OutStandard.direct(device.addr, 0x28, 0x0F)
 
@@ -47,7 +47,7 @@ class Test_Device:
 
         manager = IM.db.DeviceModifyManagerI1(device,
                                               device.db,
-                                              i1_entry.to_i1_bytes())
+                                              i1_entry)
 
         # Test bad MSB, should cause resend of set msb
         flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
@@ -79,7 +79,7 @@ class Test_Device:
 
         manager = IM.db.DeviceModifyManagerI1(device,
                                               device.db,
-                                              i1_entry.to_i1_bytes())
+                                              i1_entry)
 
         # Test wrong LSB, should cause poke of set lsb
         flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
@@ -103,7 +103,6 @@ class Test_Device:
         addr = IM.Address(0x01, 0x02, 0x03)
         device = IM.device.Base(protocol, modem, addr)
         calls = []
-
         def callback(success, msg, data):
             calls.append(msg)
 
@@ -115,7 +114,7 @@ class Test_Device:
 
         manager = IM.db.DeviceModifyManagerI1(device,
                                               device.db,
-                                              i1_entry.to_i1_bytes())
+                                              i1_entry)
 
         # Test received unused from start
         flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
@@ -140,7 +139,6 @@ class MockProto:
 
     def send(self, msg, handler, high_priority=False, after=None):
         self.msgs.append(msg)
-
 
 class MockModem():
     def __init__(self):


### PR DESCRIPTION
Fixes a small bug where writes to an i1 database were not being
updated in the software database.  They were only being fixed
by a refresh.

This brings i1 inline with how i2 and above devices work.