### PR TITLE
Detect disconnections during poll() calls

### DIFF
--- a/insteon_mqtt/network/Mqtt.py
+++ b/insteon_mqtt/network/Mqtt.py
@@ -179,8 +179,10 @@ class Mqtt(Link):
             passed in so that all clients receive the same "current" time
             instead of each calling time.time() and getting a different value.
         """
-        # This is required to handle keepalive messages.
-        self.client.loop_misc()
+        # This is required to handle keepalive messages and detect disconnections.
+        rc = self.client.loop_misc()
+        if rc == paho.MQTT_ERR_NO_CONN:
+            self._on_disconnect(self.client, None, rc)
 
     #-----------------------------------------------------------------------
     def retry_connect_dt(self):


### PR DESCRIPTION
The Paho-MQTT client may not invoke the 'on_disconnect'
callback when used with an external loop, so check for connection
loss during calls to loop_misc() and handle it appropriately.

Closes #222.