### PR TITLE
Delete Entry from Group List; Delete List if Empty

### DIFF
--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -174,7 +174,11 @@ class Modem:
         """
         self.entries.remove(entry)
         if entry.is_controller:
-            del self.groups[entry.group]
+            responders = self.groups.setdefault(entry.group, [])
+            if entry in responders:
+                responders.remove(entry)
+            if not responders and entry.group in self.groups:
+                del self.groups[entry.group]
 
         self.save()
 


### PR DESCRIPTION
A simple bug fix.

The modem delete db function didn't handle group deletion properly.

This fixes that.