### PR TITLE
Modem Responder Group from Thermostat Should be 0x01

### DIFF
--- a/insteon_mqtt/device/Thermostat.py
+++ b/insteon_mqtt/device/Thermostat.py
@@ -184,7 +184,7 @@ class Thermostat(Base):
         # types.
         for group_map in Thermostat.Groups:
             group = group_map.value
-            seq.add(self.db_add_ctrl_of, group, self.modem.addr, group,
+            seq.add(self.db_add_ctrl_of, group, self.modem.addr, 0x01,
                     refresh=False)
 
         # Ask the device to enable the broadcast messages, otherwise the


### PR DESCRIPTION
Modem responder group is likely ignored, but standard practice
is to set this to 0x01.  This fixes that mistake.

May solve #154, may not