### PR TITLE
Add a Queuing System for Messages Sent to Battery Devices

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,14 @@
   - [MQTT Doc](https://github.com/TD22057/insteon-mqtt/blob/master/docs/mqtt.md) -
     note the new set_flags options for IOLinc and the IOLinc section
 
+ - A new queueing system for battery devices ([PR240][P240]):
+   - Messages sent to the device will be queued until the device is awake
+   - When the device sends a message, the modem will attempt to immediately
+     send the oldest outgoing message.  This only works for some devices.
+   - Added an 'awake' command, to identify when a battery device has been
+     manually awaken via holding the set button.  This will cause all queued
+     and future messages to be sent to the device for up to three minutes
+
 ### Fixes
 
 ## [0.7.3]
@@ -420,3 +428,4 @@ will add new features.
 [P227]: https://github.com/TD22057/insteon-mqtt/pull/227
 [P237]: https://github.com/TD22057/insteon-mqtt/pull/227
 [P197]: https://github.com/TD22057/insteon-mqtt/pull/197
+[P240]: https://github.com/TD22057/insteon-mqtt/pull/240

--- a/config.yaml
+++ b/config.yaml
@@ -377,6 +377,17 @@ mqtt:
     low_battery_topic: 'insteon/{{address}}/battery'
     low_battery_payload: '{{is_low_str.upper()}}'
 
+    # Output heartbeat topic and payload.  This message is sent
+    # every 24 hours. Available variables for templating are:
+    #   address = 'aa.bb.cc'
+    #   name = 'device name'
+    #   is_heartbeat = 0/1
+    #   heartbeat_time = UNIX time float of the last heartbeat
+    # Not every battery device currently sends this data.  Currently only
+    # the leak sensor is known to provide this data
+    heartbeat_topic: 'insteon/{{address}}/heartbeat'
+    heartbeat_payload: '{{heartbeat_time}}'
+
   #------------------------------------------------------------------------
   # Motion sensors
   #------------------------------------------------------------------------
@@ -409,6 +420,9 @@ mqtt:
   # Leak sensors
   #------------------------------------------------------------------------
 
+  # Leak sensors will use the heartbeat configuration
+  # inputs from battery_sensor.
+  #
   # Leak sensors will report the dry/wet status and a heartbeat every 24
   # hours. The leak sensors does not support low battery signal like other
   # battery operated devices.
@@ -437,14 +451,38 @@ mqtt:
     wet_dry_topic: 'insteon/{{address}}/wet'
     wet_dry_payload: '{{is_wet_str.upper()}}'
 
-    # Output heartbeat topic and payload.  This message is sent
-    # every 24 hours. Available variables for templating are:
+  #------------------------------------------------------------------------
+  # Mini remotes
+  #------------------------------------------------------------------------
+
+  # Battery powered remotes (usually 4 or 8 buttons).  A message is
+  # sent whenever one of the buttons is pressed.
+  #
+  # The Remote will use the low_battery configuration
+  # inputs from battery_sensor.
+  remote:
+    # Output state change topic and template.  This message is sent
+    # whenever a button is pressed.  Available variables for templating are:
     #   address = 'aa.bb.cc'
     #   name = 'device name'
-    #   is_heartbeat = 0/1
-    #   heartbeat_time = UNIX time float of the last heartbeat
-    heartbeat_topic: 'insteon/{{address}}/heartbeat'
-    heartbeat_payload: '{{heartbeat_time}}'
+    #   button = 1...n  (button number 1-8 depending on configuration)
+    #   on = 0/1
+    #   on_str = 'off'/'on'
+    #   mode = 'normal'/'fast'/'instant'
+    #   fast = 0/1
+    #   instant = 0/1
+    state_topic: 'insteon/{{address}}/state/{{button}}'
+    state_payload: '{{on_str.upper()}}'
+
+    # Manual mode (holding down a button) is triggered once when the button
+    # is held and once when it's released.  Available variables for
+    # templating are address (see above), name (see above), button (see
+    # above), and:
+    #   manual_str = 'up'/'off'/'down'
+    #   manual = 1/0/-1
+    #   manual_openhab = 2/1/0
+    #manual_state_topic: 'insteon/{{address}}/manual_state'
+    #manual_state_payload: '{{manual_str.upper()}}'
 
   #------------------------------------------------------------------------
   # Smoke Bridge
@@ -583,36 +621,6 @@ mqtt:
     heat_sp_payload: '{ "temp_f" : {{value}} }'
     cool_sp_command_topic: 'insteon/{{address}}/cool_sp_command'
     cool_sp_payload: '{ "temp_f" : {{value}} }'
-
-  #------------------------------------------------------------------------
-  # Mini remotes
-  #------------------------------------------------------------------------
-
-  # Battery powered remotes (usually 4 or 8 buttons).  A message is
-  # sent whenever one of the buttons is pressed.
-  remote:
-    # Output state change topic and template.  This message is sent
-    # whenever a button is pressed.  Available variables for templating are:
-    #   address = 'aa.bb.cc'
-    #   name = 'device name'
-    #   button = 1...n  (button number 1-8 depending on configuration)
-    #   on = 0/1
-    #   on_str = 'off'/'on'
-    #   mode = 'normal'/'fast'/'instant'
-    #   fast = 0/1
-    #   instant = 0/1
-    state_topic: 'insteon/{{address}}/state/{{button}}'
-    state_payload: '{{on_str.upper()}}'
-
-    # Manual mode (holding down a button) is triggered once when the button
-    # is held and once when it's released.  Available variables for
-    # templating are address (see above), name (see above), button (see
-    # above), and:
-    #   manual_str = 'up'/'off'/'down'
-    #   manual = 1/0/-1
-    #   manual_openhab = 2/1/0
-    #manual_state_topic: 'insteon/{{address}}/manual_state'
-    #manual_state_payload: '{{manual_str.upper()}}'
 
   #------------------------------------------------------------------------
   # Fan Linc

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -928,6 +928,18 @@ templates:
    - 'is_low' is 1 for a low battery, 0 for normal.
    - 'is_low_str' is 'on' for a low battery, 'off' for normal.
 
+Some battery sensors also issues a heartbeat every 24 hours that can be used
+to confirm that they are still working.  Presently, only the Leak sensor is
+known to use heartbeat messages. The following variables can be used for
+templates:
+
+   - "is_heartbeat" is 1 whenever a heartbeat occurs
+   - "is_heartbeat_str" is "on" whenever a heartbeat occurs
+   - "heartbeat_time" is the Unix timestamp of when the heartbeat occurred
+
+The Battery Sensor class is also the base for other battery devices that
+have additional features, namely Motion Sensors, Leak Sensors, and Remotes.
+
 A sample battery sensor topic and payload configuration is:
 
    ```
@@ -939,6 +951,10 @@ A sample battery sensor topic and payload configuration is:
      # Low battery warning
      low_battery_topic: 'insteon/{{address}}/battery'
      low_battery_payload: '{{is_low_str.upper()}}'
+
+     # Heartbeats
+     heartbeat_topic: 'insteon/{{address}}/heartbeat'
+     heartbeat_payload: '{{heartbeat_time}}'
    ```
 
 ---
@@ -990,8 +1006,6 @@ A sample leak sensor topic and payload configuration is:
    leak:
      wet_dry_topic: 'insteon/{{address}}/wet'
      wet_dry_payload: '{{state.upper()}}'
-     heartbeat_topic: 'insteon/{{address}}/heartbeat'
-     heartbeat_payload: '{{heartbeat_time}}'
    ```
 
 ---

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -534,6 +534,28 @@ will be passed through to the output state change payload.
    ```
 
 
+### Mark a battery device as awake.
+
+Supported: battery devices only
+
+Normally battery devices are sleeping and will not respond to commands.  So
+normally, the program queues messages for these devices and attempts to send
+them when the device is awake.  Usually this happens for a short period of time
+after the device sends a message.  But some battery devices do not even respond
+to commands during this time.
+
+You can manually wake a battery device by up by holding in their set buttons
+until their light flashes.  At this point they will stay awake for
+approximately 3 minutes.
+
+If you manually wake up a device using this method, then call this command
+so that the program knows that it can send messages to the device for the
+next three minutes.
+
+  ```
+  { "cmd": "awake" }
+  ```
+
 ---
 
 # State change commands

--- a/insteon_mqtt/CommandSeq.py
+++ b/insteon_mqtt/CommandSeq.py
@@ -27,19 +27,18 @@ class CommandSeq:
     this library needs, it works ok.
     """
     #-----------------------------------------------------------------------
-    def __init__(self, protocol, msg=None, on_done=None, error_stop=True):
+    def __init__(self, device, msg=None, on_done=None, error_stop=True):
         """Constructor
 
         Args:
-          protocol (Protocol): The Protocol object to use.  This can also be a
-                   device.Base object.
+          device (Device): The device that these messages are sent to.
           msg (str): String message to pass to on_done if the sequence works.
           on_done: The callback to run when complete.  This will be run
                    when there is an error or when all the commands finish.
           error_stop (bool): True to stop the sequence if a command fails.
                      False to continue on with the sequence.
         """
-        self.protocol = protocol
+        self.device = device
 
         self._on_done = util.make_callback(on_done)
         self.msg = msg
@@ -130,7 +129,7 @@ class CommandSeq:
                       len(self.calls), self.total)
 
             entry = self.calls.pop(0)
-            entry.run(self.protocol, self.on_done)
+            entry.run(self.device, self.on_done)
 
     #-----------------------------------------------------------------------
 
@@ -185,17 +184,17 @@ class Entry:
         return obj
 
     #-----------------------------------------------------------------------
-    def run(self, protocol, on_done):
+    def run(self, device, on_done):
         """Run the command.
 
         Args:
-          protocol:   The Protocol object to use to send messages.
+          device:     The Device object to use to send messages.
           on_done:    The finished calllback.  This will be passed to the
                       handler or the function.
         """
         if self.func is None:
             self.handler.on_done = on_done
-            protocol.send(self.msg, self.handler)
+            device.send(self.msg, self.handler)
 
         else:
             self.func(*self.args, on_done=on_done, **self.kwargs)

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -336,7 +336,7 @@ class Modem:
         """
         # Set the error stop to false so a failed refresh doesn't stop the
         # sequence from trying to refresh other devices.
-        seq = CommandSeq(self.protocol, "Refresh all complete", on_done,
+        seq = CommandSeq(self, "Refresh all complete", on_done,
                          error_stop=False)
 
         # Reload the modem database.
@@ -371,7 +371,7 @@ class Modem:
         """
         # Set the error stop to false so a failed refresh doesn't stop the
         # sequence from trying to refresh other devices.
-        seq = CommandSeq(self.protocol, "Get Engine all complete", on_done,
+        seq = CommandSeq(self, "Get Engine all complete", on_done,
                          error_stop=False)
 
         # Reload all the device databases.
@@ -611,6 +611,26 @@ class Modem:
         self.protocol.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
+    def send(self, msg, msg_handler, high_priority=False, after=None):
+        """Send a message to the modem.
+
+        This simply forwards to Protocol.Send() but is here to provide
+        consistency with devices.
+
+        Args:
+          msg (Message):  Output message to write.  This should be an
+              instance of a message in the message directory that that starts
+              with 'Out'.
+          msg_handler (MsgHander): Message handler instance to use when
+                      replies to the message are received.  Any message
+                      received after we write out the msg are passed to this
+                      handler until the handler returns the message.FINISHED
+                      flags.
+        """
+
+        self.protocol.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
     def sync(self, dry_run=True, refresh=True, sequence=None, on_done=None):
         """Syncs the links on the device.
 
@@ -647,7 +667,7 @@ class Modem:
         if sequence is not None:
             seq = sequence
         else:
-            seq = CommandSeq(self.protocol, "Sync complete", on_done,
+            seq = CommandSeq(self, "Sync complete", on_done,
                              error_stop=False)
 
         if refresh:
@@ -712,7 +732,7 @@ class Modem:
         """
         # Set the error stop to false so a failed refresh doesn't stop the
         # sequence from trying to refresh other devices.
-        seq = CommandSeq(self.protocol, "Sync All complete", on_done,
+        seq = CommandSeq(self, "Sync All complete", on_done,
                          error_stop=False)
 
         # First the modem database.
@@ -1142,7 +1162,7 @@ class Modem:
         # discussion.
         local_data = self.link_data(is_controller, local_group, local_data)
 
-        seq = CommandSeq(self.protocol, "Device db update complete", on_done)
+        seq = CommandSeq(self, "Device db update complete", on_done)
 
         # Create a new database entry for the modem and send it to the modem
         # for updating.
@@ -1200,7 +1220,7 @@ class Modem:
             return
 
         # Add the function delete call to the sequence.
-        seq = CommandSeq(self.protocol, "Delete complete", on_done)
+        seq = CommandSeq(self, "Delete complete", on_done)
         seq.add(self.db.delete_on_device, self.protocol, entry)
 
         # For two way commands, insert a callback so that when the modem

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -192,7 +192,7 @@ class Modem:
         # request each next record as the records arrive.
         msg = Msg.OutAllLinkGetFirst()
         msg_handler = handler.ModemDbGet(self.db, on_done)
-        self.protocol.send(msg, msg_handler)
+        self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
     def db_path(self):
@@ -608,7 +608,7 @@ class Modem:
         LOG.warning("Modem being reset.  All data will be lost")
         msg = Msg.OutResetModem()
         msg_handler = handler.ModemReset(self, on_done)
-        self.protocol.send(msg, msg_handler)
+        self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
     def send(self, msg, msg_handler, high_priority=False, after=None):
@@ -857,7 +857,7 @@ class Modem:
         # nothing happens.  See the handler for details.
         msg = Msg.OutModemLinking(Msg.OutModemLinking.Cmd.EITHER, group)
         msg_handler = handler.ModemLinkStart(on_done)
-        self.protocol.send(msg, msg_handler)
+        self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
     def link_data(self, is_controller, group, data=None):
@@ -984,7 +984,7 @@ class Modem:
         cmd1 = 0x11 if is_on else 0x13
         msg = Msg.OutModemScene(group, cmd1, 0x00)
         msg_handler = handler.ModemScene(self, msg, on_done)
-        self.protocol.send(msg, msg_handler)
+        self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
     def handle_received(self, msg):

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -702,7 +702,7 @@ class Modem:
             on_done(True, None, None)
         else:
             LOG.ui("  Deleting %s:", entry)
-            self.db.delete_on_device(self.protocol, entry, on_done=on_done)
+            self.db.delete_on_device(entry, on_done=on_done)
 
     def _sync_add(self, entry, dry_run, on_done=None):
         ''' Adds a link to the device with a Log UI Message
@@ -714,7 +714,7 @@ class Modem:
             on_done(True, None, None)
         else:
             LOG.ui("  Adding %s:", entry)
-            self.db.add_on_device(self.protocol, entry, on_done=on_done)
+            self.db.add_on_device(entry, on_done=on_done)
 
     #-----------------------------------------------------------------------
     def sync_all(self, dry_run=True, refresh=True, on_done=None):
@@ -1168,7 +1168,7 @@ class Modem:
         # for updating.
         entry = db.ModemEntry(remote_addr, local_group, is_controller,
                               local_data)
-        seq.add(self.db.add_on_device, self.protocol, entry)
+        seq.add(self.db.add_on_device, entry)
 
         # For two way commands, insert a callback so that when the modem
         # command finishes, it will send the next command to the device.
@@ -1221,7 +1221,7 @@ class Modem:
 
         # Add the function delete call to the sequence.
         seq = CommandSeq(self, "Delete complete", on_done)
-        seq.add(self.db.delete_on_device, self.protocol, entry)
+        seq.add(self.db.delete_on_device, entry)
 
         # For two way commands, insert a callback so that when the modem
         # command finishes, it will send the next command to the device.

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -88,6 +88,11 @@ class Protocol:
         # Message received signal.  Every read message is passed to this.
         self.signal_received = Signal()  # (Message)
 
+        # Message finished signal.  Every write message that completes with
+        # Msg.FINISHED, will be emitted here.  Notably happens AFTER msg has
+        # been removed from the _write_queue
+        self.signal_msg_finished = Signal()  # (Message)
+
         # Inbound message buffer.
         self._buf = bytearray()
 
@@ -435,6 +440,8 @@ class Protocol:
             if status == Msg.FINISHED:
                 LOG.debug("Write handler finished")
                 self._write_finished()
+                # Notify any listeners that msg FINISHED
+                self.signal_msg_finished.emit(msg)
                 return
 
             # If this message was understood by the write handler, don't look

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -233,6 +233,20 @@ class Protocol:
         self._next_write_time = wait_time
 
     #-----------------------------------------------------------------------
+    def is_addr_in_write_queue(self, addr):
+        """Checks whether a message to the specified address already exists
+        in the _write_queue
+
+        Args:
+          addr (Address): The address to search for.
+        """
+        for out in self._write_queue:
+            if isinstance(out.msg, (Msg.OutExtended, Msg.OutStandard)):
+                if out.msg.to_addr == addr:
+                    return True
+        return False
+
+    #-----------------------------------------------------------------------
     def _poll(self, t):
         """Periodic polling function.
 

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -314,4 +314,14 @@ def import_scenes(args, config):
 
     reply = util.send(config, topic, payload, args.quiet)
     return reply["status"]
+
+#===========================================================================
+def awake(args, config):
+    topic = "%s/%s" % (args.topic, args.address)
+    payload = {
+        "cmd" : "awake",
+        }
+
+    reply = util.send(config, topic, payload, args.quiet)
+    return reply["status"]
 #===========================================================================

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -384,6 +384,17 @@ def parse_args(args):
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=device.import_scenes)
 
+    #---------------------------------------
+    # device.awake
+    # Only works on battery devices
+    sp = sub.add_parser("awake", help="Mark a battery device as being awake."
+                        "Hold the set button on the device until the light "
+                        "blinks to force the device awake for 3 minutes.")
+    sp.add_argument("address", help="Device address or name.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=device.awake)
+
     return p.parse_args(args)
 
 

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -607,26 +607,6 @@ class Device:
         return delta
 
     #-----------------------------------------------------------------------
-    def apply_diff(self, device, diff, on_done=None):
-        """TODO: doc
-        """
-        assert self.addr == diff.addr
-
-        seq = CommandSeq(device, "Device database sync complete", on_done)
-
-        # Start by removing all the entries we don't need.  This way we free
-        # up memory locations to use for the add.
-        for entry in diff.del_entries:
-            seq.add(self.delete_on_device, entry)
-
-        # Add the missing entries.
-        for entry in diff.add_entries:
-            seq.add(self.add_on_device, device, entry.addr, entry.group,
-                    entry.is_controller, entry.data)
-
-        seq.run()
-
-    #-----------------------------------------------------------------------
     def to_json(self):
         """Convert the database to JSON format.
 

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -486,24 +486,6 @@ class Modem:
         return delta
 
     #-----------------------------------------------------------------------
-    def apply_diff(self, device, diff, on_done=None):
-        """TODO: doc
-        """
-        assert diff.addr is None  # Modem db doesn't have address
-
-        seq = CommandSeq(device, "Modem database sync complete", on_done)
-
-        # Start by removing all the entries we don't need.
-        for entry in diff.del_entries:
-            seq.add(self.delete_on_device, device.protocol, entry)
-
-        # Add the missing entries.
-        for entry in diff.add_entries:
-            seq.add(self.add_on_device, device.protocol, entry)
-
-        seq.run()
-
-    #-----------------------------------------------------------------------
     def to_json(self):
         """Convert the database to JSON format.
 

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -268,7 +268,7 @@ class Modem:
         return results
 
     #-----------------------------------------------------------------------
-    def add_on_device(self, protocol, entry, on_done=None):
+    def add_on_device(self, entry, on_done=None):
         """Add an entry and push the entry to the Insteon modem.
 
         This sends the input record to the Insteon modem.  If that command
@@ -283,8 +283,6 @@ class Modem:
         If the entry already exists, nothing will be done.
 
         Args:
-          protocol:      (Protocol) The Insteon protocol object to use for
-                         sending messages.
           entry:         (ModemEntry) The entry to add.
           on_done:       Optional callback which will be called when the
                          command completes.
@@ -318,10 +316,10 @@ class Modem:
         msg_handler = handler.ModemDbModify(self, entry, exists, on_done)
 
         # Send the message.
-        protocol.send(msg, msg_handler)
+        self.device.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
-    def delete_on_device(self, protocol, entry, on_done=None):
+    def delete_on_device(self, entry, on_done=None):
         """Delete a series of entries on the device.
 
         This will delete ALL the entries for an address and group.  The modem
@@ -336,8 +334,6 @@ class Modem:
           on_done( success, message, ModemEntry )
 
         Args:
-          protocol:      (Protocol) The Insteon protocol object to use for
-                         sending messages.
           addr:          (Address) The address to delete.
           group:         (int) The group to delete.
           on_done:       Optional callback which will be called when the
@@ -404,7 +400,7 @@ class Modem:
 
         # Send the first message.  If it ACK's, it will keep sending more
         # deletes - one per entry.
-        protocol.send(msg, msg_handler)
+        self.device.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
     def diff(self, rhs):

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -13,7 +13,6 @@ from .. import message as Msg
 from .. import util
 from .ModemEntry import ModemEntry
 from .DbDiff import DbDiff
-from ..CommandSeq import CommandSeq
 
 LOG = log.get_logger()
 

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -550,7 +550,7 @@ class Base:
             on_done(True, None, None)
         else:
             LOG.ui("  Deleting %s:", entry)
-            self.db.delete_on_device(self, entry, on_done=on_done)
+            self.db.delete_on_device(entry, on_done=on_done)
 
     #-----------------------------------------------------------------------
     def _sync_add(self, entry, dry_run, on_done=None):
@@ -563,7 +563,7 @@ class Base:
             on_done(True, None, None)
         else:
             LOG.ui("  Adding %s:", entry)
-            self.db.add_on_device(self, entry.addr, entry.group,
+            self.db.add_on_device(entry.addr, entry.group,
                                   entry.is_controller, entry.data,
                                   on_done=on_done)
 
@@ -1135,7 +1135,7 @@ class Base:
             db_group = remote_group
 
         # Create a new database entry for the device and send it.
-        seq.add(self.db.add_on_device, self, remote_addr, db_group,
+        seq.add(self.db.add_on_device, remote_addr, db_group,
                 is_controller, local_data)
 
         # For two way commands, insert a callback so that when the modem
@@ -1188,7 +1188,7 @@ class Base:
         if refresh:
             seq.add(self.refresh)
 
-        seq.add(self.db.delete_on_device, self, entry)
+        seq.add(self.db.delete_on_device, entry)
 
         # For two way commands, insert a callback so that when the modem
         # command finishes, it will send the next command to the device.

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -268,7 +268,7 @@ class Base:
         LOG.info("Join Device %s", self.addr)
 
         # Using a sequence so we can pass the on_done function through.
-        seq = CommandSeq(self.protocol, "Operation Complete", on_done)
+        seq = CommandSeq(self, "Operation Complete", on_done)
 
         # First get the engine version.  This process only works and is
         # necessary on I2CS devices.
@@ -299,7 +299,7 @@ class Base:
             return
         else:
             # Build a sequence of calls to do the link.
-            seq = CommandSeq(self.protocol, "Operation Complete", on_done)
+            seq = CommandSeq(self, "Operation Complete", on_done)
 
             # Put Modem in linking mode first
             seq.add(self.modem.linking)
@@ -377,7 +377,7 @@ class Base:
         LOG.info("Device %s cmd: status refresh", self.label)
 
         # Use a sequence
-        seq = CommandSeq(self.protocol, "Device refreshed", on_done)
+        seq = CommandSeq(self, "Device refreshed", on_done)
 
         # This sends a refresh ping which will respond w/ the current
         # database delta field.  The handler checks that against the
@@ -514,7 +514,7 @@ class Base:
         if sequence is not None:
             seq = sequence
         else:
-            seq = CommandSeq(self.protocol, "Sync complete", on_done,
+            seq = CommandSeq(self, "Sync complete", on_done,
                              error_stop=False)
 
         if refresh:
@@ -1116,7 +1116,7 @@ class Base:
                    "Link will be only one direction",
                    util.ctrl_str(is_controller), remote_addr)
 
-        seq = CommandSeq(self.protocol, "Device db update complete", on_done)
+        seq = CommandSeq(self, "Device db update complete", on_done)
 
         # Check for a db update - otherwise we could be out of date and not
         # know it in which case the memory addresses to add the record in
@@ -1180,7 +1180,7 @@ class Base:
             on_done(False, "Entry doesn't exist", None)
             return
 
-        seq = CommandSeq(self.protocol, "Delete complete", on_done)
+        seq = CommandSeq(self, "Delete complete", on_done)
 
         # Check for a db update - otherwise we could be out of date and not
         # know it in which case the memory addresses to add the record in

--- a/insteon_mqtt/device/BatterySensor.py
+++ b/insteon_mqtt/device/BatterySensor.py
@@ -100,7 +100,7 @@ class BatterySensor(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "BatterySensor paired", on_done)
+        seq = CommandSeq(self, "BatterySensor paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.

--- a/insteon_mqtt/device/BatterySensor.py
+++ b/insteon_mqtt/device/BatterySensor.py
@@ -7,6 +7,7 @@ import time
 from .Base import Base
 from ..CommandSeq import CommandSeq
 from .. import log
+from .. import on_off
 from ..Signal import Signal
 
 LOG = log.get_logger()
@@ -18,7 +19,8 @@ class BatterySensor(Base):
     Battery powered sensors send basic on/off commands, low battery warnings,
     and hearbeat messages (some devices).  This includes things like door
     sensors, hidden door sensors, and window sensors.  This class also serves
-    as the base class for other battery sensors like motion sensors.
+    as the base class for other battery sensors like motion sensors, leak
+    sensors, remotes, and in the future others.
 
     The issue with a battery powered sensor is that we can't download the
     link database without the sensor being on.  You can trigger the sensor
@@ -196,8 +198,9 @@ class BatterySensor(Base):
             LOG.info("BatterySensor %s broadcast ACK grp: %s", self.addr,
                      msg.group)
 
-        # On (0x11) and off (0x13) commands.
-        elif msg.cmd1 == 0x11 or msg.cmd1 == 0x13:
+        # Valid command
+        elif (on_off.Mode.is_valid(msg.cmd1) or
+              on_off.Manual.is_valid(msg.cmd1)):
             LOG.info("BatterySensor %s broadcast cmd %s grp: %s", self.addr,
                      msg.cmd1, msg.group)
 

--- a/insteon_mqtt/device/BatterySensor.py
+++ b/insteon_mqtt/device/BatterySensor.py
@@ -113,7 +113,7 @@ class BatterySensor(Base):
         # It seems like pressing the set button seems to keep them awake for
         # about 3 minutes
         if self._awake_time >= (time.time() - 180):
-            self.protocol.send(msg, msg_handler, high_priority, after)
+            super().send(msg, msg_handler, high_priority, after)
         else:
             LOG.ui("BatterySensor %s - queueing msg until awake", self.label)
             self._send_queue.append([msg, msg_handler, high_priority, after])
@@ -293,9 +293,9 @@ class BatterySensor(Base):
         # Update the awake time to be now
         self._awake_time = time.time()
 
-        # Dump all messages in the queue to Protocol
+        # Dump all messages in the queue
         for args in self._send_queue:
-            self.protocol.send(*args)
+            super().send(*args)
         #Empty the queue
         self._send_queue = []
         on_done(True, "Complete", None)
@@ -334,6 +334,6 @@ class BatterySensor(Base):
                 # now call original on_done
                 orig_on_done(success, message, data)
             args[1].on_done = on_done
-            self.protocol.send(*args)
+            super().send(*args)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -106,7 +106,7 @@ class Dimmer(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "Dimmer paired", on_done)
+        seq = CommandSeq(self, "Dimmer paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -552,7 +552,7 @@ class Dimmer(Base):
                             "are: %s" % unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
-        seq = CommandSeq(self.protocol, "Dimmer set_flags complete", on_done)
+        seq = CommandSeq(self, "Dimmer set_flags complete", on_done)
 
         if FLAG_BACKLIGHT in kwargs:
             backlight = util.input_byte(kwargs, FLAG_BACKLIGHT)

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -101,7 +101,7 @@ class FanLinc(Dimmer):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "FanLinc paired", on_done)
+        seq = CommandSeq(self, "FanLinc paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -147,7 +147,7 @@ class FanLinc(Dimmer):
         """
         LOG.info("Device %s cmd: fan status refresh", self.addr)
 
-        seq = CommandSeq(self.protocol, "Refresh complete", on_done)
+        seq = CommandSeq(self, "Refresh complete", on_done)
 
         # Send a 0x19 0x03 command to get the fan speed level.  This sends a
         # refresh ping which will respond w/ the fan level and current

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -189,7 +189,7 @@ class IOLinc(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "IOLinc paired", on_done)
+        seq = CommandSeq(self, "IOLinc paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -337,7 +337,7 @@ class IOLinc(Base):
 
         # NOTE: IOLinc cmd1=0x00 will report the relay state.  cmd2=0x01
         # reports the sensor state which is what we want.
-        seq = CommandSeq(self.protocol, "Device refreshed", on_done)
+        seq = CommandSeq(self, "Device refreshed", on_done)
 
         # This sends a refresh ping which will respond w/ the current
         # database delta field.  The handler checks that against the current

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -147,7 +147,7 @@ class KeypadLinc(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "KeypadLinc paired", on_done)
+        seq = CommandSeq(self, "KeypadLinc paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -206,7 +206,7 @@ class KeypadLinc(Base):
         # Send a 0x19 0x01 command to get the LED light on/off flags.
         LOG.info("KeypadLinc %s cmd: keypad status refresh", self.addr)
 
-        seq = CommandSeq(self.protocol, "Refresh complete", on_done)
+        seq = CommandSeq(self, "Refresh complete", on_done)
 
         # TODO: change this to 0x2e get extended which reads on mask, off
         # mask, on level, led brightness, non-toggle mask, led bit mask (led
@@ -790,7 +790,7 @@ class KeypadLinc(Base):
 
         # Otherwise use the level changing command.
         else:
-            seq = CommandSeq(self.protocol, "Backlight level", on_done)
+            seq = CommandSeq(self, "Backlight level", on_done)
 
             # Bound to 0x11 <= level <= 0x7f per page 157 of insteon dev guide.
             level = max(0x11, min(level, 0x7f))
@@ -909,7 +909,7 @@ class KeypadLinc(Base):
                             "flags are: %s" % (unknown, flags))
 
         # Start a command sequence so we can call the flag methods in series.
-        seq = CommandSeq(self.protocol, "KeypadLinc set_flags complete",
+        seq = CommandSeq(self, "KeypadLinc set_flags complete",
                          on_done)
 
         # Get the group if it was set.

--- a/insteon_mqtt/device/Leak.py
+++ b/insteon_mqtt/device/Leak.py
@@ -93,7 +93,7 @@ class Leak(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "LeakSensor paired", on_done)
+        seq = CommandSeq(self, "LeakSensor paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.

--- a/insteon_mqtt/device/Leak.py
+++ b/insteon_mqtt/device/Leak.py
@@ -59,8 +59,6 @@ class Leak(BatterySensor):
 
         # Wet/dry signal.  API: func( Device, bool is_wet )
         self.signal_wet = Signal()
-        # Sensor heartbeat signal.  API: func( Device, True )
-        self.signal_heartbeat = Signal()  # (Device, bool)
 
         # Maps Insteon groups to message type for this sensor.
         self.group_map = {

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -55,6 +55,8 @@ class Motion(BatterySensor):
       the light level (dusk/dawn) has changed.  Not all motion sensors support
       this.
     """
+    type_name = "motion_sensor"
+
     def __init__(self, protocol, modem, address, name=None):
         """Constructor
 

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -141,7 +141,7 @@ class Motion(BatterySensor):
             raise Exception("Unknown Motion flags input: %s.\n Valid flags "
                             "are: %s" % (unknown, flags))
 
-        seq = CommandSeq(self.protocol, "Motion Set Flags Success", on_done)
+        seq = CommandSeq(self, "Motion Set Flags Success", on_done)
 
         # For some flags we need to know the existing bit before we change it.
         # So to insure that we are starting from the correct values, get the

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -97,7 +97,7 @@ class Outlet(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "Outlet paired", on_done)
+        seq = CommandSeq(self, "Outlet paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -145,7 +145,7 @@ class Outlet(Base):
         """
         LOG.info("Outlet %s cmd: status refresh", self.label)
 
-        seq = CommandSeq(self.protocol, "Device refreshed", on_done)
+        seq = CommandSeq(self, "Device refreshed", on_done)
 
         # This sends a refresh ping which will respond w/ the current
         # database delta field.  The handler checks that against the current
@@ -414,7 +414,7 @@ class Outlet(Base):
                             "are: %s" % unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
-        seq = CommandSeq(self.protocol, "Outlet set_flags complete", on_done)
+        seq = CommandSeq(self, "Outlet set_flags complete", on_done)
 
         if FLAG_BACKLIGHT in kwargs:
             backlight = util.input_byte(kwargs, FLAG_BACKLIGHT)

--- a/insteon_mqtt/device/Remote.py
+++ b/insteon_mqtt/device/Remote.py
@@ -89,7 +89,7 @@ class Remote(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "Remote paired", on_done)
+        seq = CommandSeq(self, "Remote paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.

--- a/insteon_mqtt/device/Remote.py
+++ b/insteon_mqtt/device/Remote.py
@@ -3,17 +3,17 @@
 # Remote module
 #
 #===========================================================================
+from .BatterySensor import BatterySensor
 from ..CommandSeq import CommandSeq
 from .. import log
 from .. import on_off
 from ..Signal import Signal
-from .Base import Base
 from .. import util
 
 LOG = log.get_logger()
 
 
-class Remote(Base):
+class Remote(BatterySensor):
     """Insteon multi-button battery powered mini-remote device.
 
     This class can be used for 1, 4, 6 or 8 (really any number) of battery
@@ -55,6 +55,12 @@ class Remote(Base):
 
         self.num = num_button
         self.type_name = "mini_remote_%d" % self.num
+
+        # Even though all buttons use the same callback this creats
+        # symmetry with the rest of the codebase
+        self.group_map = {}
+        for i in range(1, self.num + 1):
+            self.group_map[i] = self.handle_button
 
         # Button pressed signal.
         # API: func(Device, int group, bool on, on_off.Mode mode)
@@ -114,30 +120,17 @@ class Remote(Base):
         seq.run()
 
     #-----------------------------------------------------------------------
-    def handle_broadcast(self, msg):
-        """Handle broadcast messages from this device.
+    def handle_button(self, msg):
+        """Handle button presses and hold downs
 
-        This is called automatically by the system (via handle.Broadcast)
-        when we receive a message from the device.
-
-        The broadcast message from a device is sent when the device is
-        triggered.  The message has the group ID in it.  We'll update the
-        device state and look up the group in the all link database.  For
-        each device that is in the group (as a reponsder), we'll call
-        handle_group_cmd() on that device to trigger it.  This way all the
-        devices in the group are updated to the correct values when we see
-        the broadcast message.
+        This is called by the device when a group broadcast is
+        sent out by the sensor.
 
         Args:
           msg (InpStandard):  Broadcast message from the device.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == 0x06:
-            LOG.info("Remote %s broadcast ACK grp: %s", self.addr, msg.group)
-            return
-
         # On/off command codes.
-        elif on_off.Mode.is_valid(msg.cmd1):
+        if on_off.Mode.is_valid(msg.cmd1):
             is_on, mode = on_off.Mode.decode(msg.cmd1)
             LOG.info("Remote %s broadcast grp: %s on: %s mode: %s", self.addr,
                      msg.group, is_on, mode)
@@ -152,19 +145,6 @@ class Remote(Base):
                      msg.group, manual)
 
             self.signal_manual.emit(self, msg.group, manual)
-
-        # This will find all the devices we're the controller of for this
-        # group and call their handle_group_cmd() methods to update their
-        # states since they will have seen the group broadcast and updated
-        # (without sending anything out).
-        super().handle_broadcast(msg)
-
-        # If we haven't downloaded the device db yet, use this opportunity to
-        # get the device db since we know the sensor is awake.  This doesn't
-        # always seem to work, but it works often enough to be useful to try.
-        if len(self.db) == 0:
-            LOG.info("Remote %s awake - requesting database", self.addr)
-            self.refresh(force=True)
 
     #-----------------------------------------------------------------------
     def link_data(self, is_controller, group, data=None):

--- a/insteon_mqtt/device/SmokeBridge.py
+++ b/insteon_mqtt/device/SmokeBridge.py
@@ -87,7 +87,7 @@ class SmokeBridge(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "SmokeBridge paired", on_done)
+        seq = CommandSeq(self, "SmokeBridge paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -130,7 +130,7 @@ class SmokeBridge(Base):
         """
         LOG.info("Smoke bridge %s cmd: status refresh", self.addr)
 
-        seq = CommandSeq(self.protocol, "Device refreshed", on_done)
+        seq = CommandSeq(self, "Device refreshed", on_done)
 
         # There is no way to get the current device status but we can request
         # the all link database delta so get that.  See smoke bridge dev

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -92,7 +92,7 @@ class Switch(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "Switch paired", on_done)
+        seq = CommandSeq(self, "Switch paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -345,7 +345,7 @@ class Switch(Base):
                             "are: %s" % unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
-        seq = CommandSeq(self.protocol, "Switch set_flags complete", on_done)
+        seq = CommandSeq(self, "Switch set_flags complete", on_done)
 
         if FLAG_BACKLIGHT in kwargs:
             backlight = util.input_byte(kwargs, FLAG_BACKLIGHT)

--- a/insteon_mqtt/device/Thermostat.py
+++ b/insteon_mqtt/device/Thermostat.py
@@ -167,7 +167,7 @@ class Thermostat(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "Thermostat paired", on_done)
+        seq = CommandSeq(self, "Thermostat paired", on_done)
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -223,7 +223,7 @@ class Thermostat(Base):
         """
         LOG.info("Device %s cmd: fan status refresh", self.addr)
 
-        seq = CommandSeq(self.protocol, "Refresh complete", on_done)
+        seq = CommandSeq(self, "Refresh complete", on_done)
 
         # Send a 0x19 0x03 command to get the fan speed level.  This sends a
         # refresh ping which will respond w/ the fan level and current

--- a/insteon_mqtt/handler/Base.py
+++ b/insteon_mqtt/handler/Base.py
@@ -123,6 +123,8 @@ class Base:
 
         # Otherwise we should try and resend the message with ourselves as
         # the handler again so we don't lose the count.
+        # This calls protocol rather then device so that the hops count is
+        # correcly set, also since we don't have the Device object here
         protocol.send(self._msg, self)
 
         # Tell the protocol that we're expired.  This will end this handler

--- a/insteon_mqtt/handler/ModemDbGet.py
+++ b/insteon_mqtt/handler/ModemDbGet.py
@@ -88,7 +88,7 @@ class ModemDbGet(Base):
             # Request the next record in the PLM database.
             LOG.info("Modem requesting next db record")
             msg = Msg.OutAllLinkGetNext()
-            protocol.send(msg, self)
+            self.db.device.send(msg, self)
 
             # Return finished - this way the getnext message will go out.
             # We'll be used as the handler for that as well which repeats

--- a/insteon_mqtt/handler/ModemDbModify.py
+++ b/insteon_mqtt/handler/ModemDbModify.py
@@ -121,7 +121,7 @@ class ModemDbModify(Base):
         if self.next:
             LOG.info("Sending next modem db update")
             msg, self.entry = self.next.pop(0)
-            protocol.send(msg, self)
+            self.db.device.send(msg, self)
 
         # Only run the callback if this is the last message in the chain.
         else:

--- a/insteon_mqtt/mqtt/Leak.py
+++ b/insteon_mqtt/mqtt/Leak.py
@@ -5,12 +5,13 @@
 #===========================================================================
 import time
 from .. import log
+from .BatterySensor import BatterySensor
 from .MsgTemplate import MsgTemplate
 
 LOG = log.get_logger()
 
 
-class Leak:
+class Leak(BatterySensor):
     """Leak battery powered sensor.
 
     Leak sensors don't support any input commands - they're sleeping until
@@ -24,21 +25,16 @@ class Leak:
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.Leak):  The Insteon object to link to.
         """
-        self.mqtt = mqtt
-        self.device = device
+        super().__init__(mqtt, device)
 
         # Default values for the topics.
         self.msg_wet = MsgTemplate(
             topic='insteon/{{address}}/wet',
             payload='{{is_wet_str.lower()}}')
-        self.msg_heartbeat = MsgTemplate(
-            topic='insteon/{{address}}/heartbeat',
-            payload='{{heartbeat_time}}')
 
         # Connect the two signals from the insteon device so we get notified
         # of changes.
         device.signal_wet.connect(self._insteon_wet)
-        device.signal_heartbeat.connect(self._insteon_heartbeat)
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
@@ -49,38 +45,23 @@ class Leak:
                  config is stored in config['leak'].
           qos (int):  The default quality of service level to use.
         """
+        # Load the BatterySensor configuration.
+        super().load_config(config, qos)
+
         data = config.get("leak", None)
         if not data:
             return
 
         self.msg_wet.load_config(data, 'wet_dry_topic', 'wet_dry_payload', qos)
-        self.msg_heartbeat.load_config(data, 'heartbeat_topic',
-                                       'heartbeat_payload', qos)
+
+        # In versions <= 0.7.2, this was in leak sensor so try and
+        # load them to insure old config files still work.
+        if "heartbeat_topic" in data:
+            self.msg_heartbeat.load_config(data, 'heartbeat_topic',
+                                           'heartbeat_payload', qos)
 
     #-----------------------------------------------------------------------
-    def subscribe(self, link, qos):
-        """Subscribe to any MQTT topics the object needs.
-
-        Subscriptions are used when the object has things that can be
-        commanded to change.
-
-        Args:
-          link (network.Mqtt):  The MQTT network client to use.
-          qos (int):  The quality of service to use.
-        """
-        pass
-
-    #-----------------------------------------------------------------------
-    def unsubscribe(self, link):
-        """Unsubscribe to any MQTT topics the object was subscribed to.
-
-        Args:
-          link (network.Mqtt):  The MQTT network client to use.
-        """
-        pass
-
-    #-----------------------------------------------------------------------
-    def template_data(self, is_wet=None, is_heartbeat=None):
+    def template_data_leak(self, is_wet=None):
         """Create the Jinja templating data variables.
 
         Args:
@@ -106,11 +87,6 @@ class Leak:
             data["is_dry_str"] = "off" if is_wet else "on"
             data["state"] = "wet" if is_wet else "dry"
 
-        if is_heartbeat is not None:
-            data["is_heartbeat"] = 1 if is_heartbeat else 0
-            data["is_heartbeat_str"] = "on" if is_heartbeat else "off"
-            data["heartbeat_time"] = time.time() if is_heartbeat else 0
-
         return data
 
     #-----------------------------------------------------------------------
@@ -128,22 +104,5 @@ class Leak:
         LOG.info("MQTT received wet/dry change %s wet= %s", device.label,
                  is_wet)
 
-        data = self.template_data(is_wet)
+        data = self.template_data_leak(is_wet)
         self.msg_wet.publish(self.mqtt, data)
-
-    #-----------------------------------------------------------------------
-    def _insteon_heartbeat(self, device, is_heartbeat):
-        """Device heartbeat on/off callback.
-
-        This is triggered via signal when the Insteon device receive a
-        heartbeat. It will publish an MQTT message with the new date.
-
-        Args:
-          device (device.Leak):  The Insteon device that changed.
-          is_heartbeat (bool):  True for heartbeat, False for not.
-        """
-        LOG.info("MQTT received heartbeat %s = %s", device.label,
-                 is_heartbeat)
-
-        data = self.template_data(is_heartbeat=is_heartbeat)
-        self.msg_heartbeat.publish(self.mqtt, data)

--- a/tests/db/test_Device.py
+++ b/tests/db/test_Device.py
@@ -120,7 +120,7 @@ class Test_Device:
         device = MockDevice()
 
         local_addr = IM.Address(0x01, 0x02, 0x03)
-        db = IM.db.Device(local_addr)
+        db = IM.db.Device(local_addr, device=device)
 
         # Add local group 1 as responder of scene 30 on remote.
         data = bytes([0xff, 0x00, 0x01])

--- a/tests/db/test_Device.py
+++ b/tests/db/test_Device.py
@@ -128,8 +128,7 @@ class Test_Device:
         remote_addr = IM.Address(0x50, 0x51, 0x52)
         remote_group = 0x30
 
-        db.add_on_device(device, remote_addr, remote_group, is_controller,
-                         data)
+        db.add_on_device(remote_addr, remote_group, is_controller, data)
         assert len(device.sent) == 2
         assert len(db.entries) == 1
         val0 = list(db.entries.values())[0]
@@ -141,8 +140,7 @@ class Test_Device:
 
         # Add again w/ a different local group
         data2 = bytes([0x50, 0x00, 0x02])
-        db.add_on_device(device, remote_addr, remote_group, is_controller,
-                         data2)
+        db.add_on_device(remote_addr, remote_group, is_controller, data2)
         assert len(db.entries) == 2
 
         val1 = list(db.entries.values())[1]

--- a/tests/handler/test_ModemDbGet.py
+++ b/tests/handler/test_ModemDbGet.py
@@ -6,6 +6,7 @@
 #===========================================================================
 import insteon_mqtt as IM
 import insteon_mqtt.message as Msg
+import helpers as H
 
 
 class Test_ModemDbGet:
@@ -44,6 +45,7 @@ class Test_ModemDbGet:
             calls.append(msg)
 
         db = Mockdb()
+        db.device = MockDevice()
         handler = IM.handler.ModemDbGet(db, callback)
         proto = MockProtocol()
 
@@ -57,8 +59,8 @@ class Test_ModemDbGet:
                                       msg.db_flags.is_controller, msg.data)
         r = handler.msg_received(proto, msg)
         assert r == Msg.FINISHED
-        assert isinstance(proto.sent, Msg.OutAllLinkGetNext)
-        assert proto.handler == handler
+        assert isinstance(db.device.sent[0]['msg'], Msg.OutAllLinkGetNext)
+        assert db.device.sent[0]['handler'] == handler
         assert db.entry == test_entry
 
 #===========================================================================
@@ -76,3 +78,12 @@ class Mockdb:
 
     def add_entry(self, entry):
         self.entry = entry
+
+class MockDevice:
+    """Mock insteon_mqtt/Device class
+    """
+    def __init__(self):
+        self.sent = []
+
+    def send(self, msg, handler, priority=None, after=None):
+        self.sent.append(H.Data(msg=msg, handler=handler))

--- a/tests/mqtt/test_Leak.py
+++ b/tests/mqtt/test_Leak.py
@@ -60,16 +60,14 @@ class Test_Leak:
         assert data == right
 
         t0 = time.time()
-        data = mdev.template_data(is_wet=True, is_heartbeat=True)
+        data = mdev.template_data(is_heartbeat=True)
         right = {"address" : addr.hex, "name" : name,
-                 "is_wet" : 1, "is_wet_str" : "on", "state" : "wet",
-                 "is_dry" : 0, "is_dry_str" : "off",
                  "is_heartbeat" : 1, "is_heartbeat_str" : "on"}
         hb = data.pop('heartbeat_time')
         assert data == right
         pytest.approx(t0, hb, 5)
 
-        data = mdev.template_data(is_wet=False)
+        data = mdev.template_data_leak(is_wet=False)
         right = {"address" : addr.hex, "name" : name,
                  "is_wet" : 0, "is_wet_str" : "off", "state" : "dry",
                  "is_dry" : 1, "is_dry_str" : "on"}

--- a/tests/mqtt/test_Remote.py
+++ b/tests/mqtt/test_Remote.py
@@ -55,25 +55,26 @@ class Test_Remote:
     def test_template(self, setup):
         mdev, addr, name = setup.getAll(['mdev', 'addr', 'name'])
 
-        data = mdev.template_data(3)
+        data = mdev.template_data_remote(3)
         right = {"address" : addr.hex, "name" : name, "button" : 3}
         assert data == right
 
-        data = mdev.template_data(4, is_on=True, mode=IM.on_off.Mode.FAST,
-                                  manual=IM.on_off.Manual.STOP)
+        data = mdev.template_data_remote(4, is_on=True,
+                                         mode=IM.on_off.Mode.FAST,
+                                         manual=IM.on_off.Manual.STOP)
         right = {"address" : addr.hex, "name" : name, "button" : 4,
                  "on" : 1, "on_str" : "on",
                  "mode" : "fast", "fast" : 1, "instant" : 0,
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
         assert data == right
 
-        data = mdev.template_data(4, is_on=False)
+        data = mdev.template_data_remote(4, is_on=False)
         right = {"address" : addr.hex, "name" : name, "button"  : 4,
                  "on" : 0, "on_str" : "off",
                  "mode" : "normal", "fast" : 0, "instant" : 0}
         assert data == right
 
-        data = mdev.template_data(5, manual=IM.on_off.Manual.UP)
+        data = mdev.template_data_remote(5, manual=IM.on_off.Manual.UP)
         right = {"address" : addr.hex, "name" : name, "button" : 5,
                  "manual_str" : "up", "manual" : 1, "manual_openhab" : 2}
         assert data == right

--- a/tests/util/helpers/main.py
+++ b/tests/util/helpers/main.py
@@ -27,6 +27,7 @@ class MockProtocol:
     """
     def __init__(self):
         self.signal_received = IM.Signal()
+        self.signal_msg_finished = IM.Signal()
         self.sent = []
 
     def clear(self):


### PR DESCRIPTION
Messages are queued until the next time the device sends a message.  At that point it attempts to send the message to the device.

This also adds an "awake" call to the command line and mqtt interface.  This can be used to mark a device as awake for 3 minutes.  This can be used if you press and hold the set button.  All queued messages and any further messages will be sent to the device for those three minutes.

This also cleans up our code a bit.  We were a bit sloppy with sometimes calling Protocol.Send and sometimes Device.Send.  This moves everything to Device.Send when applicable.  It also makes all battery devices children of the BatterySensor class.

This adds a signal to the Protocol class that emits when a write_msg is msg.FINISHED and has been removed from the _write_queue.  This enables the battery class to listen to this signal for ACK, NAK or even DIRECT (if they are part of device handler such as an extended response from a db get) messages from the device.  Upon seeing a message from this device the battery class pops another message from the _send_queue.

I also found a but in the DeviceRefresh handler that probably would only ever come up if used with this feature, which has also been fixed.

- [x] Linters passed
- [x] Tests passed
- [x] Documentation Updated
- [x] Command interfaces added
- [x] Tested on my machine
- [x] Tested with devices that respond

This works with my mini_remotes and leak sensors.  I suspect it works with my newer motion sensor too.  However, older motion sensors, and door sensors don't seem to remain awake at all.  So they require using the 'awake' process.

This fixes #31 and is a prerequisite for a few other requested features.