### PR TITLE
Scene fixes

### DIFF
--- a/insteon_mqtt/Scenes.py
+++ b/insteon_mqtt/Scenes.py
@@ -124,7 +124,7 @@ class SceneManager:
         controllers are merged.
 
         This is a companion to compress_responders and compress_n_way.  These
-        are seperate functions to that they can be called seperately using
+        are seperate functions so that they can be called seperately using
         Stacks.
 
         This function only processes the scenes in a single pass.  If it runs
@@ -164,7 +164,7 @@ class SceneManager:
         merged.
 
         This is a companion to compress_controllers and compress_n_way.
-        These are seperate functions to that they can be called seperately
+        These are seperate functions so that they can be called seperately
         using Stacks.
 
         This function only processes the scenes in a single pass.  If it runs
@@ -205,7 +205,7 @@ class SceneManager:
         definition..
 
         This is a companion to compress_responders and compress_controllers.
-        These are seperate functions to that they can be called seperately
+        These are seperate functions so that they can be called seperately
         using Stacks.
 
         This function only processes the scenes in a single pass.  If it runs

--- a/insteon_mqtt/Scenes.py
+++ b/insteon_mqtt/Scenes.py
@@ -522,7 +522,7 @@ class SceneEntry:
             if not found_ctrl:
                 # We know nothing about the controller so set to default values
                 # the link-data may be wrong, but it doesn't seem to matter
-                if entry.group > 0x01:
+                if entry.group != 0x01:
                     scene['controllers'].append({entry_addr: entry.group})
                 else:
                     scene['controllers'].append(entry_addr)
@@ -731,16 +731,13 @@ class SceneDevice:
         primarily by the compress_* functions
         '''
         ret = False
-        self_group = self.group if self.group > 0x00 else 0x01
-        other_group = other.group if other.group > 0x00 else 0x01
-        if (self.addr == other.addr and self_group == other_group and
+        if (self.addr == other.addr and self.group == other.group and
                 self.link_data == other.link_data):
             ret = True
         return ret
 
     def __str__(self):
-        self_group = self.group if self.group > 0x00 else 0x01
-        subs = (self.addr, self_group, self.link_data)
+        subs = (self.addr, self.group, self.link_data)
         return 'Dev Addr: %s Group: %s Data1-3: %s' % subs
 
     def __hash__(self):
@@ -822,20 +819,20 @@ class SceneDevice:
         Args:
           value:    (int)The group value
         """
-        if self.style == 0 and value > 0x01:
+        if self.style == 0 and value != 0x01:
             if ('group' not in self._yaml_data[self.label] or
                     self._yaml_data[self.label]['group'] != value):
                 self._yaml_data[self.label]['group'] = value
-        if self.style == 1 and value > 0x01:
+        if self.style == 1 and value != 0x01:
             self._yaml_data[self.label] = value
-        if self.style == 2 and value > 0x01:
+        if self.style == 2 and value != 0x01:
             self._yaml_data = {self.label: value}
 
-        # Remove group entry in yaml_data if default value of 0x00 or 0x01
+        # Remove group entry in yaml_data if default value of 0x01
         if (self.style == 0 and 'group' in self._yaml_data[self.label] and
-                value <= 0x01):
+                value == 0x01):
             del self._yaml_data[self.label]['group']
-        elif self.style == 1 and value <= 0x01:
+        elif self.style == 1 and value == 0x01:
             self._yaml_data = self.label
         self.update_device()
 
@@ -891,7 +888,7 @@ class SceneDevice:
                 # Group is a bit special and gets added to link_data
                 # a few responders (kpl) need to know group to set data_3
                 link_dict = self._yaml_data[self.label].copy()
-                if self.group > 0x01:
+                if self.group != 0x01:
                     link_dict['group'] = self.group
                 # Convert data values from human readable form
                 pretty_data = self.device.link_data_from_pretty(

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -558,7 +558,8 @@ class Device:
 
         delta = DbDiff(self.addr)
         for entry in self.entries.values():
-            rhsEntry = rhs.find(entry.addr, entry.group, entry.is_controller)
+            rhsEntry = rhs.find(entry.addr, entry.group, entry.is_controller,
+                                entry.data[2])
 
             # RHS is missing this entry or has different data bytes we need
             # to update.

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -447,10 +447,10 @@ class Dimmer(Base):
         if 'data_3' in data:
             data_3 = data['data_3']
         if not is_controller:
-            if 'ramp' in data:
+            if 'ramp_rate' in data:
                 data_2 = 0x1f
                 for ramp_key, ramp_value in self.ramp_pretty.items():
-                    if data['ramp'] >= ramp_value:
+                    if data['ramp_rate'] >= ramp_value:
                         data_2 = ramp_key
                         break
             if 'on_level' in data:

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -498,10 +498,10 @@ class FanLinc(Dimmer):
         if not is_controller:
             if 'group' in data:
                 data_3 = data['group']
-                if 'ramp' in data and data['group'] <= 0x01:
+                if 'ramp_rate' in data and data['group'] <= 0x01:
                     data_2 = 0x1f
                     for ramp_key, ramp_value in Dimmer.ramp_pretty:
-                        if data['ramp'] >= ramp_value:
+                        if data['ramp_rate'] >= ramp_value:
                             data_2 = ramp_key
             if 'on_level' in data:
                 data_1 = int(data['on_level'] * 2.55 + .5)

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -500,9 +500,10 @@ class FanLinc(Dimmer):
                 data_3 = data['group']
                 if 'ramp_rate' in data and data['group'] <= 0x01:
                     data_2 = 0x1f
-                    for ramp_key, ramp_value in Dimmer.ramp_pretty:
+                    for ramp_key, ramp_value in Dimmer.ramp_pretty.items():
                         if data['ramp_rate'] >= ramp_value:
                             data_2 = ramp_key
+                            break
             if 'on_level' in data:
                 data_1 = int(data['on_level'] * 2.55 + .5)
         return [data_1, data_2, data_3]

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -498,7 +498,7 @@ class FanLinc(Dimmer):
         if not is_controller:
             if 'group' in data:
                 data_3 = data['group']
-            if 'ramp_rate' in data and (data_3 is None or data_3 == 0x01):
+            if 'ramp_rate' in data and (data_3 is None or data_3 <= 0x01):
                 data_2 = 0x1f
                 for ramp_key, ramp_value in Dimmer.ramp_pretty.items():
                     if data['ramp_rate'] >= ramp_value:

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -498,12 +498,12 @@ class FanLinc(Dimmer):
         if not is_controller:
             if 'group' in data:
                 data_3 = data['group']
-                if 'ramp_rate' in data and data['group'] <= 0x01:
-                    data_2 = 0x1f
-                    for ramp_key, ramp_value in Dimmer.ramp_pretty.items():
-                        if data['ramp_rate'] >= ramp_value:
-                            data_2 = ramp_key
-                            break
+            if 'ramp_rate' in data and (data_3 is None or data_3 == 0x01):
+                data_2 = 0x1f
+                for ramp_key, ramp_value in Dimmer.ramp_pretty.items():
+                    if data['ramp_rate'] >= ramp_value:
+                        data_2 = ramp_key
+                        break
             if 'on_level' in data:
                 data_1 = int(data['on_level'] * 2.55 + .5)
         return [data_1, data_2, data_3]

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -636,10 +636,10 @@ class KeypadLinc(Base):
         if 'group' in data:
             data_3 = data['group']
         if not is_controller and self.is_dimmer:
-            if 'ramp' in data:
+            if 'ramp_rate' in data:
                 data_2 = 0x1f
                 for ramp_key, ramp_value in Dimmer.ramp_pretty:
-                    if data['ramp'] >= ramp_value:
+                    if data['ramp_rate'] >= ramp_value:
                         data_2 = ramp_key
             if 'on_level' in data:
                 data_1 = int(data['on_level'] * 2.55 + .5)

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -638,9 +638,10 @@ class KeypadLinc(Base):
         if not is_controller and self.is_dimmer:
             if 'ramp_rate' in data:
                 data_2 = 0x1f
-                for ramp_key, ramp_value in Dimmer.ramp_pretty:
+                for ramp_key, ramp_value in Dimmer.ramp_pretty.items():
                     if data['ramp_rate'] >= ramp_value:
                         data_2 = ramp_key
+                        break
             if 'on_level' in data:
                 data_1 = int(data['on_level'] * 2.55 + .5)
         return [data_1, data_2, data_3]

--- a/insteon_mqtt/device/Remote.py
+++ b/insteon_mqtt/device/Remote.py
@@ -196,9 +196,8 @@ class Remote(Base):
         Returns:
           bytes[3]: Returns a list of 3 bytes to use as D1,D2,D3.
         """
-        # Most of this is from looking through Misterhouse bug reports.
         if is_controller:
-            defaults = [0x03, 0x00, group]
+            defaults = [0x03, 0x00, 0x00]
 
         # Responder data is always link dependent.  Since nothing was given,
         # assume the user wants to turn the device on (0xff).
@@ -224,7 +223,7 @@ class Remote(Base):
         Returns:
           list[3]:  list, containing a dict of the human readable values
         """
-        ret = [{'data_1': data[0]}, {'data_2': data[1]}, {'group': data[2]}]
+        ret = [{'data_1': data[0]}, {'data_2': data[1]}, {'data_3': data[2]}]
         return ret
 
     #-----------------------------------------------------------------------
@@ -251,8 +250,6 @@ class Remote(Base):
         data_3 = None
         if 'data_3' in data:
             data_3 = data['data_3']
-        if 'group' in data:
-            data_3 = data['group']
         return [data_1, data_2, data_3]
 
     #-----------------------------------------------------------------------


### PR DESCRIPTION
This change fixes a handful of problems that I identified while attempting to use the scene import/sync capabilities of insteon_mqtt with my existing Insteon network that includes an Insteon Hub (2245-222) and that has several preexisting scenes, some of which involve the hub.

These are being submitted in a single pull request because some of the changes depend on changes made in earlier commits in the same chain.  Please let me know if you feel it is important to split these into multiple PRs.

@krkeegan I would very much appreciate your code review of these changes, since you wrote much of the content that is being changed here.

Each of the issues/fixes is summarized below.

**Issues fixed:**

**Issue 1:** Multiple dimmer scenes are being combined by compress_controllers() despite having different ramp rates for responders.
- Added test (commit 16b561f200d3ac79c19d5df93f113c80b8d242cb) - Add scene tests for Dimmers with ramp rates
- Fix (commit 60cc79c1087784d75c2d1fc1fd1e3f4e7c4d7a46) - Make link_data_from_pretty match "to" variant for ramp_rate

**Issue 2:** "TypeError: 'int' object is not iterable" in KeypadLinc.py / link_data_from_pretty.
- Added test (commit 103341a6fb73385c18551238e7b8bf88e66925a0) - Add scene tests for FanLinc & KeypadLinc with ramp rates
- Fix (commit b5454978944ab52140be7f5c02092f4aa5232ebe) - Iterate on Dimmer.ramp_pretty.items(), add missing break

**Issue 3:** Scene sync tries to replace group-0 entries with group number changed to 1.
- Added test (commit 7b25c9d2936e56f11c54d6da29d3647380777a49) - Add scene tests for preserving group-0 scenes
- Fix (commit c49791b18ac70f287d0fd761175400e4ff43e641) - Don't treat group-0 and group-1 as equivalent

**Issue 4:** Scenes created by mini-remotes are being changed to have group # in data_3 field.
- Added test (commit 8634bf63da0dbb35ec7767844e0f3f6df7b29bd8) - Add simple scene tests for Remotes
- Fix: (commit 5e0e032bfe6e38804138379c017d35da9feede0e) - Change default data_3 value for mini remotes

**Issue 5:** Typos in insteon_mqtt/Scenes.py comments.
- Fix: (commit c9d94648d3fa2543827fb9933901da61e71d656e) - Fix typos in comments

**Issue 6:** Identical DB entries being removed/re-added by scene sync when scenes only differ in responder group number.
- Added test: (commit 8ff32ba355c044a47d61ae770454711fb2d16dc4) - Add scene test involving multiple groups from same device
- Fix: (commit b611ce38c12ca7e0816927effb0eee9d10afe2f8) - Force match on local_group in Device.diff()

**Issue 7:** FanLinc scenes read from yaml would all have ramp rate set to 0x1f.
- Added test: (commit 0a4e9369d5b24d75a97932b5b5d5d93e8848b0d7) - Add scene test for preserving FanLinc dimmer ramp rates
- Fix: (commit 4bd65dd8ffb414e9a00cce33b43deed917778158) - Allow FanLinc to parse ramp_rate if group is default

**Tests performed:**

- [x] Confirmed that all new pytest tests fail before fix and pass after fix (see attached test log - [scene-fixes-testing.txt](https://github.com/TD22057/insteon-mqtt/files/5604945/scene-fixes-testing.txt))
- [x] Confirmed no new flake8 errors (see attached test log - [scene-fixes-testing.txt](https://github.com/TD22057/insteon-mqtt/files/5604945/scene-fixes-testing.txt))
- [x] Confirmed no new pylint errors (see attached test log - [scene-fixes-testing.txt](https://github.com/TD22057/insteon-mqtt/files/5604945/scene-fixes-testing.txt))
- [x] Confirmed all old & new pytest tests are passing (see attached test log - [scene-fixes-testing.txt](https://github.com/TD22057/insteon-mqtt/files/5604945/scene-fixes-testing.txt))
- [x] Reviewed test coverage report for substantial new gaps (see attached test log - [scene-fixes-testing.txt](https://github.com/TD22057/insteon-mqtt/files/5604945/scene-fixes-testing.txt))
  - Untested lines of code reduced by ~135 lines.
- [x] Dog-food tested with HA version 0.118.3 and 0.118.4 for ~1 day without problems.

**Attachments:**

- [scene-fixes-testing.txt](https://github.com/TD22057/insteon-mqtt/files/5604945/scene-fixes-testing.txt)