### PR TITLE
Option to Skip Battery Devices on Refresh;  Add Get_Engine_All Function

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -202,11 +202,12 @@ reason string will be set to "refresh".
 Supported: modem
 
 The modem will send a refresh command to each device that it knows
-about (i.e. devices defined in the config file).  The command payload
+about (i.e. devices defined in the config file).  If the battery flag is false
+or not present, battery operated devices will be skipped. The command payload
 is:
 
    ```
-   { "cmd" : "refresh_all", ["force" : true/false] }
+   { "cmd" : "refresh_all", ["battery" : true/false, "force" : true/false] }
    ```
 
 

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -224,6 +224,38 @@ features are available on the device:
   ```
 
 
+### Get device engine information
+
+Supported: device
+
+The engine version can be i1, i2, or i2cs.  The engine version defines what
+type of messages can be used with a device and the type of all link database
+used by a device.
+
+New Insteon devices purchased after 2018 are almost certainly all i2cs devices.
+By default, we assume a device is i2cs.
+
+If you have an older device that is not responding the the refresh command try
+running get_engine and then try running refresh again.  This only needs to be
+run once on any device.  The resulting information will be saved in the device
+data.
+
+  ```
+  { "cmd" : "get_engine" }
+  ```
+
+### Get all device engines
+
+Supported: modem
+
+This will cause a get_engine command to be sent to each device (i.e. devices
+defined in the config file).  If the battery flag is false or not present,
+battery operated devices will be skipped. The command payload is:
+
+  ```
+  { "cmd" : "get_engine", ["battery": true/false]}
+  ```
+
 ### Add the device as a controller of another device.
 
 Supported: modem, devices

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -14,6 +14,7 @@ from . import log
 from . import message as Msg
 from . import util
 from .Signal import Signal
+from .device import BatterySensor
 
 LOG = log.get_logger()
 
@@ -292,7 +293,7 @@ class Modem:
         return device
 
     #-----------------------------------------------------------------------
-    def refresh_all(self, force=False, on_done=None):
+    def refresh_all(self, skip_battery=True, force=False, on_done=None):
         """Refresh all the all link databases.
 
         This forces a refresh of the modem and device databases.  This can
@@ -317,6 +318,9 @@ class Modem:
 
         # Reload all the device databases.
         for device in self.devices.values():
+            if skip_battery and isinstance(device, BatterySensor):
+                LOG.ui("Refresh all, skipping battery device %s", device.label)
+                continue
             seq.add(device.refresh, force)
 
         # Start the command sequence.

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -332,7 +332,7 @@ class Modem:
         seq.run()
 
     #-----------------------------------------------------------------------
-    def get_engine_all(self, skip_battery=True, on_done=None):
+    def get_engine_all(self, battery=False, on_done=None):
         """Run Get Engine on all the devices, except Modem
 
         Devices are assumed to be i2cs, which all new devices are.  If you
@@ -341,7 +341,8 @@ class Modem:
         this.
 
         Args:
-          skip_battery (bool):  If True, skips a battery device.
+          battery (bool):  If True, will run on battery devices as well,
+                           defaults to skipping them.
           on_done:  Finished callback.  This is called when the command has
                     completed.  Signature is: on_done(success, msg, data)
         """
@@ -352,7 +353,9 @@ class Modem:
 
         # Reload all the device databases.
         for device in self.devices.values():
-            if skip_battery and isinstance(device, BatterySensor):
+            if not battery and isinstance(device, (DevClass.BatterySensor,
+                                                   DevClass.Leak,
+                                                   DevClass.Remote)):
                 LOG.ui("Get engine all, skipping battery device %s",
                        device.label)
                 continue

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -293,7 +293,7 @@ class Modem:
         return device
 
     #-----------------------------------------------------------------------
-    def refresh_all(self, skip_battery=True, force=False, on_done=None):
+    def refresh_all(self, battery=False, force=False, on_done=None):
         """Refresh all the all link databases.
 
         This forces a refresh of the modem and device databases.  This can
@@ -302,6 +302,8 @@ class Modem:
         activity is expected on the network.
 
         Args:
+          battery (bool): If true, will scan battery devices as well, by
+                default they are skipped.
           force (bool):  Force flag passed to devices.  If True, devices
                 will refresh their Insteon db's even if they think the db
                 is up to date.
@@ -318,7 +320,7 @@ class Modem:
 
         # Reload all the device databases.
         for device in self.devices.values():
-            if skip_battery and isinstance(device, BatterySensor):
+            if not battery and isinstance(device, BatterySensor):
                 LOG.ui("Refresh all, skipping battery device %s", device.label)
                 continue
             seq.add(device.refresh, force)

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -13,8 +13,8 @@ from . import handler
 from . import log
 from . import message as Msg
 from . import util
+from . import device as DevClass
 from .Signal import Signal
-from .device import BatterySensor
 
 LOG = log.get_logger()
 
@@ -320,7 +320,9 @@ class Modem:
 
         # Reload all the device databases.
         for device in self.devices.values():
-            if not battery and isinstance(device, BatterySensor):
+            if not battery and isinstance(device, (DevClass.BatterySensor,
+                                                   DevClass.Leak,
+                                                   DevClass.Remote)):
                 LOG.ui("Refresh all, skipping battery device %s", device.label)
                 continue
             seq.add(device.refresh, force)

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -47,6 +47,17 @@ def parse_args(args):
     sp.set_defaults(func=modem.refresh_all)
 
     #---------------------------------------
+    # modem.get_engine_all command
+    sp = sub.add_parser("get-engine-all", help="Call get-engine on the devices "
+                        "in the configuration.")
+    sp.add_argument("--battery", action="store_true",
+                    help="Run get-engine on battery devices too, by default "
+                         "they are skipped.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=modem.get_engine_all)
+
+    #---------------------------------------
     # modem.factory_reset command
     sp = sub.add_parser("factory-reset", help="Perform a remote factory "
                         "reset.  Currently only supported on the modem.")

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -39,6 +39,9 @@ def parse_args(args):
                         "in the configuration.")
     sp.add_argument("-f", "--force", action="store_true",
                     help="Force the modem/device database to be downloaded.")
+    sp.add_argument("--battery", action="store_true",
+                    help="Refresh battery devices too, by default they are "
+                    "skipped.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=modem.refresh_all)

--- a/insteon_mqtt/cmd_line/modem.py
+++ b/insteon_mqtt/cmd_line/modem.py
@@ -20,6 +20,18 @@ def refresh_all(args, config):
 
 
 #===========================================================================
+def get_engine_all(args, config):
+    topic = "%s/modem" % (args.topic)
+    payload = {
+        "cmd" : "get_engine_all",
+        "battery" : args.battery,
+        }
+
+    reply = util.send(config, topic, payload, args.quiet)
+    return reply["status"]
+
+
+#===========================================================================
 def factory_reset(args, config):
     topic = "%s/modem" % (args.topic)
     payload = {

--- a/insteon_mqtt/cmd_line/modem.py
+++ b/insteon_mqtt/cmd_line/modem.py
@@ -11,6 +11,7 @@ def refresh_all(args, config):
     topic = "%s/modem" % (args.topic)
     payload = {
         "cmd" : "refresh_all",
+        "battery" : args.battery,
         "force" : args.force,
         }
 

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -456,7 +456,7 @@ class Base:
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        LOG.info("Device %s cmd: get engine version", self.label)
+        LOG.info("Device %s cmd: get model", self.label)
 
         # Send the get_engine_version request.
         msg = Msg.OutStandard.direct(self.addr, 0x10, 0x00)

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -800,7 +800,7 @@ class Base:
           on_done:  Finished callback.  This is called when the command has
                     completed.  Signature is: on_done(success, msg, data)
         """
-        if msg.cmd1 == 0x01:
+        if msg.cmd1 == 0x01 or msg.cmd1 == 0x02:
             dev_cat, sub_cat = msg.to_addr.ids[0], msg.to_addr.ids[1]
             firmware = msg.to_addr.ids[2]
             self.db.set_info(dev_cat, sub_cat, firmware)


### PR DESCRIPTION
Battery devices will be skipped by default unless the battery arg is true.

This is pretty helpful if you have a lot of devices on the initial setup on your network.

Similarly I added a get_engine_all function.  I still have ~20 i1 devices that can't be refreshed until the get_engine command is run.  Again, this is really only necessary for the initial setup, but it is very handy.  The need for this command should diminish as the i1 devices break or are replaced.