### PR TITLE
Don't Retry DB Get But Increase Timeout; Retry on DB Modify

### DIFF
--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -22,7 +22,7 @@ class DeviceDbGet(Base):
     Each reply is passed to the callback function set in the constructor
     which is usually a method on the device to update it's database.
     """
-    def __init__(self, device_db, on_done, num_retry=0):
+    def __init__(self, device_db, on_done, num_retry=3):
         """Constructor
 
         The on_done callback has the signature on_done(success, msg, entry)

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -22,7 +22,7 @@ class DeviceDbGet(Base):
     Each reply is passed to the callback function set in the constructor
     which is usually a method on the device to update it's database.
     """
-    def __init__(self, device_db, on_done, num_retry=3):
+    def __init__(self, device_db, on_done, num_retry=0, time_out=10):
         """Constructor
 
         The on_done callback has the signature on_done(success, msg, entry)
@@ -38,8 +38,18 @@ class DeviceDbGet(Base):
                     handler times out without returning Msg.FINISHED.
                     This count does include the initial sending so a
                     retry of 3 will send once and then retry 2 more times.
+                    Retries should be 0 for this handler.  This is because the
+                    only message sent out is the initial request for a dump of
+                    the database.  If the handler times out, there is no way
+                    to recover, besides starting the request over again.
+          time_out (int): Timeout in seconds.  The default for this handler
+                          is double the default rate.  This is because the
+                          communication is almost entirely one-sided coming
+                          from the device.  There is nothing we can do from
+                          this end if a message fails to arrive, so we keep
+                          the network as quiet as possible.
         """
-        super().__init__(on_done, num_retry)
+        super().__init__(on_done, num_retry, time_out)
         self.db = device_db
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -29,7 +29,7 @@ class DeviceDbModify(Base):
                     added to the handler.  Signature is:
                     on_done(success, msg, entry)
         """
-        super().__init__(on_done)
+        super().__init__(on_done, num_retry)
 
         self.db = device_db
         self.entry = entry

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -18,7 +18,7 @@ class DeviceDbModify(Base):
     modifications to the device's all link database class to reflect what
     happened on the physical device.
     """
-    def __init__(self, device_db, entry, on_done=None):
+    def __init__(self, device_db, entry, on_done=None, num_retry=3):
         """Constructor
 
         Args:

--- a/insteon_mqtt/handler/DeviceRefresh.py
+++ b/insteon_mqtt/handler/DeviceRefresh.py
@@ -127,7 +127,7 @@ class DeviceRefresh(Base):
                     db_msg = Msg.OutExtended.direct(self.addr, 0x2f, 0x00,
                                                     bytes(14))
                     msg_handler = DeviceDbGet(self.device.db, on_done,
-                                              num_retry=0)
+                                              num_retry=3)
                     self.device.send(db_msg, msg_handler)
 
             # Either way - this transaction is complete.

--- a/insteon_mqtt/handler/DeviceRefresh.py
+++ b/insteon_mqtt/handler/DeviceRefresh.py
@@ -127,7 +127,7 @@ class DeviceRefresh(Base):
                     db_msg = Msg.OutExtended.direct(self.addr, 0x2f, 0x00,
                                                     bytes(14))
                     msg_handler = DeviceDbGet(self.device.db, on_done,
-                                              num_retry=3)
+                                              num_retry=0)
                     self.device.send(db_msg, msg_handler)
 
             # Either way - this transaction is complete.


### PR DESCRIPTION
This issue was discovered in part by #231 

For some reason we had 0 retries on DB_Modify, which was wrong.  This changes that to the default 3.

_-- Update see comment below, we can have retry of 3 for the initial get message --_
Also, it became clear why the DB_Get handler must have a retry of 0.  The handler only sends a single request and then waits for numerous extended messages from the device.  If the time between messages from the device exceeds the time_out, there is really nothing we can do.  There is no way to ask the device to resume from that point.  In fact, asking again while the device is still responding seems to just be ignored by the device.

So instead, this increases the time_out for this particular handler.  It should decrease some errors with little side effect.  If the handler receives the final entry in the DB the handler exits with a complete and will not block for the full timeout.