### PR TITLE
Fix Ambient Temp Calculation in Thermo; Add More Documentation

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -1104,4 +1104,23 @@ Sample Configuration:
   cool_sp_payload: '{ "temp_f" : {{value}} }'
   ```
 
+### Polling
+
+If the 'pair' command has been run correctly, the thermostat should push
+ambient temp, setpoint temps, humdity, and status message automatically.
+However if you want, you can poll the device for the status of these values
+as well by running 'get_status'.  This command will also get the units (C or F)
+specified on the device, which is necessary for properly decoding some of the
+temp messages from the device.  This command is also run as part of a 'refresh'.
+So if you are seeing strange temperatures, try running this command or 'refresh'
+
+Topic:
+  ```
+  insteon/command/aa.bb.cc
+  ```
+
+Payload:
+  ```
+  { "cmd" : "get_status"}
+  ```
 ---

--- a/insteon_mqtt/handler/ThermostatCmd.py
+++ b/insteon_mqtt/handler/ThermostatCmd.py
@@ -84,7 +84,8 @@ class ThermostatCmd(Base):
 
         # Pull out and process the commands that this handler handles
         if msg.cmd1 == STATUS_TEMP:
-            temp = int(msg.cmd2)
+            # Temperature is 2x presumably for resolution
+            temp = int(msg.cmd2) / 2
             if self.device.units == self.device.FARENHEIT:
                 temp = (temp - 32) * 5 / 9
             self.device.signal_ambient_temp_change.emit(self.device, temp)


### PR DESCRIPTION
Fixes TD22057\#142

Ambient Temp push messages are in 2x format.

Add get_status to normal refresh commands.  Ensures that we have
the proper units (C or F) set.  Otherwise we may misinterpret
temp messages.

Add more documentation to try and make things easier to understand.