### PR TITLE
Enable Software Control of Motion Sensor Flags

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -347,7 +347,7 @@ Switch, KeypadLinc, and Dimmer all support the flags:
      off.  This is used to implement radio buttons.
    - signal_bits: 8 bit integer flags - 1 per button.  Only used for
      non-toggle buttons.  If a bit is 1, then the button only sends on
-     commands.  If a bit is 0, hten the button only sends off commands.
+     commands.  If a bit is 0, then the button only sends off commands.
    - nontoggle_bits: 8 bit integer flags - 1 per button.  If a bit is 1, then
      that button is a non-toggle button and will only send a signal per the
      signal_bits input.  If a bit is 0, then that button is a toggle button
@@ -360,7 +360,21 @@ IOLinc supports the flags:
    - trigger_reverse: 0/1 reverses the trigger command state
    - relay_linked: 0/1 links the relay to the sensor value
 
+Motion Sensors support the flags:
 
+   - led_on: 0/1 - Should led on the device flash on motion?
+
+   - night_only: 0/1 - Should motion only be reported at night?
+
+   - on_only: 0/1 - Should only on motions be reported with no off messages?
+
+   - timeout: seconds between state updates (30 second increments, 2842
+     models allow between 30 seconds to 4 hours, the 2844 models allow
+     between 30 seconds and 40 minutes).
+
+   - light_sensitivity: 1-255:  Amount of darkness required for night
+     to be triggered.  Affects night_only mode as well as the dawn/dusk
+     reporting
 
 ### Print the current all link database.
 

--- a/insteon_mqtt/catalog.py
+++ b/insteon_mqtt/catalog.py
@@ -451,6 +451,7 @@ entries = {
         0x11: Desc("2845-222", "Door Sensor II (915 MHz)"),
         0x14: Desc("2845-422", "Door Sensor II (869 MHz)"),
         0x15: Desc("2845-522", "Door Sensor II (921 MHz)"),
+        0x16: Desc("2844-222", "Motion Sensor II - (915 MHz)"),
         },
     # dev_cat = 0x11
     Category.SURVEILLANCE: {

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -4,8 +4,12 @@
 #
 #===========================================================================
 from .BatterySensor import BatterySensor
+from ..CommandSeq import CommandSeq
 from .. import log
+from .. import handler
 from ..Signal import Signal
+from .. import message as Msg
+from .. import util
 
 LOG = log.get_logger()
 
@@ -70,6 +74,18 @@ class Motion(BatterySensor):
         # handles the other groups.
         self.group_map[0x02] = self.handle_dawn
 
+        # Remote (mqtt) commands mapped to methods calls.  Add to the
+        # base class defined commands.
+        self.cmd_map.update({
+            'set_flags' : self.set_flags,
+            })
+
+        # Set default values for bits.  These should always be updated prior
+        # to setting
+        self.led_on = 1
+        self.night_only = 0
+        self.on_only = 0
+
     #-----------------------------------------------------------------------
     def handle_dawn(self, msg):
         """Handle a dusk/dawn message.
@@ -84,5 +100,195 @@ class Motion(BatterySensor):
         """
         # Send True for dawn, False for dusk.
         self.signal_dawn.emit(self, msg.cmd1 == 0x11)
+
+    #-----------------------------------------------------------------------
+    def set_flags(self, on_done, **kwargs):
+        """Set internal device flags.
+
+        This command is used to change internal device flags and states.
+        These include LED On/Off (off conserves batteries), Timeout (seconds
+        between state updates), Light Sensitivity (Percentage of light for
+        night sensitivity), Night Only Mode and On Only Mode:
+
+        valid kwargs:
+        - led_on = 1/0: Should led flash on motion?
+
+        - night_only = 1/0: Should motion only be reported at night?
+
+        - on_only = 1/0: Should only on motions be reported?
+
+        - timeout = seconds between state updates (30 second increments, 2842
+        models allow between 30 seconds to over 4 hours, the 2844 models allow
+        between 30 seconds and 40 minutes)
+
+        - light_sensitivity = 1-255:  Amount of darkness required for night
+        to be triggered.
+
+        Args:
+          kwargs: Key=value pairs of the flags to change.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        LOG.info("Motion %s cmd: set operation flags", self.label)
+
+        # Check the input flags to make sure only ones we can understand were
+        # passed in.
+        flags = set(["led_on", "night_only", "on_only", "timeout",
+                     "light_sensitivity"])
+        unknown = set(kwargs.keys()).difference(flags)
+        if unknown:
+            raise Exception("Unknown Motion flags input: %s.\n Valid flags "
+                            "are: %s" % unknown, flags)
+
+        seq = CommandSeq(self.protocol, "Flags set", on_done)
+
+        # For some flags we need to know the existing bit before we change it.
+        # So to insure that we are starting from the correct values, get the
+        # current bits and pass that to the callback which will update them to
+        # make the changes.
+        flags = set(["led_on", "night_only", "on_only"])
+        if any(x in kwargs.keys() for x in flags):
+            seq.add(self._get_ext_flags)
+            seq.add(self._change_flags, kwargs)
+        if "light_sensitivity" in kwargs.keys():
+            seq.add(self._set_light_sens, kwargs["light_sensitivity"])
+        if "timeout" in kwargs.keys():
+            seq.add(self._set_timeout, kwargs["timeout"])
+
+        seq.run()
+
+    #-----------------------------------------------------------------------
+    def _change_flags(self, flags, on_done):
+        """Change the operating flags.
+
+        See the set_flags() code for details.
+        """
+
+        # Generate the value of the combined flags.
+        value = 0
+        value = util.bit_set(value, 3, flags.get("led_on", self.led_on))
+        value = util.bit_set(value, 2,
+                             flags.get("night_only", self.night_only))
+        value = util.bit_set(value, 1, flags.get("on_only", self.on_only))
+
+        # Push the flags value to the device.
+        data = bytes([
+            0x00,   # D1 = 0x00
+            0x05,   # D2 = 0x05 Set Flags
+            value,  # D3 = the flag value
+            ] + [0x00] * 11)
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+        msg_handler = handler.StandardCmd(msg, self.handle_ext_cmd)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def _get_ext_flags(self, on_done=None):
+        """Get the Insteon operational extended flags field from the device.
+
+        For the motion device, these flags include led_on, night_only, and
+        on_only.
+
+        Args:
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        LOG.info("Motion %s cmd: get extended operation flags", self.label)
+
+        # Requesting data is all 0s. Flags are in D6 of ext response msg
+        data = bytes([0x00] * 14)
+
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+        msg_handler = handler.ExtendedCmdResponse(msg, self.handle_ext_flags,
+                                                  on_done)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def handle_ext_flags(self, msg, on_done):
+        """Handle replies to the _get_ext_flags command.
+
+        Data 6 of the extended response contains the bits we are interested
+        in.  This parses them out and stores their value for use in setting
+        flags.
+
+        Args:
+          msg (message.InpExtended):  The message reply.  The current
+              flags are in D6.
+          on_done:  Finished callback.  This is called when the command has
+                    completed.  Signature is: on_done(success, msg, data)
+        """
+        LOG.ui("Motion %s extended operating flags: %s", self.addr,
+               "{:08b}".format(msg.data[5]))
+        self.led_on = util.bit_get(msg.data[5], 3)
+        self.night_only = util.bit_get(msg.data[5], 2)
+        self.on_only = util.bit_get(msg.data[5], 1)
+        on_done(True, "Operation complete", msg.data[5])
+
+    #-----------------------------------------------------------------------
+    def handle_ext_cmd(self, msg, on_done):
+        """Handle replies to the set_flags command.
+        Nothing to do, any NAK of failure is caught by the message handler
+        """
+        on_done(True, "Operation complete", None)
+
+    #-----------------------------------------------------------------------
+    def _set_light_sens(self, sensitivity, on_done):
+        """Change the light sensitivity amount.
+
+        See the set_flags() code for details.
+        """
+        assert 1 <= int(sensitivity) <= 255
+
+        # Push the flags value to the device.
+        data = bytes([
+            0x00,   # D1 = 0x00
+            0x04,   # D2 = 0x05 Set Flags
+            int(sensitivity),  # D3 = the sensitivity value
+            ] + [0x00] * 11)
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+        msg_handler = handler.StandardCmd(msg, self.handle_ext_cmd)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def _set_timeout(self, timeout, on_done):
+        """Change the timeout in seconds.
+
+        This will automatically change the timeout requested to fit within the
+        valid values.
+
+        See the set_flags() code for details.
+        """
+        timeout = int(timeout)
+        # 30 seconds is the minimum permitted timeout
+        if timeout < 30:
+            timeout = 30
+        # The calculation of the timeout value is stored differently on the
+        # older 2842 and the newer 2844 motion sensors.  We will assume the
+        # newer style as a default.
+        if (self.db.desc is not None and
+                self.db.desc.model.split("-")[0] == "2842"):
+            # Max 4 hours
+            if timeout > 14400:
+                timeout = 14400
+            timeout = int(timeout / 30) - 1
+            LOG.ui("Motion %s setting timeout to %s seconds", self.addr,
+                   ((timeout + 1) * 30))
+        else:
+            # Assuming this is a 2844 sensor or that is uses the same style
+            # Max 40 Minutes
+            if timeout > 2400:
+                timeout = 2400
+            timeout = int(timeout / 10)
+            LOG.ui("Motion %s setting timeout to %s seconds", self.addr,
+                   ((timeout) * 10))
+
+        # Push the flags value to the device.
+        data = bytes([
+            0x00,   # D1 = 0x00
+            0x03,   # D2 = 0x05 Set Flags
+            timeout,  # D3 = the sensitivity value
+            ] + [0x00] * 11)
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+        msg_handler = handler.StandardCmd(msg, self.handle_ext_cmd)
+        self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------


### PR DESCRIPTION
This enables the software control of flags on the motion sensor. This includes the on-only mode, the night only mode, the LED on and off, the light sensitivity, and the length of timeout.

There are some distinctions between the older 2842 models of motion sensor and the newer 2844 models of motion sensor. This attempts to accommodate both of them.

Updated documentation.

Closes #184