### PR TITLE
Support for the default ramp rate setting for Dimmer and KeypadLinc

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -471,6 +471,11 @@ Switch, KeypadLinc, and Dimmer all support the flags:
      signal_bits input.  If a bit is 0, then that button is a toggle button
      and will alternate on an doff signals
 
+  KeypadLinc and Dimmer support the flags:
+   
+   - ramp_rate: integer in the range of 0x00-0x1f which sets the default ramp
+     rate that will be used when the button is pressed
+
 IOLinc supports the flags:
 
    - mode: "latching" / "momentary-a" / "momentary-b" / "momentary-c" to

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -473,7 +473,7 @@ Switch, KeypadLinc, and Dimmer all support the flags:
 
   KeypadLinc and Dimmer support the flags:
    
-   - ramp_rate: integer in the range of 0x00-0x1f which sets the default ramp
+   - ramp_rate: float in the range of 0.5 to 540 seconds which sets the default ramp
      rate that will be used when the button is pressed
 
 IOLinc supports the flags:

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -523,7 +523,7 @@ class Dimmer(Base):
 
     #-----------------------------------------------------------------------
     def set_ramp_rate(self, rate, on_done=None):
-        """Set the device default on level.
+        """Set the device default ramp rate.
 
         This changes the dimmer default ramp rate of how quickly the it
         will turn on or off. This rate can be between .1 seconds and up

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -638,7 +638,7 @@ class Dimmer(Base):
     def handle_ramp_rate(self, msg, on_done):
         """Callback for handling set_ramp_rate() responses.
 
-        This is called when we get a response to the set_on_level() command.
+        This is called when we get a response to the set_ramp_rate() command.
         We don't need to do anything - just call the on_done callback with
         the status.
 

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -525,8 +525,9 @@ class Dimmer(Base):
     def set_ramp_rate(self, rate, on_done=None):
         """Set the device default ramp rate.
 
-        This changes the dimmer default ramp rate of how quickly the it
-        to 9 minutes.
+        This changes the dimmer default ramp rate of how quickly it will 
+        turn on or off. This rate can be between 0.1 seconds and up to 9 
+        minutes.
 
         Args:
           rate (float): Ramp rate in in the range [0.1, 540] seconds

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -46,7 +46,7 @@ class Dimmer(Base):
 
     def __init__(self, protocol, modem, address, name=None):
         """Constructor
-
+        
         Args:
           protocol (Protocol): The Protocol object used to communicate
                    with the Insteon network.  This is needed to allow the
@@ -522,6 +522,35 @@ class Dimmer(Base):
         self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
+    def set_ramp_rate(self, rate, on_done=None):
+        """Set the device default on level.
+
+        This changes the dimmer default ramp rate of how quickly the it
+        will turn on or off. This rate can be between .1 seconds and up
+        to 9 minutes.
+
+        Args:
+          rate (int): The default ramp rate in the range [0,31]
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        LOG.info("Dimmer %s setting ramp rate to %s", self.label, rate)
+
+        # Extended message data - see Insteon dev guide p156.
+        data = bytes([
+            0x01,   # D1 must be group 0x01
+            0x05,   # D2 set ramp rate when button is pressed
+            rate,  # D3 rate
+            ] + [0x00] * 11)
+
+        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+
+        # Use the standard command handler which will notify us when the
+        # command is ACK'ed.
+        msg_handler = handler.StandardCmd(msg, self.handle_ramp_rate, on_done)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
     def set_flags(self, on_done, **kwargs):
         """Set internal device flags.
 
@@ -545,7 +574,8 @@ class Dimmer(Base):
         # passed in.
         FLAG_BACKLIGHT = "backlight"
         FLAG_ON_LEVEL = "on_level"
-        flags = set([FLAG_BACKLIGHT, FLAG_ON_LEVEL])
+        FLAG_RAMP_RATE = "ramp_rate"
+        flags = set([FLAG_BACKLIGHT, FLAG_ON_LEVEL, FLAG_RAMP_RATE])
         unknown = set(kwargs.keys()).difference(flags)
         if unknown:
             raise Exception("Unknown Dimmer flags input: %s.\n Valid flags "
@@ -561,6 +591,10 @@ class Dimmer(Base):
         if FLAG_ON_LEVEL in kwargs:
             on_level = util.input_byte(kwargs, FLAG_ON_LEVEL)
             seq.add(self.set_on_level, on_level)
+
+        if FLAG_RAMP_RATE in kwargs:
+            rate = util.input_byte(kwargs, FLAG_RAMP_RATE)
+            seq.add(self.set_ramp_rate, rate)
 
         seq.run()
 
@@ -599,6 +633,24 @@ class Dimmer(Base):
             on_done(True, "Button on level updated", None)
         else:
             on_done(False, "Button on level failed", None)
+
+    #-----------------------------------------------------------------------
+    def handle_ramp_rate(self, msg, on_done):
+        """Callback for handling set_ramp_rate() responses.
+
+        This is called when we get a response to the set_on_level() command.
+        We don't need to do anything - just call the on_done callback with
+        the status.
+
+        Args:
+          msg (InpStandard): The response message from the command.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
+            on_done(True, "Button ramp rate updated", None)
+        else:
+            on_done(False, "Button ramp rate failed", None)
 
     #-----------------------------------------------------------------------
     def handle_broadcast(self, msg):

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -872,7 +872,7 @@ class KeypadLinc(Base):
 
     #-----------------------------------------------------------------------
     def set_ramp_rate(self, rate, on_done=None):
-        """Set the device default on level.
+        """Set the device default ramp rate.
 
         This changes the dimmer default ramp rate of how quickly the it
         will turn on or off. This rate can be between .1 seconds and up

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -883,6 +883,11 @@ class KeypadLinc(Base):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
+        if not self.is_dimmer:
+          LOG.error("KeypadLinc %s switch doesn't support setting ramp_rate",
+                      self.addr)
+          return
+
         LOG.info("Dimmer %s setting ramp rate to %s", self.label, rate)
 
         # Extended message data - see Insteon dev guide p156.

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -875,26 +875,32 @@ class KeypadLinc(Base):
         """Set the device default ramp rate.
 
         This changes the dimmer default ramp rate of how quickly the it
-        will turn on or off. This rate can be between .1 seconds and up
+        will turn on or off. This rate can be between 0.1 seconds and up
         to 9 minutes.
 
         Args:
-          rate (int): The default ramp rate in the range [0,31]
+          rate (float): Ramp rate in in the range [0.1, 540] seconds
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
         if not self.is_dimmer:
-          LOG.error("KeypadLinc %s switch doesn't support setting ramp_rate",
+            LOG.error("KeypadLinc %s switch doesn't support setting ramp_rate",
                       self.addr)
-          return
+            return
 
         LOG.info("Dimmer %s setting ramp rate to %s", self.label, rate)
+
+        data_3 = 0x1c #the default ramp rate is .5
+        for ramp_key, ramp_value in Dimmer.ramp_pretty.items():
+            if rate >= ramp_value:
+                data_3 = ramp_key
+                break
 
         # Extended message data - see Insteon dev guide p156.
         data = bytes([
             0x01,   # D1 must be group 0x01
             0x05,   # D2 set ramp rate when button is pressed
-            rate,  # D3 rate
+            data_3,  # D3 rate
             ] + [0x00] * 11)
 
         msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
@@ -964,7 +970,7 @@ class KeypadLinc(Base):
             seq.add(self.set_on_level, on_level)
 
         if FLAG_RAMP_RATE in kwargs:
-            rate = util.input_byte(kwargs, FLAG_RAMP_RATE)
+            rate = util.input_float(kwargs,FLAG_RAMP_RATE)
             seq.add(self.set_ramp_rate, rate)
 
         if FLAG_FOLLOW_MASK in kwargs:

--- a/insteon_mqtt/util.py
+++ b/insteon_mqtt/util.py
@@ -280,3 +280,35 @@ def input_byte(inputs, field):
     except ValueError:
         msg = "Invalid %s input.  Valid inputs are 0-255" % input
         raise ValueError(msg)
+
+#===========================================================================
+def input_float(inputs, field):
+    """Convert an input field to an float.
+
+    Raises:
+      If the input is not a valid float, an exception is thrown.
+
+    Args:
+      inputs (dict):  Key/value pairs of user inputs.
+      field (str): The field to get.
+
+    Returns:
+      Returns None if field is not in inputs.  Otherwise the input field
+      is converted to an integer and returned.
+    """
+    value = inputs.pop(field, None)
+    if value is None:
+        return None
+
+    try:
+        if isinstance(value, str):
+            lv = value.lower()
+            if lv == 'none':
+                return None
+            else:
+                return float(value)
+        else:
+            return float(value)
+    except ValueError:
+        msg = "Invalid %s input.  Valid inputs are float values." % input
+        raise ValueError(msg)


### PR DESCRIPTION
This adds support for setting the ramp rate using the set_flags command. It supports a value between 0 and 31. I've tested locally on real hardware and setting the rate works without any issue. The changes I've made are basically a duplicate of the set_on_level method.