### PR TITLE
Print Device Names When Printing a Device's Database

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,9 @@
 - Added support for Smartenit EZIO4O 4 relay output module (thanks @embak)
   ([PR 219][P219])
 
+- Device names are now printed when printing the database.  This makes reading
+  the database output much easier.  ([PR 239][P239])
+
 ### Fixes
 
 - Database delta is updated on database writes.  This eliminates a number of
@@ -438,3 +441,4 @@ will add new features.
 [P240]: https://github.com/TD22057/insteon-mqtt/pull/240
 [P248]: https://github.com/TD22057/insteon-mqtt/pull/248
 [P219]: https://github.com/TD22057/insteon-mqtt/pull/219
+[P239]: https://github.com/TD22057/insteon-mqtt/pull/239

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -1147,7 +1147,7 @@ class Modem:
         # Create a new database entry for the modem and send it to the modem
         # for updating.
         entry = db.ModemEntry(remote_addr, local_group, is_controller,
-                              local_data)
+                              local_data, db=self.db)
         seq.add(self.db.add_on_device, self.protocol, entry)
 
         # For two way commands, insert a callback so that when the modem

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -675,7 +675,7 @@ class Device:
 
         o.write("GroupMap\n")
         for grp, elem in self.groups.items():
-            o.write("  %s -> %s\n" % (grp, [i.addr.hex for i in elem]))
+            o.write("  %s -> %-25s\n" % (grp, [i.label[:25] for i in elem]))
 
         return o.getvalue()
 

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -74,13 +74,13 @@ class Device:
         obj._meta = data.get('meta', {})
 
         for d in data['used']:
-            obj.add_entry(DeviceEntry.from_json(d), save=False)
+            obj.add_entry(DeviceEntry.from_json(d, db=obj), save=False)
 
         for d in data['unused']:
-            obj.add_entry(DeviceEntry.from_json(d), save=False)
+            obj.add_entry(DeviceEntry.from_json(d, db=obj), save=False)
 
         if "last" in data:
-            obj.last = DeviceEntry.from_json(data["last"])
+            obj.last = DeviceEntry.from_json(data["last"], db=obj)
 
         # When loading db's <= ver 0.6, no last field was saved to create
         # one at the correct location.
@@ -146,7 +146,7 @@ class Device:
         flags = Msg.DbFlags(in_use=False, is_controller=False,
                             is_last_rec=True)
         self.last = DeviceEntry(Address(0, 0, 0), 0, START_MEM_LOC, flags,
-                                None)
+                                None, db=self)
 
         # Map of all link group number to DeviceEntry objects that respond to
         # that group command.
@@ -755,7 +755,7 @@ class Device:
         if remote.is_controller:
             group = remote.group
         entry = DeviceEntry(remote.addr, group, mem_loc, db_flags,
-                            local.link_data)
+                            local.link_data, db=self)
 
         # Add the Entry to the DB
         self.add_entry(entry, save=False)
@@ -833,7 +833,8 @@ class Device:
         # Create the new entry at the current last memory location.
         db_flags = Msg.DbFlags(in_use=True, is_controller=is_controller,
                                is_last_rec=False)
-        entry = DeviceEntry(addr, group, self.last.mem_loc, db_flags, data)
+        entry = DeviceEntry(addr, group, self.last.mem_loc, db_flags, data,
+                            db=self)
 
         if self.engine == 0:
             # on_done is passed by the sequence manager inside seq.add()

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -675,7 +675,7 @@ class Device:
 
         o.write("GroupMap\n")
         for grp, elem in self.groups.items():
-            o.write("  %s -> %-25s\n" % (grp, [i.label[:25] for i in elem]))
+            o.write("  %s -> %s\n" % (grp, [i.label for i in elem]))
 
         return o.getvalue()
 

--- a/insteon_mqtt/db/DeviceEntry.py
+++ b/insteon_mqtt/db/DeviceEntry.py
@@ -40,7 +40,7 @@ class DeviceEntry:
     """
 
     @staticmethod
-    def from_json(data):
+    def from_json(data, db=None):
         """Read a DeviceEntry from a JSON input.
 
         The inverse of this is to_json().
@@ -50,16 +50,18 @@ class DeviceEntry:
 
         Returns:
           DeviceEntry: Returns the created DeviceEntry object.
+          db: (db.Device) The parent database which contains this entry
         """
         return DeviceEntry(Address.from_json(data['addr']),
                            data['group'],
                            data['mem_loc'],
                            Msg.DbFlags.from_json(data['db_flags']),
-                           bytes(data['data']))
+                           bytes(data['data']),
+                           db=db)
 
     #-----------------------------------------------------------------------
     @staticmethod
-    def from_bytes(data):
+    def from_bytes(data, db=None):
         """Read a DeviceEntry from a byte array.
 
         This is used to read an entry from an InpExtended insteon message
@@ -67,6 +69,7 @@ class DeviceEntry:
 
         Args:
           data:  (bytes) The data 14 byte array from an InpExtended message.
+          db:    (db.device) The parent database containing this entry
 
         Returns:
           DeviceEntry: Returns the created DeviceEntry object.
@@ -81,11 +84,12 @@ class DeviceEntry:
         link_addr = Address.from_bytes(data, 7)
         link_data = data[10:13]
 
-        return DeviceEntry(link_addr, group, mem_loc, db_flags, link_data)
+        return DeviceEntry(link_addr, group, mem_loc, db_flags,
+                           link_data, db=db)
 
     #-----------------------------------------------------------------------
     @staticmethod
-    def from_i1_bytes(data):
+    def from_i1_bytes(data, db=None):
         """Read a DeviceEntry from an i1 device byte array.
 
         This is used to read an entry from the DeviceScanManagerI1 handler for
@@ -95,6 +99,7 @@ class DeviceEntry:
         Args:
           data:      (bytes) The 8 byte record, preceeded by the 2 byte
                      location.
+          db:        (db.device) The parent database containing this entry
 
         Returns:
           DeviceEntry: Returns the created DeviceEntry object.
@@ -105,10 +110,11 @@ class DeviceEntry:
         link_addr = Address.from_bytes(data, 4)
         link_data = data[7:10]
 
-        return DeviceEntry(link_addr, group, mem_loc, db_flags, link_data)
+        return DeviceEntry(link_addr, group, mem_loc, db_flags,
+                           link_data, db=db)
 
     #-----------------------------------------------------------------------
-    def __init__(self, addr, group, mem_loc, db_flags, data):
+    def __init__(self, addr, group, mem_loc, db_flags, data, db=None):
         """Constructor
 
         Args:
@@ -118,6 +124,7 @@ class DeviceEntry:
           db_flags: (message.DbFlags) The db controler record flags.
           data:     (bytes) 3 data bytes.  [0] is the on level, [1] is the
                     ramp rate.
+          db:       (db.device) The parent database containing this entry
         """
         # Accept either bytes, list of ints, or None for the data input.
         if data is not None:
@@ -132,6 +139,7 @@ class DeviceEntry:
         self.db_flags = db_flags
         self.is_controller = db_flags.is_controller
         self.data = data
+        self.db = db
 
     #-----------------------------------------------------------------------
     def copy(self):
@@ -141,7 +149,7 @@ class DeviceEntry:
            Returns a copy of the DeviceEntry object.
         """
         return DeviceEntry(self.addr, self.group, self.mem_loc,
-                           self.db_flags.copy(), self.data[:])
+                           self.db_flags.copy(), self.data[:], db=self.db)
 
     #-----------------------------------------------------------------------
     def update_from(self, addr, group, is_controller, data):

--- a/insteon_mqtt/db/DeviceEntry.py
+++ b/insteon_mqtt/db/DeviceEntry.py
@@ -142,6 +142,22 @@ class DeviceEntry:
         self.db = db
 
     #-----------------------------------------------------------------------
+    @property
+    def label(self):
+        """Returns the label of the device that the address in this entry is
+        associated with or the address if the device cannot be found.
+
+        Returns:
+          (str) A label or address for the entry
+        """
+        # We allow for no db to be set
+        if self.db is not None and self.db.device is not None:
+            device = self.db.device.modem.find(self.addr)
+            if device is not None:
+                return device.label
+        return str(self.addr)
+
+    #-----------------------------------------------------------------------
     def copy(self):
         """Make a copy of the DeviceEntry.
 
@@ -285,8 +301,8 @@ class DeviceEntry:
         last = " (LAST)" if self.db_flags.is_last_rec else ""
         unused = " (UNUSED)" if not self.db_flags.in_use else ""
 
-        return ("%04x: %s grp: %3s type: %s data: %#04x %#04x %#04x%s%s" %
-                (self.mem_loc, self.addr.hex, self.group,
+        return ("%04x: %25s grp: %3s type: %s data: %#04x %#04x %#04x%s%s" %
+                (self.mem_loc, self.label, self.group,
                  util.ctrl_str(self.db_flags.is_controller),
                  self.data[0], self.data[1], self.data[2], unused, last))
 

--- a/insteon_mqtt/db/DeviceEntry.py
+++ b/insteon_mqtt/db/DeviceEntry.py
@@ -302,7 +302,7 @@ class DeviceEntry:
         unused = " (UNUSED)" if not self.db_flags.in_use else ""
 
         return ("%04x: %-25s grp: %3s type: %s data: %#04x %#04x %#04x%s%s" %
-                (self.mem_loc, self.label, self.group,
+                (self.mem_loc, self.label[:24], self.group,
                  util.ctrl_str(self.db_flags.is_controller),
                  self.data[0], self.data[1], self.data[2], unused, last))
 

--- a/insteon_mqtt/db/DeviceEntry.py
+++ b/insteon_mqtt/db/DeviceEntry.py
@@ -301,7 +301,7 @@ class DeviceEntry:
         last = " (LAST)" if self.db_flags.is_last_rec else ""
         unused = " (UNUSED)" if not self.db_flags.in_use else ""
 
-        return ("%04x: %25s grp: %3s type: %s data: %#04x %#04x %#04x%s%s" %
+        return ("%04x: %-25s grp: %3s type: %s data: %#04x %#04x %#04x%s%s" %
                 (self.mem_loc, self.label, self.group,
                  util.ctrl_str(self.db_flags.is_controller),
                  self.data[0], self.data[1], self.data[2], unused, last))

--- a/insteon_mqtt/db/DeviceEntry.py
+++ b/insteon_mqtt/db/DeviceEntry.py
@@ -302,7 +302,7 @@ class DeviceEntry:
         unused = " (UNUSED)" if not self.db_flags.in_use else ""
 
         return ("%04x: %-25s grp: %3s type: %s data: %#04x %#04x %#04x%s%s" %
-                (self.mem_loc, self.label[:24], self.group,
+                (self.mem_loc, self.label[:25], self.group,
                  util.ctrl_str(self.db_flags.is_controller),
                  self.data[0], self.data[1], self.data[2], unused, last))
 

--- a/insteon_mqtt/db/DeviceScanManagerI1.py
+++ b/insteon_mqtt/db/DeviceScanManagerI1.py
@@ -139,7 +139,7 @@ class DeviceScanManagerI1:
 
             # Convert the message to a database device entry.
             entry = DeviceEntry.from_i1_bytes(bytes([self.msb, self.lsb] +
-                                                    self.record))
+                                                    self.record), db=self.db)
             LOG.ui("Entry: %s", entry)
             self.db.add_entry(entry)
 

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -53,7 +53,7 @@ class Modem:
         """
         obj = Modem(path, device)
         for d in data['entries']:
-            obj.add_entry(ModemEntry.from_json(d), save=False)
+            obj.add_entry(ModemEntry.from_json(d, db=obj), save=False)
 
         # pylint: disable=protected-access
         obj._meta = data.get('meta', {})
@@ -577,7 +577,7 @@ class Modem:
         if remote.is_controller:
             group = remote.group
         entry = ModemEntry(remote.addr, group, local.is_controller,
-                           local.link_data)
+                           local.link_data, db=self)
 
         # Add the Entry to the DB
         self.add_entry(entry, save=False)

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -525,7 +525,7 @@ class Modem:
 
         o.write("GroupMap\n")
         for grp, elem in self.groups.items():
-            o.write("  %s -> %-25s\n" % (grp, [i.label[:25] for i in elem]))
+            o.write("  %s -> %s\n" % (grp, [i.label for i in elem]))
 
         return o.getvalue()
 

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -525,7 +525,7 @@ class Modem:
 
         o.write("GroupMap\n")
         for grp, elem in self.groups.items():
-            o.write("  %s -> %s\n" % (grp, [i.addr.hex for i in elem]))
+            o.write("  %s -> %-25s\n" % (grp, [i.label[:25] for i in elem]))
 
         return o.getvalue()
 

--- a/insteon_mqtt/db/ModemEntry.py
+++ b/insteon_mqtt/db/ModemEntry.py
@@ -120,8 +120,8 @@ class ModemEntry:
 
     #-----------------------------------------------------------------------
     def __str__(self):
-        return ("ID: %-25s  grp: %3s type: %s  data: %#04x %#04x %#04x" %
-                (self.label[:24], self.group, util.ctrl_str(self.is_controller),
+        return ("ID: %-25s grp: %3s type: %s  data: %#04x %#04x %#04x" %
+                (self.label[:25], self.group, util.ctrl_str(self.is_controller),
                  self.data[0], self.data[1], self.data[2]))
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/db/ModemEntry.py
+++ b/insteon_mqtt/db/ModemEntry.py
@@ -20,13 +20,14 @@ class ModemEntry:
     """
 
     @staticmethod
-    def from_json(data):
+    def from_json(data, db=None):
         """Read a ModemEntry from a JSON input.
 
         The inverse of this is to_json().
 
         Args:
           data:    (dict): The data to read from.
+          db:      (db.Modem): The Modem database which this entry belongs
 
         Returns:
           ModemEntry: Returns the created ModemEntry object.
@@ -34,10 +35,11 @@ class ModemEntry:
         return ModemEntry(Address.from_json(data['addr']),
                           data['group'],
                           data['is_controller'],
-                          bytes(data['data']))
+                          bytes(data['data']),
+                          db=db)
 
     #-----------------------------------------------------------------------
-    def __init__(self, addr, group, is_controller, data=None):
+    def __init__(self, addr, group, is_controller, data=None, db=None):
         """Constructor
 
         Args:
@@ -47,6 +49,8 @@ class ModemEntry:
                            False if this device is a responder of addr.
           data:            (bytes) 3 data bytes.  [0] is the on level, [1]
                            is the ramp rate.
+          db:              (db.Modem): The Modem database which this entry
+                           belongs
         """
         # Accept either bytes, list of ints, or None for the data input.
         if data is not None:
@@ -60,6 +64,7 @@ class ModemEntry:
         self.group = int(group)
         self.is_controller = is_controller
         self.data = data
+        self.db = db
 
     #-----------------------------------------------------------------------
     def to_json(self):

--- a/insteon_mqtt/db/ModemEntry.py
+++ b/insteon_mqtt/db/ModemEntry.py
@@ -121,7 +121,7 @@ class ModemEntry:
     #-----------------------------------------------------------------------
     def __str__(self):
         return ("ID: %-25s  grp: %3s type: %s  data: %#04x %#04x %#04x" %
-                (self.label, self.group, util.ctrl_str(self.is_controller),
+                (self.label[:24], self.group, util.ctrl_str(self.is_controller),
                  self.data[0], self.data[1], self.data[2]))
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/db/ModemEntry.py
+++ b/insteon_mqtt/db/ModemEntry.py
@@ -120,7 +120,7 @@ class ModemEntry:
 
     #-----------------------------------------------------------------------
     def __str__(self):
-        return ("ID: %25s  grp: %3s type: %s  data: %#04x %#04x %#04x" %
+        return ("ID: %-25s  grp: %3s type: %s  data: %#04x %#04x %#04x" %
                 (self.label, self.group, util.ctrl_str(self.is_controller),
                  self.data[0], self.data[1], self.data[2]))
 

--- a/insteon_mqtt/db/ModemEntry.py
+++ b/insteon_mqtt/db/ModemEntry.py
@@ -81,6 +81,22 @@ class ModemEntry:
             }
 
     #-----------------------------------------------------------------------
+    @property
+    def label(self):
+        """Returns the label of the device that the address in this entry is
+        associated with or the address if the device cannot be found.
+
+        Returns:
+          (str) A label or address for the entry
+        """
+        # We allow for no db to be set
+        if self.db is not None and self.db.device is not None:
+            device = self.db.device.find(self.addr)
+            if device is not None:
+                return device.label
+        return str(self.addr)
+
+    #-----------------------------------------------------------------------
     def __eq__(self, rhs):
         """Check for equality.
 
@@ -104,8 +120,8 @@ class ModemEntry:
 
     #-----------------------------------------------------------------------
     def __str__(self):
-        return ("ID: %s  grp: %s  type: %s  data: %#04x %#04x %#04x" %
-                (self.addr.hex, self.group, util.ctrl_str(self.is_controller),
+        return ("ID: %25s  grp: %3s type: %s  data: %#04x %#04x %#04x" %
+                (self.label, self.group, util.ctrl_str(self.is_controller),
                  self.data[0], self.data[1], self.data[2]))
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -103,7 +103,7 @@ class DeviceDbGet(Base):
                 return Msg.UNKNOWN
 
             # Convert the message to a database device entry.
-            entry = db.DeviceEntry.from_bytes(msg.data)
+            entry = db.DeviceEntry.from_bytes(msg.data, db=self.db)
             LOG.ui("Entry: %s", entry)
 
             # Skip entries w/ a null memory location.

--- a/insteon_mqtt/handler/ModemDbGet.py
+++ b/insteon_mqtt/handler/ModemDbGet.py
@@ -81,7 +81,8 @@ class ModemDbGet(Base):
                 # Create a modem database entry from the message data and
                 # write it into the database.
                 entry = db.ModemEntry(msg.addr, msg.group,
-                                      msg.db_flags.is_controller, msg.data)
+                                      msg.db_flags.is_controller, msg.data,
+                                      db=self.db)
                 self.db.add_entry(entry)
                 LOG.ui("Entry: %s", entry)
 

--- a/insteon_mqtt/handler/ModemLinkComplete.py
+++ b/insteon_mqtt/handler/ModemLinkComplete.py
@@ -78,7 +78,8 @@ class ModemLinkComplete(Base):
                 else:
                     data = self.modem.link_data(msg.group, is_ctrl)
 
-                entry = db.ModemEntry(msg.addr, msg.group, is_ctrl, data)
+                entry = db.ModemEntry(msg.addr, msg.group, is_ctrl, data,
+                                      db=self.modem.db)
                 self.modem.db.add_entry(entry)
 
             return Msg.FINISHED

--- a/tests/db/test_Device.py
+++ b/tests/db/test_Device.py
@@ -43,14 +43,14 @@ class Test_Device:
                addr.ids[0], addr.ids[1], addr.ids[2],
                data[0], data[1], data[2], 0x06]
         msg = Msg.InpExtended(addr, addr, flags, 0x00, 0x00, bytes(raw))
-        entry = IM.db.DeviceEntry.from_bytes(msg.data)
+        entry = IM.db.DeviceEntry.from_bytes(msg.data, db=obj)
         obj.add_entry(entry)
 
         # add same addr w/ different group
         raw[6] = 0x02
         raw[3] = 0x11  # have to change memory location
         msg.data = raw
-        entry = IM.db.DeviceEntry.from_bytes(msg.data)
+        entry = IM.db.DeviceEntry.from_bytes(msg.data, db=obj)
         obj.add_entry(entry)
 
         # new addr, same group
@@ -58,7 +58,7 @@ class Test_Device:
         raw[9] = 0x1d
         raw[3] = 0x12  # have to change memory location
         msg.data = raw
-        entry = IM.db.DeviceEntry.from_bytes(msg.data)
+        entry = IM.db.DeviceEntry.from_bytes(msg.data, db=obj)
         obj.add_entry(entry)
 
         # responder - not in a group
@@ -67,7 +67,7 @@ class Test_Device:
         raw[5] = db_flags.to_bytes()[0]
         raw[3] = 0x13  # have to change memory location
         msg.data = raw
-        entry = IM.db.DeviceEntry.from_bytes(msg.data)
+        entry = IM.db.DeviceEntry.from_bytes(msg.data, db=obj)
         obj.add_entry(entry)
 
         # in use = False
@@ -76,7 +76,7 @@ class Test_Device:
         raw[5] = db_flags.to_bytes()[0]
         raw[3] = 0x14  # have to change memory location
         msg.data = raw
-        entry = IM.db.DeviceEntry.from_bytes(msg.data)
+        entry = IM.db.DeviceEntry.from_bytes(msg.data, db=obj)
         obj.add_entry(entry)
 
         assert len(obj.entries) == 4
@@ -136,7 +136,7 @@ class Test_Device:
 
         db_flags = IM.message.DbFlags(True, False, True)
         right0 = IM.db.DeviceEntry(remote_addr, remote_group, val0.mem_loc,
-                                   db_flags, data)
+                                   db_flags, data, db=db)
         assert right0 == val0
 
         # Add again w/ a different local group
@@ -149,7 +149,7 @@ class Test_Device:
 
         db_flags = IM.message.DbFlags(True, False, True)
         right1 = IM.db.DeviceEntry(remote_addr, remote_group, val1.mem_loc,
-                                   db_flags, data2)
+                                   db_flags, data2, db=None)
         assert right1 == val1
 
 

--- a/tests/db/test_DeviceEntry.py
+++ b/tests/db/test_DeviceEntry.py
@@ -62,3 +62,43 @@ class Test_DeviceEntry:
         str(obj)
 
     #-----------------------------------------------------------------------
+    def test_label(self):
+        addr = IM.Address('12.34.ab')
+        ctrl = Msg.DbFlags(in_use=True, is_controller=True, is_last_rec=False)
+        data = bytes([0x01, 0x02, 0x03])
+        mem_loc = (0xfe << 8) + 0x10
+        obj = IM.db.DeviceEntry(addr, 0x03, mem_loc, ctrl, data, db=None)
+
+        assert obj.label == str(addr)
+
+        protocol = MockProto()
+        modem = MockModem()
+        addr1 = IM.Address(0x03, 0x04, 0x05)
+        addr = IM.Address('12.34.ab')
+        device1 = IM.device.Base(protocol, modem, addr1)
+        obj = IM.db.DeviceEntry(addr, 0x03, mem_loc, ctrl, data, db=device1.db)
+        device = IM.device.Base(protocol, modem, addr, name="Awesomesauce")
+        modem.set_linked_device(device)
+
+        assert obj.label == "12.34.ab (Awesomesauce)"
+
+    #-----------------------------------------------------------------------
+
+#===========================================================================
+class MockProto:
+    def __init__(self):
+        self.msgs = []
+
+    def send(self, msg, handler, high_priority=False, after=None):
+        self.msgs.append(msg)
+
+class MockModem():
+    def __init__(self):
+        self.save_path = ''
+        self.linked_device = None
+
+    def set_linked_device(self, device):
+        self.linked_device = device
+
+    def find(self, *args, **kwargs):
+        return self.linked_device

--- a/tests/db/test_DeviceEntry.py
+++ b/tests/db/test_DeviceEntry.py
@@ -14,7 +14,7 @@ class Test_DeviceEntry:
         ctrl = Msg.DbFlags(in_use=True, is_controller=True, is_last_rec=False)
         data = bytes([0x01, 0x02, 0x03])
         mem_loc = (0xfe << 8) + 0x10
-        obj = IM.db.DeviceEntry(addr, 0x03, mem_loc, ctrl, data)
+        obj = IM.db.DeviceEntry(addr, 0x03, mem_loc, ctrl, data, db=None)
 
         assert obj.addr == addr
         assert obj.group == 0x03
@@ -26,7 +26,7 @@ class Test_DeviceEntry:
         assert obj.mem_bytes() == bytes([0xfe, 0x10])
 
         d = obj.to_json()
-        obj2 = IM.db.DeviceEntry.from_json(d)
+        obj2 = IM.db.DeviceEntry.from_json(d, db=None)
         assert obj2.addr == obj.addr
         assert obj2.group == obj.group
         assert obj2.mem_loc == obj.mem_loc
@@ -42,7 +42,7 @@ class Test_DeviceEntry:
                       addr.ids[0], addr.ids[1], addr.ids[2],
                       data[0], data[1], data[2]])
 
-        obj3 = IM.db.DeviceEntry.from_bytes(data)
+        obj3 = IM.db.DeviceEntry.from_bytes(data, db=None)
         assert obj3.addr == obj.addr
         assert obj3.group == obj.group
         assert obj3.mem_loc == obj.mem_loc

--- a/tests/db/test_DeviceEntryI1.py
+++ b/tests/db/test_DeviceEntryI1.py
@@ -16,7 +16,7 @@ class Test_DeviceEntryI1:
         data = bytes([0xFE, 0x1F, 0x00])
         entry = IM.db.DeviceEntry.from_i1_bytes(bytes([0x0F, 0xFF, 0xE2, 0x01,
                                                        0x20, 0xC4, 0xBA, 0xFE,
-                                                       0x1F, 0x00]))
+                                                       0x1F, 0x00]), db=None)
 
         assert entry.addr == addr
         assert entry.group == 0x01

--- a/tests/db/test_DeviceModifyManagerI1.py
+++ b/tests/db/test_DeviceModifyManagerI1.py
@@ -20,7 +20,7 @@ class Test_Device:
         db_flags = Msg.DbFlags(in_use=True, is_controller=True,
                                is_last_rec=False)
         i1_entry = IM.db.DeviceEntry(addr, 0x01, device.db.last.mem_loc,
-                                     db_flags, None)
+                                     db_flags, None, db=device.db)
 
         manager = IM.db.DeviceModifyManagerI1(device,
                                               device.db,
@@ -43,7 +43,7 @@ class Test_Device:
         db_flags = Msg.DbFlags(in_use=True, is_controller=True,
                                is_last_rec=False)
         i1_entry = IM.db.DeviceEntry(addr, 0x01, device.db.last.mem_loc,
-                                     db_flags, None)
+                                     db_flags, None, db=device.db)
 
         manager = IM.db.DeviceModifyManagerI1(device,
                                               device.db,
@@ -75,7 +75,7 @@ class Test_Device:
         db_flags = Msg.DbFlags(in_use=True, is_controller=True,
                                is_last_rec=False)
         i1_entry = IM.db.DeviceEntry(addr, 0x01, device.db.last.mem_loc,
-                                     db_flags, None)
+                                     db_flags, None, db=device.db)
 
         manager = IM.db.DeviceModifyManagerI1(device,
                                               device.db,
@@ -110,7 +110,7 @@ class Test_Device:
         db_flags = Msg.DbFlags(in_use=False, is_controller=True,
                                is_last_rec=False)
         i1_entry = IM.db.DeviceEntry(addr, 0x01, device.db.last.mem_loc,
-                                     db_flags, None)
+                                     db_flags, None, db=device.db)
 
         manager = IM.db.DeviceModifyManagerI1(device,
                                               device.db,

--- a/tests/db/test_DeviceScanManagerI1.py
+++ b/tests/db/test_DeviceScanManagerI1.py
@@ -139,7 +139,7 @@ class Test_Device:
                0x01,  # group
                0x3a, 0x29, 0x84,
                0x01, 0x0E, 0x43, 0x06]
-        entry = IM.db.DeviceEntry.from_bytes(bytes(raw))
+        entry = IM.db.DeviceEntry.from_bytes(bytes(raw), db=device_db)
 
         assert len(device_db.entries) == 1
         assert len(device_db.unused) == 0

--- a/tests/db/test_Modem.py
+++ b/tests/db/test_Modem.py
@@ -14,17 +14,17 @@ class Test_Modem:
 
         addr = IM.Address('12.34.ab')
         data = bytes([0xff, 0x00, 0x00])
-        e = IM.db.ModemEntry(addr, 0x01, True, data)
+        e = IM.db.ModemEntry(addr, 0x01, True, data, db=obj)
         obj.add_entry(e)
 
         addr = IM.Address('12.34.ac')
         data = bytes([0xff, 0x00, 0x00])
-        e = IM.db.ModemEntry(addr, 0x01, True, data)
+        e = IM.db.ModemEntry(addr, 0x01, True, data, db=obj)
         obj.add_entry(e)
 
         addr = IM.Address('12.34.ad')
         data = bytes([0xff, 0x00, 0x00])
-        e = IM.db.ModemEntry(addr, 0x02, True, data)
+        e = IM.db.ModemEntry(addr, 0x02, True, data, db=obj)
         obj.add_entry(e)
 
         assert len(obj) == 3

--- a/tests/db/test_ModemEntry.py
+++ b/tests/db/test_ModemEntry.py
@@ -11,7 +11,7 @@ class Test_ModemEntry:
     def test_ctrl(self):
         addr = IM.Address('12.34.ab')
         data = bytes([0x01, 0x02, 0x03])
-        obj = IM.db.ModemEntry(addr, 0x03, True, data)
+        obj = IM.db.ModemEntry(addr, 0x03, True, data, db=None)
 
         assert obj.addr == addr
         assert obj.group == 0x03
@@ -19,7 +19,7 @@ class Test_ModemEntry:
         assert obj.data == data
 
         d = obj.to_json()
-        obj2 = IM.db.ModemEntry.from_json(d)
+        obj2 = IM.db.ModemEntry.from_json(d, db=None)
         assert obj2.addr == obj.addr
         assert obj2.group == obj.group
         assert obj2.is_controller == obj.is_controller
@@ -43,7 +43,7 @@ class Test_ModemEntry:
     def test_resp(self):
         addr = IM.Address('12.34.ab')
         data = bytes([0x01, 0x02, 0x03])
-        obj = IM.db.ModemEntry(addr, 0x03, False, data)
+        obj = IM.db.ModemEntry(addr, 0x03, False, data, db=None)
 
         assert obj.addr == addr
         assert obj.group == 0x03
@@ -51,7 +51,7 @@ class Test_ModemEntry:
         assert obj.data == data
 
         d = obj.to_json()
-        obj2 = IM.db.ModemEntry.from_json(d)
+        obj2 = IM.db.ModemEntry.from_json(d, db=None)
         assert obj2.addr == obj.addr
         assert obj2.group == obj.group
         assert obj2.is_controller == obj.is_controller

--- a/tests/db/test_ModemEntry.py
+++ b/tests/db/test_ModemEntry.py
@@ -64,6 +64,45 @@ class Test_ModemEntry:
         str(obj)
 
     #-----------------------------------------------------------------------
+    def test_label(self):
+        addr = IM.Address('12.34.ab')
+        data = bytes([0x01, 0x02, 0x03])
+        obj = IM.db.ModemEntry(addr, 0x03, False, data, db=None)
+
+        assert obj.label == str(addr)
+
+        protocol = MockProto()
+        modem = MockModem()
+        db = MockDB(modem)
+        addr = IM.Address(0x03, 0x04, 0x05)
+        obj = IM.db.ModemEntry(addr, 0x03, False, data, db=db)
+        device = IM.device.Base(protocol, modem, addr, name="Awesomesauce")
+        modem.set_linked_device(device)
+
+        assert obj.label == "03.04.05 (Awesomesauce)"
+
+    #-----------------------------------------------------------------------
 
 
 #===========================================================================
+class MockProto:
+    def __init__(self):
+        self.msgs = []
+
+    def send(self, msg, handler, high_priority=False, after=None):
+        self.msgs.append(msg)
+
+class MockModem():
+    def __init__(self):
+        self.save_path = ''
+        self.linked_device = None
+
+    def set_linked_device(self, device):
+        self.linked_device = device
+
+    def find(self, *args, **kwargs):
+        return self.linked_device
+
+class MockDB():
+    def __init__(self, modem):
+        self.device = modem

--- a/tests/handler/test_ModemDbGet.py
+++ b/tests/handler/test_ModemDbGet.py
@@ -54,7 +54,8 @@ class Test_ModemDbGet:
                    0x01, 0x0e, 0x43])  # data
         msg = Msg.InpAllLinkRec.from_bytes(b)
         test_entry = IM.db.ModemEntry(msg.addr, msg.group,
-                                      msg.db_flags.is_controller, msg.data)
+                                      msg.db_flags.is_controller, msg.data,
+                                      db=None)
         r = handler.msg_received(proto, msg)
         assert r == Msg.FINISHED
         assert isinstance(proto.sent, Msg.OutAllLinkGetNext)

--- a/tests/test_Scenes.py
+++ b/tests/test_Scenes.py
@@ -30,7 +30,7 @@ class Test_Scenes:
                                        "db_flags": {"is_last_rec": False,
                                                     "in_use": False,
                                                     "is_controller": True},
-                                       "addr": "cc.bb.aa"})
+                                       "addr": "cc.bb.aa"}, db=None)
         device = modem.find("aa.bb.cc")
         scenes.add_or_update(device, entry)
         assert len(scenes.entries) == 1
@@ -46,7 +46,7 @@ class Test_Scenes:
                                        "db_flags": {"is_last_rec": False,
                                                     "in_use": False,
                                                     "is_controller": False},
-                                       "addr": "cc.bb.aa"})
+                                       "addr": "cc.bb.aa"}, db=None)
         device = modem.find("aa.bb.cc")
         scenes.add_or_update(device, entry)
         assert len(scenes.entries) == 1
@@ -62,7 +62,7 @@ class Test_Scenes:
                                        "db_flags": {"is_last_rec": False,
                                                     "in_use": False,
                                                     "is_controller": False},
-                                       "addr": "ff.ff.ff"})
+                                       "addr": "ff.ff.ff"}, db=None)
         device = modem.find("aa.bb.cc")
         scenes.add_or_update(device, entry)
         assert len(scenes.entries) == 2
@@ -78,7 +78,7 @@ class Test_Scenes:
                                        "db_flags": {"is_last_rec": False,
                                                     "in_use": False,
                                                     "is_controller": False},
-                                       "addr": "cc.bb.aa"})
+                                       "addr": "cc.bb.aa"}, db=None)
         device = modem.find("aa.bb.cc")
         scenes.add_or_update(device, entry)
         assert len(scenes.entries) == 1
@@ -94,7 +94,7 @@ class Test_Scenes:
                                        "db_flags": {"is_last_rec": False,
                                                     "in_use": False,
                                                     "is_controller": False},
-                                       "addr": "cc.bb.aa"})
+                                       "addr": "cc.bb.aa"}, db=None)
         device = modem.find("aa.bb.cc")
         scenes.add_or_update(device, entry)
         assert len(scenes.entries) == 2
@@ -118,7 +118,7 @@ class Test_Scenes:
                                        "db_flags": {"is_last_rec": False,
                                                     "in_use": False,
                                                     "is_controller": True},
-                                       "addr": "cc.bb.aa"})
+                                       "addr": "cc.bb.aa"}, db=None)
         device = modem.find("aa.bb.cc")
         scenes.add_or_update(device, entry)
         scenes.compress_controllers()


### PR DESCRIPTION
Straightforward, this now additionally prints the device name if the device exists when printing database entries.  This makes them much easier to read.

If the device cannot be found, just the address is printed.

I also cleaned up some formatting so database entries appear consistent for easier reading.

- [x] Flake8 passed
- [x] pylint passed
- [x] new pytests added and passed
- [x] no documentation needed
- [x] works fine on my setup, plus the code is written to be permissive, so in the worst case, if I missed something, the name simply won't print but no error should happen.

Closes #166 