### PR TITLE
Properly Handle Pre-NAK Response

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,9 @@
 - Fixed a bug in the modem database class when removing an entry (thanks
   @krkeegan) ([PR#196][P196])
 
+- Changed the MQTT remote to never mark messages for retain so the broker
+  doesn't get out of sync with the device. ([Issue #I210][I210])
+
 
 ## [0.7.2]
 
@@ -378,4 +381,5 @@
 [I193]: https://github.com/TD22057/insteon-mqtt/issues/193
 [I195]: https://github.com/TD22057/insteon-mqtt/issues/195
 [P196]: https://github.com/TD22057/insteon-mqtt/pull/196
+[I210]: https://github.com/TD22057/insteon-mqtt/issues/210
 [P220]: https://github.com/TD22057/insteon-mqtt/pull/220

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # Revision Change History
 
+## [0.7.5]
+
+### Additions
+
+### Fixes
+
+- Improved message handling and processing of Pre_NAK messages.
+  ([PR 236][P236])
+
 ## [0.7.4]
 
 ### Additions
@@ -459,3 +468,4 @@ will add new features.
 [P235]: https://github.com/TD22057/insteon-mqtt/pull/235
 [P259]: https://github.com/TD22057/insteon-mqtt/pull/259
 [P234]: https://github.com/TD22057/insteon-mqtt/pull/234
+[P236]: https://github.com/TD22057/insteon-mqtt/pull/236

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -454,7 +454,7 @@ class Base:
 
         # Send the get_engine_version request.
         msg = Msg.OutStandard.direct(self.addr, 0x0D, 0x00)
-        msg_handler = handler.StandardCmd(msg, self.handle_engine, on_done)
+        msg_handler = handler.StandardCmdNAK(msg, self.handle_engine, on_done)
         self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
@@ -1092,11 +1092,7 @@ class Base:
                    completed.  Signature is: on_done(success, msg, data)
         """
         on_done = util.make_callback(on_done)
-
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            on_done(True, "Entered linking mode", None)
-        else:
-            on_done(False, "Linking mode failed", None)
+        on_done(True, "Entered linking mode", None)
 
     #-----------------------------------------------------------------------
     def _db_update(self, local_group, is_controller, remote_addr, remote_group,

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -268,7 +268,7 @@ class Base:
         LOG.info("Join Device %s", self.addr)
 
         # Using a sequence so we can pass the on_done function through.
-        seq = CommandSeq(self, "Operation Complete", on_done)
+        seq = CommandSeq(self, "Device joined.", on_done)
 
         # First get the engine version.  This process only works and is
         # necessary on I2CS devices.

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -577,10 +577,7 @@ class Dimmer(Base):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            on_done(True, "Backlight level updated", None)
-        else:
-            on_done(False, "Backlight level failed", None)
+        on_done(True, "Backlight level updated", None)
 
     #-----------------------------------------------------------------------
     def handle_on_level(self, msg, on_done):
@@ -595,10 +592,7 @@ class Dimmer(Base):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            on_done(True, "Button on level updated", None)
-        else:
-            on_done(False, "Button on level failed", None)
+        on_done(True, "Button on level updated", None)
 
     #-----------------------------------------------------------------------
     def handle_broadcast(self, msg):
@@ -706,20 +700,13 @@ class Dimmer(Base):
         """
         # If this it the ACK we're expecting, update the internal state and
         # emit our signals.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("Dimmer %s ACK: %s", self.addr, msg)
+        LOG.debug("Dimmer %s ACK: %s", self.addr, msg)
 
-            _is_on, mode = on_off.Mode.decode(msg.cmd1)
-            reason = reason if reason else on_off.REASON_COMMAND
-            self._set_level(msg.cmd2, mode, reason)
-            on_done(True, "Dimmer state updated to %s" % self._level,
-                    msg.cmd2)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Dimmer %s NAK error: %s, Message: %s", self.addr,
-                      msg.nak_str(), msg)
-            on_done(False, "Dimmer state update failed. " + msg.nak_str(),
-                    None)
+        _is_on, mode = on_off.Mode.decode(msg.cmd1)
+        reason = reason if reason else on_off.REASON_COMMAND
+        self._set_level(msg.cmd2, mode, reason)
+        on_done(True, "Dimmer state updated to %s" % self._level,
+                msg.cmd2)
 
     #-----------------------------------------------------------------------
     def handle_scene(self, msg, on_done, reason=""):
@@ -741,21 +728,14 @@ class Dimmer(Base):
         # Call the callback.  We don't change state here - the device will
         # send a regular broadcast message which will run handle_broadcast
         # which will then update the state.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("Dimmer %s ACK: %s", self.addr, msg)
+        LOG.debug("Dimmer %s ACK: %s", self.addr, msg)
 
-            # Reason is device because we're simulating a button press.  We
-            # can't really pass this around because we just get a broadcast
-            # message later from the device.  So we set a temporary variable
-            # here and use it in handle_broadcast() to output the reason.
-            self.broadcast_reason = reason if reason else on_off.REASON_DEVICE
-            on_done(True, "Scene triggered", None)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Dimmer %s NAK error: %s, Message: %s", self.addr,
-                      msg.nak_str(), msg)
-            on_done(False, "Scene trigger failed failed. " + msg.nak_str(),
-                    None)
+        # Reason is device because we're simulating a button press.  We
+        # can't really pass this around because we just get a broadcast
+        # message later from the device.  So we set a temporary variable
+        # here and use it in handle_broadcast() to output the reason.
+        self.broadcast_reason = reason if reason else on_off.REASON_DEVICE
+        on_done(True, "Scene triggered", None)
 
     #-----------------------------------------------------------------------
     def handle_increment(self, msg, on_done, delta, reason=""):
@@ -777,22 +757,15 @@ class Dimmer(Base):
         """
         # If this it the ACK we're expecting, update the internal state and
         # emit our signals.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("Dimmer %s ACK: %s", self.addr, msg)
+        LOG.debug("Dimmer %s ACK: %s", self.addr, msg)
 
-            # Add the delta and bound at [0, 255]
-            level = min(self._level + delta, 255)
-            level = max(level, 0)
-            self._set_level(level, reason=reason)
+        # Add the delta and bound at [0, 255]
+        level = min(self._level + delta, 255)
+        level = max(level, 0)
+        self._set_level(level, reason=reason)
 
-            s = "Dimmer %s state updated to %s" % (self.addr, self._level)
-            on_done(True, s, msg.cmd2)
-
-        elif msg.flags.Dimmer == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Dimmer %s NAK error: %s, Message: %s", self.addr,
-                      msg.nak_str(), msg)
-            on_done(False, "Dimmer %s state update failed. " + msg.nak_str(),
-                    None)
+        s = "Dimmer %s state updated to %s" % (self.addr, self._level)
+        on_done(True, s, msg.cmd2)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, msg):

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -338,19 +338,12 @@ class FanLinc(Dimmer):
 
         # If this it the ACK we're expecting, update the internal state and
         # emit our signals.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("FanLinc fan %s ACK: %s", self.addr, msg)
+        LOG.debug("FanLinc fan %s ACK: %s", self.addr, msg)
 
-            reason = reason if reason else on_off.REASON_COMMAND
-            self._set_fan_speed(msg.cmd2, reason)
-            on_done(True, "Fan %s state updated to %s" %
-                    (self.addr, self._fan_speed), msg.cmd2)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("FanLinc fan %s NAK error: %s, Message: %s", self.addr,
-                      msg.nak_str(), msg)
-            on_done(False, "Fan %s state update failed. " + msg.nak_str(),
-                    None)
+        reason = reason if reason else on_off.REASON_COMMAND
+        self._set_fan_speed(msg.cmd2, reason)
+        on_done(True, "Fan %s state updated to %s" %
+                (self.addr, self._fan_speed), msg.cmd2)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, msg):

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -838,24 +838,18 @@ class IOLinc(Base):
                    completed.  Signature is: on_done(success, msg, data)
         """
         # This state is for the relay.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("IOLinc %s ACK: %s", self.addr, msg)
-            on_done(True, "IOLinc command complete", None)
+        LOG.debug("IOLinc %s ACK: %s", self.addr, msg)
+        on_done(True, "IOLinc command complete", None)
 
-            # On command.  0x11: on
-            if msg.cmd1 == 0x11:
-                LOG.info("IOLinc %s relay ON", self.addr)
-                self._set_relay_is_on(True)
+        # On command.  0x11: on
+        if msg.cmd1 == 0x11:
+            LOG.info("IOLinc %s relay ON", self.addr)
+            self._set_relay_is_on(True)
 
-            # Off command. 0x13: off
-            elif msg.cmd1 == 0x13:
-                LOG.info("IOLinc %s relay OFF", self.addr)
-                self._set_relay_is_on(False)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("IOLinc %s NAK error: %s, Message: %s", self.addr,
-                      msg.nak_str(), msg)
-            on_done(False, "IOLinc command failed. " + msg.nak_str(), None)
+        # Off command. 0x13: off
+        elif msg.cmd1 == 0x13:
+            LOG.info("IOLinc %s relay OFF", self.addr)
+            self._set_relay_is_on(False)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, msg):

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -878,7 +878,7 @@ class IOLinc(Base):
         # This reflects a change in the relay state.
         # Handle on/off commands codes.
         if on_off.Mode.is_valid(msg.cmd1):
-            is_on, mode = on_off.Mode.decode(msg.cmd1)
+            is_on = on_off.Mode.decode(msg.cmd1)[0]
             if self.mode == IOLinc.Modes.MOMENTARY_A:
                 # In Momentary A the relay only turns on if the cmd matches
                 # the responder link D1, else it always turns off.  Even if

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -1150,10 +1150,7 @@ class KeypadLinc(Base):
                    completed.  Signature is: on_done(success, msg, data)
           task (str):  The message to report.
         """
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            on_done(True, "%s updated" % task, None)
-        else:
-            on_done(False, "%s failed" % task, None)
+        on_done(True, "%s updated" % task, None)
 
     #-----------------------------------------------------------------------
     def handle_backlight_on(self, msg, on_done, is_on):
@@ -1166,11 +1163,8 @@ class KeypadLinc(Base):
           is_on (bool): True if the backlight is being turned on, False for
                 off.
         """
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            on_done(True, "backlight set to %s" % is_on, None)
-            self._backlight = is_on
-        else:
-            on_done(False, "backlight set failed", None)
+        on_done(True, "backlight set to %s" % is_on, None)
+        self._backlight = is_on
 
     #-----------------------------------------------------------------------
     def handle_refresh(self, msg):
@@ -1218,27 +1212,20 @@ class KeypadLinc(Base):
         """
         # If this is the ACK we're expecting, update the internal state and
         # emit our signals.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("KeypadLinc LED %s group %s ACK: %s", self.addr, group,
-                      msg)
+        LOG.debug("KeypadLinc LED %s group %s ACK: %s", self.addr, group,
+                  msg)
 
-            # Update the LED bit for the updated group.
-            self._led_bits = led_bits
-            LOG.ui("KeypadLinc %s LED's changed to %s", self.addr,
-                   "{:08b}".format(self._led_bits))
+        # Update the LED bit for the updated group.
+        self._led_bits = led_bits
+        LOG.ui("KeypadLinc %s LED's changed to %s", self.addr,
+               "{:08b}".format(self._led_bits))
 
-            # Change the level and emit the active signal.
-            self._set_level(group, 0xff if is_on else 0x00, reason=reason)
+        # Change the level and emit the active signal.
+        self._set_level(group, 0xff if is_on else 0x00, reason=reason)
 
-            msg = "KeypadLinc %s LED group %s updated to %s" % \
-                  (self.addr, group, is_on)
-            on_done(True, msg, is_on)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("KeypadLinc LED %s NAK error: %s, Message: %s",
-                      self.addr, msg.nak_str(), msg)
-            on_done(False, "KeypadLinc %s LED update failed. " + msg.nak_str(),
-                    None)
+        msg = "KeypadLinc %s LED group %s updated to %s" % \
+              (self.addr, group, is_on)
+        on_done(True, msg, is_on)
 
     #-----------------------------------------------------------------------
     def handle_load_attach(self, msg, on_done, is_attached):
@@ -1252,20 +1239,15 @@ class KeypadLinc(Base):
         """
         # If this it the ACK we're expecting, update the internal state and
         # emit our signals.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("KeypadLinc %s ACK: %s", self.addr, msg)
-            if is_attached:
-                self._load_group = 1
-            else:
-                self._load_group = 9
+        LOG.debug("KeypadLinc %s ACK: %s", self.addr, msg)
+        if is_attached:
+            self._load_group = 1
+        else:
+            self._load_group = 9
 
-            LOG.ui("Keypadlinc %s, setting load to group %s", self.addr,
-                   self._load_group)
-            on_done(True, "Load set to group: %s" % self._load_group, None)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("KeypadLinc %s NAK error: %s", self.addr, msg)
-            on_done(False, "Changing the load group failed", None)
+        LOG.ui("Keypadlinc %s, setting load to group %s", self.addr,
+               self._load_group)
+        on_done(True, "Load set to group: %s" % self._load_group, None)
 
     #-----------------------------------------------------------------------
     def handle_refresh_led(self, msg):
@@ -1458,17 +1440,12 @@ class KeypadLinc(Base):
         """
         # If this is the ACK we're expecting, update the internal state and
         # emit our signals.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("KeypadLinc %s ACK: %s", self.addr, msg)
+        LOG.debug("KeypadLinc %s ACK: %s", self.addr, msg)
 
-            _is_on, mode = on_off.Mode.decode(msg.cmd1)
-            self._set_level(self._load_group, msg.cmd2, mode, reason)
-            on_done(True, "KeypadLinc state updated to %s" % self._level,
-                    msg.cmd2)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("KeypadLinc %s NAK error: %s", self.addr, msg)
-            on_done(False, "KeypadLinc state update failed", None)
+        _is_on, mode = on_off.Mode.decode(msg.cmd1)
+        self._set_level(self._load_group, msg.cmd2, mode, reason)
+        on_done(True, "KeypadLinc state updated to %s" % self._level,
+                msg.cmd2)
 
     #-----------------------------------------------------------------------
     def handle_scene(self, msg, on_done, reason=""):
@@ -1490,19 +1467,14 @@ class KeypadLinc(Base):
         # Call the callback.  We don't change state here - the device will
         # send a regular broadcast message which will run handle_broadcast
         # which will then update the state.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("KeypadLinc %s ACK: %s", self.addr, msg)
+        LOG.debug("KeypadLinc %s ACK: %s", self.addr, msg)
 
-            # Reason is device because we're simulating a button press.  We
-            # can't really pass this around because we just get a broadcast
-            # message later from the device.  So we set a temporary variable
-            # here and use it in handle_broadcast() to output the reason.
-            self.broadcast_reason = reason if reason else on_off.REASON_DEVICE
-            on_done(True, "Scene triggered", None)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("KeypadLinc %s NAK error: %s", self.addr, msg)
-            on_done(False, "Scene trigger failed failed", None)
+        # Reason is device because we're simulating a button press.  We
+        # can't really pass this around because we just get a broadcast
+        # message later from the device.  So we set a temporary variable
+        # here and use it in handle_broadcast() to output the reason.
+        self.broadcast_reason = reason if reason else on_off.REASON_DEVICE
+        on_done(True, "Scene triggered", None)
 
     #-----------------------------------------------------------------------
     def handle_increment(self, msg, on_done, delta, reason=""):
@@ -1523,20 +1495,15 @@ class KeypadLinc(Base):
         """
         # If this it the ACK we're expecting, update the internal state and
         # emit our signals.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("KeypadLinc %s ACK: %s", self.addr, msg)
+        LOG.debug("KeypadLinc %s ACK: %s", self.addr, msg)
 
-            # Add the delta and bound at [0, 255]
-            level = min(self._level + delta, 255)
-            level = max(level, 0)
-            self._set_level(self._load_group, level, reason=reason)
+        # Add the delta and bound at [0, 255]
+        level = min(self._level + delta, 255)
+        level = max(level, 0)
+        self._set_level(self._load_group, level, reason=reason)
 
-            s = "KeypadLinc %s state updated to %s" % (self.addr, self._level)
-            on_done(True, s, msg.cmd2)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("KeypadLinc %s NAK error: %s", self.addr, msg)
-            on_done(False, "KeypadLinc %s state update failed", None)
+        s = "KeypadLinc %s state updated to %s" % (self.addr, self._level)
+        on_done(True, s, msg.cmd2)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, msg):

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -366,10 +366,7 @@ class Switch(Base):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            on_done(True, "Backlight level updated", None)
-        else:
-            on_done(False, "Backlight level failed", None)
+        on_done(True, "Backlight level updated", None)
 
     #-----------------------------------------------------------------------
     def handle_broadcast(self, msg):
@@ -477,20 +474,13 @@ class Switch(Base):
         """
         # If this it the ACK we're expecting, update the internal state and
         # emit our signals.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("Switch %s ACK: %s", self.addr, msg)
+        LOG.debug("Switch %s ACK: %s", self.addr, msg)
 
-            is_on, mode = on_off.Mode.decode(msg.cmd1)
-            reason = reason if reason else on_off.REASON_COMMAND
-            self._set_is_on(is_on, mode, reason)
-            on_done(True, "Switch state updated to on=%s" % self._is_on,
-                    self._is_on)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Switch %s NAK error: %s, Message: %s", self.addr,
-                      msg.nak_str(), msg)
-            on_done(False, "Switch state update failed. " + msg.nak_str(),
-                    None)
+        is_on, mode = on_off.Mode.decode(msg.cmd1)
+        reason = reason if reason else on_off.REASON_COMMAND
+        self._set_is_on(is_on, mode, reason)
+        on_done(True, "Switch state updated to on=%s" % self._is_on,
+                self._is_on)
 
     #-----------------------------------------------------------------------
     def handle_scene(self, msg, on_done, reason=""):
@@ -512,22 +502,14 @@ class Switch(Base):
         # Call the callback.  We don't change state here - the device will
         # send a regular broadcast message which will run handle_broadcast
         # which will then update the state.
-        if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
-            LOG.debug("Switch %s ACK: %s", self.addr, msg)
+        LOG.debug("Switch %s ACK: %s", self.addr, msg)
 
-            # Reason is device because we're simulating a button press.  We
-            # can't really pass this around because we just get a broadcast
-            # message later from the device.  So we set a temporary variable
-            # here and use it in handle_broadcast() to output the reason.
-            self.broadcast_reason = reason if reason else on_off.REASON_DEVICE
-            on_done(True, "Scene triggered", None)
-
-        elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("Switch %s NAK error: %s, Message: %s", self.addr,
-                      msg.nak_str(), msg)
-            self.broadcast_reason = None
-            on_done(False, "Scene trigger failed failed. " + msg.nak_str(),
-                    None)
+        # Reason is device because we're simulating a button press.  We
+        # can't really pass this around because we just get a broadcast
+        # message later from the device.  So we set a temporary variable
+        # here and use it in handle_broadcast() to output the reason.
+        self.broadcast_reason = reason if reason else on_off.REASON_DEVICE
+        on_done(True, "Scene triggered", None)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, msg):

--- a/insteon_mqtt/device/Thermostat.py
+++ b/insteon_mqtt/device/Thermostat.py
@@ -454,14 +454,8 @@ class Thermostat(Base):
         """
         on_done = util.make_callback(on_done)
 
-        if msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("%s NAK: %s, Message: %s", self.db.addr, msg.nak_str(),
-                      msg)
-            on_done(False, "Thermostat command NAK. " + msg.nak_str(), None)
-
-        else:
-            LOG.debug("Thermostat %s generic ack recevied", self.addr)
-            on_done(True, "Thermostat generic ack recevied", None)
+        LOG.debug("Thermostat %s generic ack recevied", self.addr)
+        on_done(True, "Thermostat generic ack recevied", None)
 
     #-----------------------------------------------------------------------
     def handle_broadcast(self, msg):
@@ -538,13 +532,7 @@ class Thermostat(Base):
         """
         on_done = util.make_callback(on_done)
 
-        if msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("%s mode command NAK: %s, Message: %s", self.db.addr,
-                      msg.nak_str(), msg)
-            on_done(False, "Thermostat mode command NAK. " + msg.nak_str(),
-                    None)
-
-        elif msg.cmd1 == 0x6b:
+        if msg.cmd1 == 0x6b:
             self.signal_mode_change.emit(self,
                                          Thermostat.ModeCommands(msg.cmd2))
             on_done(True, "Thermostat recevied mode command", None)
@@ -586,13 +574,7 @@ class Thermostat(Base):
         """
         on_done = util.make_callback(on_done)
 
-        if msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-            LOG.error("%s fan command NAK: %s, Message: %s", self.db.addr,
-                      msg.nak_str(), msg)
-            on_done(False, "Thermostat fan command NAK. " + msg.nak_str(),
-                    None)
-
-        elif msg.cmd1 == 0x6b:
+        if msg.cmd1 == 0x6b:
             self.signal_fan_mode_change.emit(self,
                                              Thermostat.FanCommands(msg.cmd2))
             on_done(True, "Thermostat recevied fan mode command", None)

--- a/insteon_mqtt/handler/BroadcastCmdResponse.py
+++ b/insteon_mqtt/handler/BroadcastCmdResponse.py
@@ -60,9 +60,9 @@ class BroadcastCmdResponse(Base):
             # waiting for a reply.
             if msg.to_addr == self.addr and msg.cmd1 == self.cmd:
                 if not msg.is_ack:
-                    LOG.error("%s NAK response", self.addr)
-
-                LOG.debug("%s got msg ACK", self.addr)
+                    LOG.warning("%s PLM NAK response", self.addr)
+                else:
+                    LOG.debug("%s got PLM ACK", self.addr)
                 return Msg.CONTINUE
 
             # Message didn't match the expected addr/cmd.

--- a/insteon_mqtt/handler/BroadcastCmdResponse.py
+++ b/insteon_mqtt/handler/BroadcastCmdResponse.py
@@ -82,7 +82,7 @@ class BroadcastCmdResponse(Base):
                 return Msg.CONTINUE
 
             elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                if msg.cmd2 == 0xFC:
+                if msg.cmd2 == msg.NakType.PRE_NAK:
                     # This is a "Pre NAK in case database search takes
                     # too long".  This happens when the device database is
                     # large.  Just ignore it, add more wait time and wait.

--- a/insteon_mqtt/handler/BroadcastCmdResponse.py
+++ b/insteon_mqtt/handler/BroadcastCmdResponse.py
@@ -82,9 +82,17 @@ class BroadcastCmdResponse(Base):
                 return Msg.CONTINUE
 
             elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                LOG.error("%s device NAK error: %s", msg.from_addr, msg)
-                self.on_done(False, "Device command NAK", None)
-                return Msg.FINISHED
+                if msg.cmd2 == 0xFC:
+                    # This is a "Pre NAK in case database search takes
+                    # too long".  This happens when the device database is
+                    # large.  Just ignore it, add more wait time and wait.
+                    LOG.warning("%s Pre-NAK: %s, Message: %s", msg.from_addr,
+                                msg.nak_str(), msg)
+                    return Msg.CONTINUE
+                else:
+                    LOG.error("%s device NAK error: %s", msg.from_addr, msg)
+                    self.on_done(False, "Device command NAK", None)
+                    return Msg.FINISHED
 
             else:
                 LOG.warning("%s device unexpected msg: %s", msg.from_addr, msg)

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -96,8 +96,8 @@ class DeviceDbGet(Base):
                 else:
                     LOG.error("%s device NAK error: %s, Message: %s",
                               msg.from_addr, msg.nak_str(), msg)
-                    self.on_done(False, "Database command NAK. " + msg.nak_str(),
-                                 None)
+                    self.on_done(False, "Database command NAK. " +
+                                 msg.nak_str(), None)
                     return Msg.FINISHED
 
             else:

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -86,11 +86,19 @@ class DeviceDbGet(Base):
                 return Msg.CONTINUE
 
             elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                LOG.error("%s device NAK error: %s, Message: %s",
-                          msg.from_addr, msg.nak_str(), msg)
-                self.on_done(False, "Database command NAK. " + msg.nak_str(),
-                             None)
-                return Msg.FINISHED
+                if msg.cmd2 == 0xFC:
+                    # This is a "Pre NAK in case database search takes
+                    # too long".  This happens when the device database is
+                    # large.  Just ignore it, add more wait time and wait.
+                    LOG.warning("%s Pre-NAK: %s, Message: %s", msg.from_addr,
+                                msg.nak_str(), msg)
+                    return Msg.CONTINUE
+                else:
+                    LOG.error("%s device NAK error: %s, Message: %s",
+                              msg.from_addr, msg.nak_str(), msg)
+                    self.on_done(False, "Database command NAK. " + msg.nak_str(),
+                                 None)
+                    return Msg.FINISHED
 
             else:
                 LOG.warning("%s device unexpected msg: %s", msg.from_addr, msg)

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -103,7 +103,7 @@ class DeviceDbGet(Base):
                 return Msg.CONTINUE
 
             elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                if msg.cmd2 == 0xFC:
+                if msg.cmd2 == msg.NakType.PRE_NAK:
                     # This is a "Pre NAK in case database search takes
                     # too long".  This happens when the device database is
                     # large.  Just ignore it, add more wait time and wait.

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -83,7 +83,7 @@ class DeviceDbGet(Base):
         if isinstance(msg, (Msg.OutExtended, Msg.OutStandard)):
             if msg.to_addr == self.db.addr and msg.cmd1 == 0x2f:
                 if not msg.is_ack:
-                    LOG.error("%s NAK response", self.db.addr)
+                    LOG.warning("%s PLM NAK response", self.db.addr)
                 return Msg.CONTINUE
 
             return Msg.UNKNOWN

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -80,12 +80,12 @@ class DeviceDbModify(Base):
                         # This is a "Pre NAK in case database search takes
                         # too long".  This happens when the device database is
                         # large.  Just ignore it, add more wait time and wait.
-                        LOG.warning("%s Pre-NAK: %s, Message: %s", self.db.addr,
-                                    msg.nak_str(), msg)
+                        LOG.warning("%s Pre-NAK: %s, Message: %s",
+                                    self.db.addr, msg.nak_str(), msg)
                         return Msg.CONTINUE
                     else:
-                        LOG.error("%s db mod NAK: %s, Message: %s", self.db.addr,
-                                  msg.nak_str(), msg)
+                        LOG.error("%s db mod NAK: %s, Message: %s",
+                                  self.db.addr, msg.nak_str(), msg)
                         self.on_done(False, "Device database update failed. " +
                                      msg.nak_str(), None)
 

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -80,6 +80,8 @@ class DeviceDbModify(Base):
                         # This is a "Pre NAK in case database search takes
                         # too long".  This happens when the device database is
                         # large.  Just ignore it, add more wait time and wait.
+                        LOG.warning("%s Pre-NAK: %s, Message: %s", self.db.addr,
+                                    msg.nak_str(), msg)
                         return Msg.CONTINUE
                     else:
                         LOG.error("%s db mod NAK: %s, Message: %s", self.db.addr,

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -78,7 +78,7 @@ class DeviceDbModify(Base):
                                  self.entry)
 
                 elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                    if msg.cmd2 == 0xFC:
+                    if msg.cmd2 == msg.NakType.PRE_NAK:
                         # This is a "Pre NAK in case database search takes
                         # too long".  This happens when the device database is
                         # large.  Just ignore it, add more wait time and wait.

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -76,10 +76,16 @@ class DeviceDbModify(Base):
                                  self.entry)
 
                 elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                    LOG.error("%s db mod NAK: %s, Message: %s", self.db.addr,
-                              msg.nak_str(), msg)
-                    self.on_done(False, "Device database update failed. " +
-                                 msg.nak_str(), None)
+                    if msg.cmd2 == 0xFC:
+                        # This is a "Pre NAK in case database search takes
+                        # too long".  This happens when the device database is
+                        # large.  Just ignore it, add more wait time and wait.
+                        return Msg.CONTINUE
+                    else:
+                        LOG.error("%s db mod NAK: %s, Message: %s", self.db.addr,
+                                  msg.nak_str(), msg)
+                        self.on_done(False, "Device database update failed. " +
+                                     msg.nak_str(), None)
 
                 else:
                     LOG.error("%s db mod unexpected msg type: %s",

--- a/insteon_mqtt/handler/DeviceRefresh.py
+++ b/insteon_mqtt/handler/DeviceRefresh.py
@@ -69,12 +69,11 @@ class DeviceRefresh(Base):
         # Probably an echo back of our sent message.
         if isinstance(msg, Msg.OutStandard) and msg.to_addr == self.addr:
             if msg.is_ack:
-                LOG.debug("%s ACK response", self.addr)
+                LOG.debug("%s PLM ACK response", self.addr)
                 return Msg.CONTINUE
             else:
-                LOG.error("%s NAK response", self.addr)
-                self.on_done(False, "NAK response", None)
-                return Msg.FINISHED
+                LOG.warning("%s PLM NAK response", self.addr)
+                return Msg.CONTINUE
 
         # See if this is the standard message ack/nak we're expecting.
         elif isinstance(msg, Msg.InpStandard) and msg.from_addr == self.addr:

--- a/insteon_mqtt/handler/ExtendedCmdResponse.py
+++ b/insteon_mqtt/handler/ExtendedCmdResponse.py
@@ -71,7 +71,7 @@ class ExtendedCmdResponse(Base):
         if isinstance(msg, (Msg.OutExtended, Msg.OutStandard)):
             if msg.to_addr == self.addr and msg.cmd1 == self.cmd:
                 if not msg.is_ack:
-                    LOG.error("%s NAK response", self.addr)
+                    LOG.warning("%s PLM NAK response", self.addr)
                 return Msg.CONTINUE
 
             return Msg.UNKNOWN

--- a/insteon_mqtt/handler/ExtendedCmdResponse.py
+++ b/insteon_mqtt/handler/ExtendedCmdResponse.py
@@ -88,11 +88,19 @@ class ExtendedCmdResponse(Base):
                 return Msg.CONTINUE
 
             elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                LOG.error("%s device NAK error: %s, Message: %s",
-                          msg.from_addr, msg.nak_str(), msg)
-                self.on_done(False, "Device command NAK. " + msg.nak_str(),
-                             None)
-                return Msg.FINISHED
+                if msg.cmd2 == 0xFC:
+                    # This is a "Pre NAK in case database search takes
+                    # too long".  This happens when the device database is
+                    # large.  Just ignore it, add more wait time and wait.
+                    LOG.warning("%s Pre-NAK: %s, Message: %s", msg.from_addr,
+                                msg.nak_str(), msg)
+                    return Msg.CONTINUE
+                else:
+                    LOG.error("%s device NAK error: %s, Message: %s",
+                              msg.from_addr, msg.nak_str(), msg)
+                    self.on_done(False, "Device command NAK. " + msg.nak_str(),
+                                 None)
+                    return Msg.FINISHED
 
             else:
                 LOG.warning("%s device unexpected msg: %s", msg.from_addr, msg)

--- a/insteon_mqtt/handler/ExtendedCmdResponse.py
+++ b/insteon_mqtt/handler/ExtendedCmdResponse.py
@@ -88,7 +88,7 @@ class ExtendedCmdResponse(Base):
                 return Msg.CONTINUE
 
             elif msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
-                if msg.cmd2 == 0xFC:
+                if msg.cmd2 == msg.NakType.PRE_NAK:
                     # This is a "Pre NAK in case database search takes
                     # too long".  This happens when the device database is
                     # large.  Just ignore it, add more wait time and wait.

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -107,10 +107,10 @@ class StandardCmd(Base):
                     # Indicate no more messages are expected.
                     return Msg.FINISHED
 
-            # Only make it here if this is a bad msg.
-            LOG.info("Possible unexpected message from %s cmd %#04x but "
-                     "expected %s cmd %#04x", msg.from_addr, msg.cmd1,
-                     self.addr, self.cmd)
+                # Only make it here if this is a bad msg.
+                LOG.info("Possible unexpected message from %s cmd %#04x but "
+                         "expected %s cmd %#04x", msg.from_addr, msg.cmd1,
+                         self.addr, self.cmd)
 
         return Msg.UNKNOWN
 

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -101,8 +101,7 @@ class StandardCmd(Base):
                                      msg.nak_str(), None)
                         return Msg.FINISHED
 
-                # Run the callback - it's up to the callback to check if this
-                # is really the ACK or not.
+                # Run the callback
                 self.callback(msg, on_done=self.on_done)
 
                 # Indicate no more messages are expected.

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -101,15 +101,16 @@ class StandardCmd(Base):
                                      msg.nak_str(), None)
                         return Msg.FINISHED
 
-                # Run the callback
-                self.callback(msg, on_done=self.on_done)
+                elif msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
+                    # Run the callback
+                    self.callback(msg, on_done=self.on_done)
+                    # Indicate no more messages are expected.
+                    return Msg.FINISHED
 
-                # Indicate no more messages are expected.
-                return Msg.FINISHED
-            else:
-                LOG.info("Possible unexpected message from %s cmd %#04x but "
-                         "expected %s cmd %#04x", msg.from_addr, msg.cmd1,
-                         self.addr, self.cmd)
+            # Only make it here if this is a bad msg.
+            LOG.info("Possible unexpected message from %s cmd %#04x but "
+                     "expected %s cmd %#04x", msg.from_addr, msg.cmd1,
+                     self.addr, self.cmd)
 
         return Msg.UNKNOWN
 

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -73,8 +73,8 @@ class StandardCmd(Base):
             if msg.to_addr == self.addr and msg.cmd1 == self.cmd:
                 if not msg.is_ack:
                     LOG.error("%s NAK response", self.addr)
-
-                LOG.debug("%s got msg ACK", self.addr)
+                else:
+                    LOG.debug("%s got msg ACK", self.addr)
                 return Msg.CONTINUE
 
             # Message didn't match the expected addr/cmd.

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -24,7 +24,7 @@ class StandardCmd(Base):
 
     When we get the InptStandard message we expect to see, it will be passed
     to the callback set in the constructor which is usually a method on the
-    device to handle the result (or the ACK that the command went through).
+    device to handle the ACK (or the ACK that the command went through).
     """
     def __init__(self, msg, callback, on_done=None, num_retry=3):
         """Constructor
@@ -34,7 +34,7 @@ class StandardCmd(Base):
               reply must match the address and msg.cmd1 field to be
               processed by this handler.
           callback:  The message handler callback. This is called when a
-                     matching message is read.  Calling signature:
+                     matching ACK is read.  Calling signature:
                      callback( msg, on_done )
           on_done: The finished callback.  Calling signature:
                    on_done( bool success, str message, data )

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -72,9 +72,9 @@ class StandardCmd(Base):
             # waiting for a reply.
             if msg.to_addr == self.addr and msg.cmd1 == self.cmd:
                 if not msg.is_ack:
-                    LOG.error("%s NAK response", self.addr)
+                    LOG.warning("%s PLM NAK response", self.addr)
                 else:
-                    LOG.debug("%s got msg ACK", self.addr)
+                    LOG.debug("%s got PLM ACK", self.addr)
                 return Msg.CONTINUE
 
             # Message didn't match the expected addr/cmd.

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -86,14 +86,20 @@ class StandardCmd(Base):
             # If this message matches our address and command, it's probably
             # the ACK we're expecting.
             if msg.from_addr == self.addr and msg.cmd1 == self.cmd:
-                if (msg.flags.type == Msg.Flags.Type.DIRECT_NAK and
-                        msg.cmd2 == 0xFC):
-                    # This is a "Pre NAK in case database search takes
-                    # too long".  This happens when the device database is
-                    # large.  Just ignore it, add more wait time and wait.
-                    LOG.warning("%s Pre-NAK: %s, Message: %s", msg.from_addr,
-                                msg.nak_str(), msg)
-                    return Msg.CONTINUE
+                if msg.flags.type == Msg.Flags.Type.DIRECT_NAK:
+                    if msg.cmd2 == msg.NakType.PRE_NAK:
+                        # This is a "Pre NAK in case database search takes
+                        # too long".  This happens when the device database is
+                        # large.  Just ignore it, add more wait time and wait.
+                        LOG.warning("%s Pre-NAK: %s, Message: %s",
+                                    msg.from_addr, msg.nak_str(), msg)
+                        return Msg.CONTINUE
+                    else:
+                        LOG.error("%s device NAK error: %s, Message: %s",
+                                  msg.from_addr, msg.nak_str(), msg)
+                        self.on_done(False, "Command failed. " +
+                                     msg.nak_str(), None)
+                        return Msg.FINISHED
 
                 # Run the callback - it's up to the callback to check if this
                 # is really the ACK or not.

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -24,7 +24,7 @@ class StandardCmd(Base):
 
     When we get the InptStandard message we expect to see, it will be passed
     to the callback set in the constructor which is usually a method on the
-    device to handle the ACK (or the ACK that the command went through).
+    device to handle the ACK.
     """
     def __init__(self, msg, callback, on_done=None, num_retry=3):
         """Constructor

--- a/insteon_mqtt/handler/StandardCmdNAK.py
+++ b/insteon_mqtt/handler/StandardCmdNAK.py
@@ -43,9 +43,9 @@ class StandardCmdNAK(StandardCmd):
             # waiting for a reply.
             if msg.to_addr == self.addr and msg.cmd1 == self.cmd:
                 if not msg.is_ack:
-                    LOG.error("%s NAK response", self.addr)
-
-                LOG.debug("%s got msg ACK", self.addr)
+                    LOG.warning("%s PLM NAK response", self.addr)
+                else:
+                    LOG.debug("%s got PLM ACK", self.addr)
                 return Msg.CONTINUE
 
             # Message didn't match the expected addr/cmd.

--- a/insteon_mqtt/handler/StandardCmdNAK.py
+++ b/insteon_mqtt/handler/StandardCmdNAK.py
@@ -1,0 +1,72 @@
+#===========================================================================
+#
+# Insteon broadcast message handler
+#
+#===========================================================================
+from .. import log
+from .. import message as Msg
+from .StandardCmd import StandardCmd
+
+LOG = log.get_logger()
+
+
+class StandardCmdNAK(StandardCmd):
+    """Insteon standard input mesage handler that passes on NAKs
+
+    The Standard command handler will process and not pass on Naks to the
+    callback function.
+
+    This is handler is identical in everyway, but will pass on a NAK so that
+    the callback can process it.  This is rarely needed
+    """
+
+    #-----------------------------------------------------------------------
+    def msg_received(self, protocol, msg):
+        """See if we can handle the message.
+
+        See if the message is the expected ACK of our output or the expected
+        InpStandard reply message.  If we get a reply, pass it to the
+        callback.
+
+        Args:
+          protocol (Protocol):  The Insteon Protocol object
+          msg: Insteon message object that was read.
+
+        Returns:
+          Msg.UNKNOWN if we can't handle this message.
+          Msg.CONTINUE if we handled the message and expect more.
+          Msg.FINISHED if we handled the message and are done.
+        """
+        # Probably an echo back of our sent message.
+        if isinstance(msg, Msg.OutStandard):
+            # If the message is the echo back of our message, then continue
+            # waiting for a reply.
+            if msg.to_addr == self.addr and msg.cmd1 == self.cmd:
+                if not msg.is_ack:
+                    LOG.error("%s NAK response", self.addr)
+
+                LOG.debug("%s got msg ACK", self.addr)
+                return Msg.CONTINUE
+
+            # Message didn't match the expected addr/cmd.
+            LOG.debug("%s handler unknown msg", self.addr)
+            return Msg.UNKNOWN
+
+        # See if this is the standard message ack/nak we're expecting.
+        elif isinstance(msg, Msg.InpStandard):
+            # If this message matches our address and command, it's probably
+            # the ACK we're expecting.
+            if msg.from_addr == self.addr and msg.cmd1 == self.cmd:
+                # Run the callback it decides what to do with an ACK or NAK
+                self.callback(msg, on_done=self.on_done)
+
+                # Indicate no more messages are expected.
+                return Msg.FINISHED
+            else:
+                LOG.info("Possible unexpected message from %s cmd %#04x but "
+                         "expected %s cmd %#04x", msg.from_addr, msg.cmd1,
+                         self.addr, self.cmd)
+
+        return Msg.UNKNOWN
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/__init__.py
+++ b/insteon_mqtt/handler/__init__.py
@@ -44,5 +44,6 @@ from .ModemLinkStart import ModemLinkStart
 from .ModemReset import ModemReset
 from .ModemScene import ModemScene
 from .StandardCmd import StandardCmd
+from .StandardCmdNAK import StandardCmdNAK
 from .ThermostatCmd import ThermostatCmd
 from .BroadcastCmdResponse import BroadcastCmdResponse

--- a/insteon_mqtt/message/InpStandard.py
+++ b/insteon_mqtt/message/InpStandard.py
@@ -113,11 +113,13 @@ class InpStandard(Base):
         """
         ret = ""
         naks = {
-            0xFF: "Senders ID not in responders db. Try running 'join' again.",
-            0xFE: "Load sense detects no load",
-            0xFD: "Checksum is incorrect",
-            0xFC: "Pre NAK in case database search takes too long",
-            0xFB: "Illegal value in command"
+            self.NakType.SENDER_NOT_IN_DB:
+                "Senders ID not in responders db. Try running 'join' again.",
+            self.NakType.NO_LOAD: "Load sense detects no load",
+            self.NakType.BAD_CHECKSUM: "Checksum is incorrect",
+            self.NakType.PRE_NAK:
+                "Pre NAK in case database search takes too long",
+            self.NakType.ILLEGAL_VALUE: "Illegal value in command"
         }
         if (self.flags.type == Flags.Type.DIRECT_NAK and
                 self.cmd2 in naks.keys()):

--- a/insteon_mqtt/message/InpStandard.py
+++ b/insteon_mqtt/message/InpStandard.py
@@ -113,7 +113,7 @@ class InpStandard(Base):
         """
         ret = ""
         naks = {
-            0xFF: "Senders ID not in responders db. Try linking again.",
+            0xFF: "Senders ID not in responders db. Try running 'join' again.",
             0xFE: "Load sense detects no load",
             0xFD: "Checksum is incorrect",
             0xFC: "Pre NAK in case database search takes too long",

--- a/insteon_mqtt/message/InpStandard.py
+++ b/insteon_mqtt/message/InpStandard.py
@@ -3,6 +3,7 @@
 # Input insteon standard and extended message.
 #
 #===========================================================================
+import enum
 import io
 import time
 from ..Address import Address
@@ -22,6 +23,14 @@ class InpStandard(Base):
 
     msg_code = 0x50
     fixed_msg_size = 11
+
+    # NAK types
+    class NakType(enum.IntEnum):
+        SENDER_NOT_IN_DB = 0xFF
+        NO_LOAD = 0xFE
+        BAD_CHECKSUM = 0xFD
+        PRE_NAK = 0xFC
+        ILLEGAL_VALUE = 0xFB
 
     #-----------------------------------------------------------------------
     @classmethod

--- a/insteon_mqtt/mqtt/Leak.py
+++ b/insteon_mqtt/mqtt/Leak.py
@@ -3,7 +3,6 @@
 # MQTT leak sensor device
 #
 #===========================================================================
-import time
 from .. import log
 from .BatterySensor import BatterySensor
 from .MsgTemplate import MsgTemplate

--- a/insteon_mqtt/mqtt/Remote.py
+++ b/insteon_mqtt/mqtt/Remote.py
@@ -136,9 +136,13 @@ class Remote:
         LOG.info("MQTT received button press %s = btn %s on %s %s",
                  device.label, button, is_on, mode)
 
-        # For manual mode messages, don't retain them because they don't
-        # represent persistent state - they're momentary events.
-        retain = False if mode == on_off.Mode.MANUAL else None
+        # For the remote control, there is no way to know it's state on start
+        # up so we don't want to retain those messages.  If we did, then a
+        # remote that got out of sync (because of the device changing state
+        # and the remote not knowing about it) would cause problems when HA
+        # is restarted because the remotes retain message would still be in
+        # the broker.
+        retain = False
 
         data = self.template_data(button, is_on, mode)
         self.msg_state.publish(self.mqtt, data, retain=retain)

--- a/tests/device/test_IOLinc.py
+++ b/tests/device/test_IOLinc.py
@@ -278,7 +278,6 @@ class Test_Handles():
     @pytest.mark.parametrize("cmd1, type, expected", [
         (0x11, IM.message.Flags.Type.DIRECT_ACK, True),
         (0X13, IM.message.Flags.Type.DIRECT_ACK, False),
-        (0X11, IM.message.Flags.Type.DIRECT_NAK, None),
     ])
     def test_handle_ack(self, test_iolinc, cmd1, type, expected):
         with mock.patch.object(IM.Signal, 'emit'):
@@ -288,11 +287,8 @@ class Test_Handles():
             msg = IM.message.InpStandard(from_addr, to_addr, flags, cmd1, 0x01)
             test_iolinc.handle_ack(msg, lambda success, msg, cmd: True)
             calls = IM.Signal.emit.call_args_list
-            if expected is not None:
-                assert calls[0][0][2] == expected
-                assert IM.Signal.emit.call_count == 1
-            else:
-                assert IM.Signal.emit.call_count == 0
+            assert calls[0][0][2] == expected
+            assert IM.Signal.emit.call_count == 1
 
     @pytest.mark.parametrize("cmd1, entry_d1, mode, sensor, expected", [
         (0x11, None, IM.device.IOLinc.Modes.LATCHING, False, None),

--- a/tests/handler/test_BroadcastCmdResponse.py
+++ b/tests/handler/test_BroadcastCmdResponse.py
@@ -67,6 +67,12 @@ class Test_BroadcastCmdResponse:
         r = handler.msg_received(proto, msg)
         assert r == Msg.FINISHED
 
+        # direct Pre NAK
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_NAK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x10, 0xFC)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.CONTINUE
+
         # unexpected
         flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
         msg = Msg.InpStandard(addr, addr, flags, 0x10, 0x00)

--- a/tests/handler/test_DeviceDbGet.py
+++ b/tests/handler/test_DeviceDbGet.py
@@ -36,6 +36,12 @@ class Test_DeviceDbGet:
         r = handler.msg_received(proto, std_ack)
         assert r == Msg.UNKNOWN
 
+        # direct Pre NAK
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_NAK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x2f, 0xFC)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.CONTINUE
+
         # Try w/ an extended msg.
         ext_data = bytes(14)
         ext_ack = Msg.OutExtended.direct(addr, 0x2f, 0x00, ext_data)

--- a/tests/handler/test_ExtendedCmdResponse.py
+++ b/tests/handler/test_ExtendedCmdResponse.py
@@ -69,6 +69,12 @@ class Test_ExtendedCmdResponse:
         r = handler.msg_received(proto, msg)
         assert r == Msg.FINISHED
 
+        # direct Pre NAK
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_NAK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x2e, 0xFC)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.CONTINUE
+
         # unexpected
         flags = Msg.Flags(Msg.Flags.Type.BROADCAST, False)
         msg = Msg.InpStandard(addr, addr, flags, 0x2e, 0x00)

--- a/tests/mqtt/test_Remote.py
+++ b/tests/mqtt/test_Remote.py
@@ -91,9 +91,9 @@ class Test_Remote:
         dev.signal_pressed.emit(dev, 4, False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
-            topic='%s/state/2' % topic, payload='on', qos=0, retain=True)
+            topic='%s/state/2' % topic, payload='on', qos=0, retain=False)
         assert link.client.pub[1] == dict(
-            topic='%s/state/4' % topic, payload='off', qos=0, retain=True)
+            topic='%s/state/4' % topic, payload='off', qos=0, retain=False)
         link.client.clear()
 
         # Send a manual mode signal - should do nothing w/ the default config.
@@ -121,9 +121,9 @@ class Test_Remote:
         dev.signal_pressed.emit(dev, 4, False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
-            topic="%s/2" % stopic, payload='1 ON', qos=qos, retain=True)
+            topic="%s/2" % stopic, payload='1 ON', qos=qos, retain=False)
         assert link.client.pub[1] == dict(
-            topic="%s/4" % stopic, payload='0 OFF', qos=qos, retain=True)
+            topic="%s/4" % stopic, payload='0 OFF', qos=qos, retain=False)
         link.client.clear()
 
         # Send a manual signal


### PR DESCRIPTION
A NAK with the cmd2 value of `0xFC = Pre NAK in case database search takes too long ` see [Insteon Notes](http://cache.insteon.com/developer/i2CSdev-022012-en.pdf)

There is no other documentation of this, and @jonsmirl appears to be the first person to report this in #231.  Based on what I see, it seems that this NAK can show up whenever, even when not searching the DB.

It appears the proper way to handle this is just to reset the message timeout and do nothing else.

This solves many of the issues of #231