### PR TITLE
Handle Housekeeping Messages Sent to Modem During Scene Command

### DIFF
--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -621,7 +621,7 @@ class Modem:
 
         cmd1 = 0x11 if is_on else 0x13
         msg = Msg.OutModemScene(group, cmd1, 0x00)
-        msg_handler = handler.ModemScene(self, msg, on_done, num_retry=1)
+        msg_handler = handler.ModemScene(self, msg, on_done, num_retry=0)
         self.protocol.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -621,7 +621,7 @@ class Modem:
 
         cmd1 = 0x11 if is_on else 0x13
         msg = Msg.OutModemScene(group, cmd1, 0x00)
-        msg_handler = handler.ModemScene(self, msg, on_done, num_retry=0)
+        msg_handler = handler.ModemScene(self, msg, on_done)
         self.protocol.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -621,7 +621,7 @@ class Modem:
 
         cmd1 = 0x11 if is_on else 0x13
         msg = Msg.OutModemScene(group, cmd1, 0x00)
-        msg_handler = handler.ModemScene(self, msg, on_done)
+        msg_handler = handler.ModemScene(self, msg, on_done, num_retry=1)
         self.protocol.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -222,6 +222,17 @@ class Protocol:
             self._send_next_msg()
 
     #-----------------------------------------------------------------------
+    def set_wait_time(self, wait_time):
+        """Set the Next Time that a Message Can be Sent to Avoid Collision.
+
+        Next time that a message can be written.
+
+        Args:
+          wait_time (epoch Seconds): The next time a message can be sent
+        """
+        self._next_write_time = wait_time
+
+    #-----------------------------------------------------------------------
     def _poll(self, t):
         """Periodic polling function.
 

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -708,19 +708,6 @@ class Base:
                           "%s with args: %s", self.label, cmd, str(kwargs))
 
     #-----------------------------------------------------------------------
-    def send_direct_cleanup(self, msg, msg_handler):
-        """Sends a Direct Message to a Device after a Failed ModemScene Cmd
-
-        Args:
-          msg (OutModemScene): The scene message that was attempted by the
-                               modem
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-        """
-        msg = Msg.OutStandard.link_cleanup(self.addr, msg.cmd1, msg.group)
-        self.send(msg, msg_handler)
-
-    #-----------------------------------------------------------------------
     def handle_received(self, msg):
         """Receives incoming message notifications from protocol
 

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -4,6 +4,7 @@
 #
 #===========================================================================
 import json
+import time
 import os.path
 from .MsgHistory import MsgHistory
 from ..Address import Address
@@ -832,6 +833,16 @@ class Base:
         responders = self.db.find_group(group)
         LOG.debug("Found %s responders in group %s", len(responders), group)
         LOG.debug("Group %s -> %s", group, [i.addr.hex for i in responders])
+
+        # A device broadcast will be followed up a series of cleanup messages
+        # between the devices and sent to the modem.  Don't send anything
+        # during this time to avoid causing a collision.  Time is equal to .5
+        # second of overhead, plus .5 seconds per responer device.  This is
+        # based off the same 87 msec empircal testing performed when designing
+        # misterhouse.  Each device causes a cleanup and an ack.  Assuminng
+        # a max of three hops in each direction that is 6 * .087 or .522 per
+        # device.
+        self.protocol.set_wait_time(time.time() + .5 + (len(responders) * .5))
 
         # For each device that we're the controller of call it's handler for
         # the broadcast message.

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -708,6 +708,19 @@ class Base:
                           "%s with args: %s", self.label, cmd, str(kwargs))
 
     #-----------------------------------------------------------------------
+    def send_direct_cleanup(self, msg, msg_handler):
+        """Sends a Direct Message to a Device after a Failed ModemScene Cmd
+
+        Args:
+          msg (OutModemScene): The scene message that was attempted by the
+                               modem
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        msg = Msg.OutStandard.link_cleanup(self.addr, msg.cmd1, msg.group)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
     def handle_received(self, msg):
         """Receives incoming message notifications from protocol
 

--- a/insteon_mqtt/handler/ModemScene.py
+++ b/insteon_mqtt/handler/ModemScene.py
@@ -71,6 +71,21 @@ class ModemScene(Base):
                             self.modem.label, msg.from_addr)
             return Msg.CONTINUE
 
+        # This is an all link failure report.
+        elif (isinstance(msg, Msg.InpAllLinkFailure) and
+              msg.group == self.msg.group):
+            LOG.error("%s failed to respond to broadcast for group %s",
+                      msg.addr, msg.group)
+            return Msg.CONTINUE
+
+        # This is a NAK response from a device.
+        elif (isinstance(msg, Msg.InpStandard) and
+              msg.flags.type == Flags.Type.CLEANUP_NAK and
+              msg.group == self.msg.group):
+            LOG.error("%s responded NAK to broadcast for group %s",
+                      msg.from_addr, msg.group)
+            return Msg.CONTINUE
+
         # Finally there should be an InpAllLinkStatus which tells us the
         # scene command is complete.
         elif isinstance(msg, Msg.InpAllLinkStatus):

--- a/insteon_mqtt/handler/ModemScene.py
+++ b/insteon_mqtt/handler/ModemScene.py
@@ -6,7 +6,7 @@
 from .. import log
 from .. import message as Msg
 from .Base import Base
-from .Flags import Flags
+from ..message.Flags import Flags
 
 LOG = log.get_logger()
 

--- a/insteon_mqtt/handler/ModemScene.py
+++ b/insteon_mqtt/handler/ModemScene.py
@@ -80,10 +80,9 @@ class ModemScene(Base):
 
         # This is a NAK response from a device.
         elif (isinstance(msg, Msg.InpStandard) and
-              msg.flags.type == Flags.Type.CLEANUP_NAK and
-              msg.group == self.msg.group):
+              msg.flags.type == Flags.Type.CLEANUP_NAK):
             LOG.error("%s responded NAK to broadcast for group %s",
-                      msg.from_addr, msg.group)
+                      msg.from_addr, self.msg.group)
             return Msg.CONTINUE
 
         # Finally there should be an InpAllLinkStatus which tells us the

--- a/insteon_mqtt/handler/ModemScene.py
+++ b/insteon_mqtt/handler/ModemScene.py
@@ -16,6 +16,71 @@ class ModemScene(Base):
 
     This handles the callbacks when simulated modem scene is sent using the
     OutModemScene message.  Calls modem.handle_scene when complete.
+
+    Modem scene controls are complicated things.  Their main feature is that
+    from an end-user's perspective and if the message is received correctly
+    all devices seem to change instananeously and at once.
+
+    However, it seems that because of the complexity of the task the modem is
+    asked to perform, it seems that if the modem is interrupted by any
+    extraneous Insteon message while performing the scene command, it may
+    somewhat lose its mind.  This message can originate from the host side of
+    the modem.  We attempt to prevent this by using appropriate delays before
+    writing.  But the interruptions can also occur from the Insteon network
+    for example if another device is triggered while the scene command is
+    processing.  This we can't control.
+
+    The process of a scene command looks like:
+    1. Send command to modem from host
+    2. Modem ACKs the command back to host
+    3. Modem sends a broadcast message on the insteon network.
+    4. Modem sends individual cleanup messages to each device in the group on
+       the insteon network
+    5. Devices ACK the cleanup messages
+    6. The modem reports the ACKs to the host
+    7. If any failures occur, the modem delivers a cleanup report to the host
+    8. The modem delivers a scene ACK or NAK report to the host
+
+    The cleanup process (4-6) can take between 1/3 to 1/2 second per device. So
+    for example, on my network a scene command sent to 50 devices can take
+    20 seconds to complete.
+
+    During this time, if another device on the insteon network sends a message
+    to the modem, things can go sideways.  These are some of the things I have
+    seen:
+    - Step 6 - The modem ACKs contain the wrong group.  Commonly group 0xFF
+    - Step 6 - Shortly after the prior oddity, the modem simply reports all
+               CLEANUP_NAK messages, even though the devices themselves
+               correctly respond to the command
+    - Step 6 - If an ACK is reported with the proper group, it seems to be
+               always correct.  I have never seen a false positive of this.
+    - Step 7 - The cleanup report identifies 1 or more devices that did not ACK
+               the cleanup command, but again frequently gets the group number
+               of the command wrong.  And in almost all cases, the devices
+               listed in this report are only a subset of the devices with
+               reported NAKs.
+    - Step 8 - Generally, if any of the above occurs, a NAK is delivered.  I
+               have never seen an ACK that was a false positive.
+
+    Taking all of this into account, our method of handling scene commands is
+    as follows:
+    1. Generate a list of all devices that should respond to the scene command
+    2. Send the scene command using the modem
+    3. For every device ACK received remove that device from the dev_list
+    4. Catch NAK commands and report them if we can (some may have the wrong
+       group number, in which case these remain un handled) do nothing
+    5. Catch the All Link Report if we can (again if group number is right) do
+       nothing
+    6. If an ACK to the scene command is received, declare success.
+    7. Otherwise, send direct commands to the devices that still remain in
+       the dev_list
+
+    As a result, it is recommended to set num_retry=1 for this handler.  Any
+    failure of this command will results in the above handling of the scene
+    command, whether it is caused by a NAK or a timeout.  Otherwise, if a
+    single device fails to properly NAK a command (such as if a device has
+    been removed from your network) an extremely long scene command will be
+    sent up to three times using a lot of network resources.
     """
     def __init__(self, modem, msg, on_done=None, num_retry=3):
         """Constructor
@@ -29,11 +94,17 @@ class ModemScene(Base):
                     handler times out without returning Msg.FINISHED.
                     This count does include the initial sending so a
                     retry of 3 will send once and then retry 2 more times.
+                    It is recommended to set this to num_retry=1 for
+                    ModemScene commands and let the automatic cleanup discussed
+                    above handle any failures.
         """
         super().__init__(on_done, num_retry)
 
         self.modem = modem
         self.msg = msg
+        self.dev_list = []
+        for element in modem.db.find_group(msg.group):
+            self.dev_list.append(element.addr)
 
     #-----------------------------------------------------------------------
     def msg_received(self, protocol, msg):
@@ -61,6 +132,13 @@ class ModemScene(Base):
         elif (isinstance(msg, Msg.InpStandard) and
               msg.flags.type == Flags.Type.CLEANUP_ACK and
               msg.group == self.msg.group):
+            # Remove this from dev_list of it exists
+            try:
+                self.dev_list.remove(msg.from_addr)
+            except ValueError:
+                pass
+
+            # Trigger an update of our internal state of this device
             device = self.modem.find(msg.from_addr)
             if device:
                 LOG.debug("%s broadcast to %s for group %s was ack'd",
@@ -69,7 +147,14 @@ class ModemScene(Base):
             else:
                 LOG.warning("%s broadcast - ack for device %s not found",
                             self.modem.label, msg.from_addr)
-            return Msg.CONTINUE
+
+            if len(self.dev_list) == 0:
+                LOG.debug("All ACKs of Scene Command grp: %s received.",
+                          msg.group)
+                self.on_done(True, "Scene command complete", None)
+                return Msg.FINISHED
+            else:
+                return Msg.CONTINUE
 
         # This is an all link failure report.
         elif (isinstance(msg, Msg.InpAllLinkFailure) and
@@ -97,9 +182,22 @@ class ModemScene(Base):
 
             return Msg.FINISHED
 
-        # NOTE: The devices in the scene will also send an all link clean up
-        # report when they respond.  But we don't need to handle those. The
-        # regular device scene broadcast will take care of that.
         return Msg.UNKNOWN
 
+    # Need to handle timeout too, make sure only call _send_direct_cmds once?
+
+    #-----------------------------------------------------------------------
+    def _send_direct_cmds(self):
+        """If Scene Command Not ACK'd Properly, Send Direct Commands.
+
+        Will cause direct commands to be send to each device to put the device
+        in the appropriate state based on its db entry for the scene
+        """
+        for element in self.dev_list:
+            device = self.modem.find(element.addr)
+            if device:
+                device.send_direct_cleanup(self.msg, self)
+            else:
+                LOG.warning("Scene cleanup - device %s not found",
+                            element.addr)
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/ModemScene.py
+++ b/insteon_mqtt/handler/ModemScene.py
@@ -21,66 +21,22 @@ class ModemScene(Base):
     from an end-user's perspective and if the message is received correctly
     all devices seem to change instananeously and at once.
 
-    However, it seems that because of the complexity of the task the modem is
-    asked to perform, it seems that if the modem is interrupted by any
-    extraneous Insteon message while performing the scene command, it may
-    somewhat lose its mind.  This message can originate from the host side of
-    the modem.  We attempt to prevent this by using appropriate delays before
-    writing.  But the interruptions can also occur from the Insteon network
-    for example if another device is triggered while the scene command is
-    processing.  This we can't control.
+    However, because of the complexity of the task the modem is asked to
+    perform, it seems that if the modem is interrupted by any extraneous
+    Insteon message while performing the scene command, it may somewhat lose
+    its mind.
 
-    The process of a scene command looks like:
-    1. Send command to modem from host
-    2. Modem ACKs the command back to host
-    3. Modem sends a broadcast message on the insteon network.
-    4. Modem sends individual cleanup messages to each device in the group on
-       the insteon network
-    5. Devices ACK the cleanup messages
-    6. The modem reports the ACKs to the host
-    7. If any failures occur, the modem delivers a cleanup report to the host
-    8. The modem delivers a scene ACK or NAK report to the host
+    It appears the the Modem still continues to process everything correctly
+    but the messages it reports to the host can appear wrong.  Such as wrong
+    groups reported, CLEANUP_NAKs that are wrong, wrong InpAllLinkFailure
+    reports and even a wrong or premature InpAllLinkStatus NAK.
 
-    The cleanup process (4-6) can take between 1/3 to 1/2 second per device. So
-    for example, on my network a scene command sent to 50 devices can take
-    20 seconds to complete.
-
-    During this time, if another device on the insteon network sends a message
-    to the modem, things can go sideways.  These are some of the things I have
-    seen:
-    - Step 6 - The modem ACKs contain the wrong group.  Commonly group 0xFF
-    - Step 6 - Shortly after the prior oddity, the modem simply reports all
-               CLEANUP_NAK messages, even though the devices themselves
-               correctly respond to the command
-    - Step 6 - If an ACK is reported with the proper group, it seems to be
-               always correct.  I have never seen a false positive of this.
-    - Step 7 - The cleanup report identifies 1 or more devices that did not ACK
-               the cleanup command, but again frequently gets the group number
-               of the command wrong.  And in almost all cases, the devices
-               listed in this report are only a subset of the devices with
-               reported NAKs.
-    - Step 8 - Generally, if any of the above occurs, a NAK is delivered.  I
-               have never seen an ACK that was a false positive.
-
-    Taking all of this into account, our method of handling scene commands is
-    as follows:
-    1. Generate a list of all devices that should respond to the scene command
-    2. Send the scene command using the modem
-    3. For every device ACK received remove that device from the dev_list
-    4. Catch NAK commands and report them if we can (some may have the wrong
-       group number, in which case these remain un handled) do nothing
-    5. Catch the All Link Report if we can (again if group number is right) do
-       nothing
-    6. If an ACK to the scene command is received, declare success.
-    7. Otherwise, send direct commands to the devices that still remain in
-       the dev_list
-
-    As a result, it is recommended to set num_retry=1 for this handler.  Any
-    failure of this command will results in the above handling of the scene
-    command, whether it is caused by a NAK or a timeout.  Otherwise, if a
-    single device fails to properly NAK a command (such as if a device has
-    been removed from your network) an extremely long scene command will be
-    sent up to three times using a lot of network resources.
+    We can't do anything with these messages when they arrive, since we don't
+    know what they should have meant.  However, if we extend the time_out each
+    time we receive one of these garbled messages, we eventually will receive
+    a correct InpAllLinkStatus ACK.  To the extent we can identify any of
+    these messages as meant for this handler, we report them to the user for
+    potential debugging.
     """
     def __init__(self, modem, msg, on_done=None, num_retry=3):
         """Constructor
@@ -94,17 +50,11 @@ class ModemScene(Base):
                     handler times out without returning Msg.FINISHED.
                     This count does include the initial sending so a
                     retry of 3 will send once and then retry 2 more times.
-                    It is recommended to set this to num_retry=1 for
-                    ModemScene commands and let the automatic cleanup discussed
-                    above handle any failures.
         """
         super().__init__(on_done, num_retry)
 
         self.modem = modem
         self.msg = msg
-        self.dev_list = []
-        for element in modem.db.find_group(msg.group):
-            self.dev_list.append(element.addr)
 
     #-----------------------------------------------------------------------
     def msg_received(self, protocol, msg):
@@ -132,17 +82,12 @@ class ModemScene(Base):
         elif (isinstance(msg, Msg.InpStandard) and
               msg.flags.type == Flags.Type.CLEANUP_ACK):
             if msg.group != self.msg.group:
-                # This isn't the right group, so don't remove from list
-                # but extend the waiting time to see if we get more
+                # This isn't the right group, but extend the waiting time to
+                # see if we get more messages, but report as unknown in case
+                # another handler can do something with this.
                 self.update_expire_time()
                 return Msg.UNKNOWN
             else:
-                # Remove this from dev_list of it exists
-                try:
-                    self.dev_list.remove(msg.from_addr)
-                except ValueError:
-                    pass
-
                 # Trigger an update of our internal state of this device
                 device = self.modem.find(msg.from_addr)
                 if device:
@@ -153,19 +98,14 @@ class ModemScene(Base):
                     LOG.warning("%s broadcast - ack for device %s not found",
                                 self.modem.label, msg.from_addr)
 
-                if len(self.dev_list) == 0:
-                    LOG.debug("All ACKs of Scene Command grp: %s received.",
-                              msg.group)
-                    self.on_done(True, "Scene command complete", None)
-                    return Msg.FINISHED
-                else:
-                    return Msg.CONTINUE
+                return Msg.CONTINUE
 
         # This is an all link failure report.
         elif isinstance(msg, Msg.InpAllLinkFailure):
             if msg.group != self.msg.group:
-                # This isn't the right group, so don't report anything
-                # but extend the waiting time to see if we get more
+                # This isn't the right group, but extend the waiting time to
+                # see if we get more messages, but report as unknown in case
+                # another handler can do something with this.
                 self.update_expire_time()
                 return Msg.UNKNOWN
             else:
@@ -176,6 +116,8 @@ class ModemScene(Base):
         # This is a NAK response from a device.
         elif (isinstance(msg, Msg.InpStandard) and
               msg.flags.type == Flags.Type.CLEANUP_NAK):
+            # NAK responses have no group details cmd2 in theory contains a
+            # reason for the failure, but in practice isn't helpful
             LOG.error("%s responded NAK to broadcast for group %s",
                       msg.from_addr, self.msg.group)
             return Msg.CONTINUE
@@ -188,30 +130,14 @@ class ModemScene(Base):
                 self.modem.handle_scene(self.msg)
                 self.on_done(True, "Scene command complete", None)
             else:
-                #self.on_done(False, "Scene command failed", None)
-                LOG.warning("Received NAK, waiting instead")
-                #self._send_direct_cmds()
+                # The modem seems to automatically retry even after sending a
+                # NAK, so just wait.  If the timeout occurs we will resend
+                # then
+                LOG.warning("Modem scene %s NAK, waiting...", self.msg.group)
                 return Msg.CONTINUE
 
             return Msg.FINISHED
 
         return Msg.UNKNOWN
 
-    # Need to handle timeout too, make sure only call _send_direct_cmds once?
-
-    #-----------------------------------------------------------------------
-    def _send_direct_cmds(self):
-        """If Scene Command Not ACK'd Properly, Send Direct Commands.
-
-        Will cause direct commands to be send to each device to put the device
-        in the appropriate state based on its db entry for the scene
-        """
-        for addr in self.dev_list:
-            device = self.modem.find(addr)
-            if device:
-                LOG.ui("Sending Direct")
-                device.send_direct_cleanup(self.msg, self)
-            else:
-                LOG.warning("Scene cleanup - device %s not found",
-                            addr)
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/message/InpAllLinkFailure.py
+++ b/insteon_mqtt/message/InpAllLinkFailure.py
@@ -8,15 +8,16 @@ from .Base import Base
 
 
 class InpAllLinkFailure(Base):
-    """User pressed the PLM set button.
+    """All Link Failure Report
 
-    This is sent from the PLM modem to the host when all linking between the
-    modem and a device fails.
+    This is sent from the PLM modem to the host when all link command (scene
+    control) between the modem and a device fails.  Means that no ack or nak
+    was received from the device.
     """
     # pylint: disable=abstract-method
 
     msg_code = 0x56
-    fixed_msg_size = 7
+    fixed_msg_size = 6
 
     #-----------------------------------------------------------------------
     @classmethod
@@ -35,9 +36,8 @@ class InpAllLinkFailure(Base):
         assert len(raw) >= InpAllLinkFailure.fixed_msg_size
         assert raw[0] == 0x02 and raw[1] == InpAllLinkFailure.msg_code
 
-        assert raw[2] == 0x01
-        group = raw[3]
-        addr = Address.from_bytes(raw, 4)
+        group = raw[2]
+        addr = Address.from_bytes(raw, 3)
         return InpAllLinkFailure(group, addr)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/message/InpStandard.py
+++ b/insteon_mqtt/message/InpStandard.py
@@ -74,6 +74,9 @@ class InpStandard(Base):
             self.group = self.to_addr.ids[2]
         elif (self.flags.type == Flags.Type.ALL_LINK_CLEANUP or
               self.flags.type == Flags.Type.CLEANUP_ACK):
+            # The INSTEON Whitepaper defines cmd2 as status for CLEANUP_ACK
+            # so it is possible that on some devices this isn't group, so use
+            # with caution.
             self.group = self.cmd2
 
         # This is the time by which the final hop would arrive, used to

--- a/insteon_mqtt/message/OutStandard.py
+++ b/insteon_mqtt/message/OutStandard.py
@@ -79,6 +79,22 @@ class OutStandard(Base):
 
     #-----------------------------------------------------------------------
     @classmethod
+    def link_cleanup(cls, to_addr, cmd1, cmd2):
+        """Construct a ALL_LINK_CLEANUP message
+
+        Args:
+          to_addr (Address):  The adddress to send the commadn to.
+          cmd1 (int):  The command 1 field to set.
+          cmd2 (int):  The command 2 field to set.
+
+        Returns:
+          Returns the created OutStandard message.
+        """
+        flags = Flags(Flags.Type.ALL_LINK_CLEANUP, is_ext=False)
+        return OutStandard(to_addr, flags, cmd1, cmd2)
+
+    #-----------------------------------------------------------------------
+    @classmethod
     def msg_size(cls, raw):
         """Return the message size in bytes.
 


### PR DESCRIPTION
Solves issues with:

1. Timeouts because of a lot of AllLink Cleanup messages coming in.

2. Better handle failed scene commands by changing the successful devices.

3. Properly warn users about failures with error messages.

Ironically, this includes fixing a bug that is caused by an error in the Insteon documentation.  The same bug I fixed almost exactly seven years ago in MisterHouse.  Seven years working on Insteon, ugh, I would never have expected that.