### PR TITLE
Check the Remote Battery Periodically and Report to Low Battery Topic

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,11 @@
      manually awaken via holding the set button.  This will cause all queued
      and future messages to be sent to the device for up to three minutes
 
+- Added support for querying the battery on a mini-remote.  The battery state
+  will be automatically queried when the device wakes up if is has been 4 days
+  since the last battery check and will emit messages on the low_battery
+  topic. ([PR 244][P244])
+
 - Added support for Smartenit EZIO4O 4 relay output module (thanks @embak)
   ([PR 219][P219])
 
@@ -442,3 +447,4 @@ will add new features.
 [P248]: https://github.com/TD22057/insteon-mqtt/pull/248
 [P219]: https://github.com/TD22057/insteon-mqtt/pull/219
 [P239]: https://github.com/TD22057/insteon-mqtt/pull/239
+[P244]: https://github.com/TD22057/insteon-mqtt/pull/244

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -324,4 +324,14 @@ def awake(args, config):
 
     reply = util.send(config, topic, payload, args.quiet)
     return reply["status"]
+
+#===========================================================================
+def get_battery_voltage(args, config):
+    topic = "%s/%s" % (args.topic, args.address)
+    payload = {
+        "cmd" : "get_battery_voltage",
+        }
+
+    reply = util.send(config, topic, payload, args.quiet)
+    return reply["status"]
 #===========================================================================

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -395,6 +395,17 @@ def parse_args(args):
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=device.awake)
 
+    #---------------------------------------
+    # device.get_battery_voltage
+    # Only works on some battery devices
+    sp = sub.add_parser("get-battery-voltage", help="Check the battery "
+                        "voltage.  Will request the value the nex time the "
+                        "device is awake.")
+    sp.add_argument("address", help="Device address or name.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=device.get_battery_voltage)
+
     return p.parse_args(args)
 
 

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -66,7 +66,7 @@ class Device:
         dev_cat = data.get('dev_cat', None)
         sub_cat = data.get('sub_cat', None)
         obj.desc = None
-        if dev_cat:
+        if dev_cat is not None:
             obj.desc = catalog.find(dev_cat, sub_cat)
 
         obj.firmware = data.get('firmware', None)

--- a/insteon_mqtt/device/Remote.py
+++ b/insteon_mqtt/device/Remote.py
@@ -3,6 +3,7 @@
 # Remote module
 #
 #===========================================================================
+import time
 from .BatterySensor import BatterySensor
 from ..CommandSeq import CommandSeq
 from .. import log
@@ -40,6 +41,18 @@ class Remote(BatterySensor):
       device starts or stops manual mode (when a button is held down or
       released).
     """
+    # This defines what is the minimum time between battery status requests
+    # for devices that support it.  Value is in seconds
+    # Currently set at 4 Days
+    BATTERY_TIME = (60 * 60) * 24 * 4
+
+    # Voltages below this value will report as low
+    # Full charge value looks to be 3.7v which make sense for Li-Ion
+    # It is hard to say what a good number is here.  Using recommendations from
+    # https://learn.adafruit.com/li-ion-and-lipoly-batteries/voltages
+    # I also tried to drain the battery of one of my devices
+    BATTERY_VOLTAGE_LOW = 3.4
+
     def __init__(self, protocol, modem, address, name, num_button):
         """Constructor
 
@@ -76,25 +89,31 @@ class Remote(BatterySensor):
             'get_battery_voltage' : self.get_extended_flags,
             })
 
+        # This allows for a short timer between sending automatic battery
+        # requests.  Otherwise, a request may get queued multiple times
+        self._battery_request_time = 0
+
     #-----------------------------------------------------------------------
     @property
-    def battery_voltage(self):
-        """Returns the battery voltage from the saved metadata
+    def battery_voltage_time(self):
+        """Returns the timestamp of the last battery voltage report from the
+        saved metadata
         """
         meta = self.db.get_meta('Remote')
-        ret = 3.7  # the full battery voltage is 3.7v
-        if isinstance(meta, dict) and 'battery_voltage' in meta:
-            ret = meta['battery_voltage']
+        ret = 0
+        if isinstance(meta, dict) and 'battery_voltage_time' in meta:
+            ret = meta['battery_voltage_time']
         return ret
 
     #-----------------------------------------------------------------------
-    @battery_voltage.setter
-    def battery_voltage(self, val):
-        """Saves battery voltage to the database metadata
+    @battery_voltage_time.setter
+    def battery_voltage_time(self, val):
+        """Saves the timestamp of the last battery voltage report to the
+        database metadata
         Args:
-          val:    (float) 0-3.7
+          val:    (timestamp) time.time() value
         """
-        meta = {'battery_voltage': val}
+        meta = {'battery_voltage_time': val}
         existing = self.db.get_meta('Remote')
         if isinstance(existing, dict):
             existing.update(meta)
@@ -156,10 +175,15 @@ class Remote(BatterySensor):
 
         Primarily this is used to get the battery voltage
         """
-        self.battery_voltage = msg.data[10] / 50
+        # D10 voltage in tenth position, but remember starts at 0
+        batt_volt = msg.data[9] / 50
         LOG.info("Remote %s battery voltage is %s", self.label,
-                 self.battery_voltage)
-        on_done(True, "Operation complete", msg.data[10])
+                 batt_volt)
+        self.battery_voltage_time = time.time()
+        # Signal low battery
+        self.signal_low_battery.emit(self,
+                                     batt_volt <= self.BATTERY_VOLTAGE_LOW)
+        on_done(True, "Battery voltage is %s" % batt_volt, msg.data[9])
 
     #-----------------------------------------------------------------------
     def handle_button(self, msg):
@@ -289,5 +313,45 @@ class Remote(BatterySensor):
                                                   self.handle_extended_flags,
                                                   on_done=on_done)
         self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def auto_check_battery(self):
+        """Queues a Battery Voltage Request if Necessary
+
+        If the device supports it, and the requisite amount of time has
+        elapsed, queue a battery request.
+        """
+        if (self.db.desc is not None and
+                self.db.desc.model.split("-")[0] == "2342"):
+            # This is a device that supports battery requests
+            last_checked = self.battery_voltage_time
+            # Don't send this message more than once every 5 minutes no
+            # matter what
+            if (last_checked + self.BATTERY_TIME <= time.time() and
+                    self._battery_request_time + 300 <= time.time()):
+                self._battery_request_time = time.time()
+                LOG.info("Remote %s: Auto requesting battery voltage",
+                         self.label)
+                self.get_extended_flags(None)
+
+    #-----------------------------------------------------------------------
+    def awake(self, on_done):
+        """Injects a Battery Voltage Request if Necessary
+
+        Queue a battery request that should go out now, since the device is
+        awake.
+        """
+        self.auto_check_battery()
+        super().awake(on_done)
+
+    #-----------------------------------------------------------------------
+    def _pop_send_queue(self):
+        """Injects a Battery Voltage Request if Necessary
+
+        Queue a battery request that should go out now, since the device is
+        awake.
+        """
+        self.auto_check_battery()
+        super()._pop_send_queue()
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/Remote.py
+++ b/insteon_mqtt/device/Remote.py
@@ -278,7 +278,7 @@ class Remote(BatterySensor):
         return [data_1, data_2, data_3]
 
     #-----------------------------------------------------------------------
-    def get_extended_flags(self):
+    def get_extended_flags(self, on_done):
         """Requests the Extended Flags from the Device
 
         Notably, these flags contain the battery voltage.
@@ -286,7 +286,8 @@ class Remote(BatterySensor):
         data = bytes([0x01] + [0x00] * 13)
         msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
         msg_handler = handler.ExtendedCmdResponse(msg,
-                                                  self.handle_extended_flags)
+                                                  self.handle_extended_flags,
+                                                  on_done=on_done)
         self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------


### PR DESCRIPTION
This requires merging #240 first.

This is a new feature which will check the battery level for 2342-xxx remotes at most once every 4 days.  The device is generally asleep, so the message is sent just after receiving a message from the device when it is awake.  This means you will not get battery warnings from devices that you do not use.

If the battery voltage is low, a message will be emitted to the Low_Battery topic.

- [x] Linting passes
- [x] Unit tests were updated and pass
- [x] Documentation was updated
- [x] Command line functions were added
- [x] Works well in a test environment, attempting to drain the battery on a remote, but actually testing would take a while

Closes #49
