### PR TITLE
Increment Database Delta on Writing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,7 +16,7 @@
   - [MQTT Doc](https://github.com/TD22057/insteon-mqtt/blob/master/docs/mqtt.md) -
     note the new set_flags options for IOLinc and the IOLinc section
 
- - A new queueing system for battery devices ([PR240][P240]):
+- A new queueing system for battery devices ([PR240][P240]):
    - Messages sent to the device will be queued until the device is awake
    - When the device sends a message, the modem will attempt to immediately
      send the oldest outgoing message.  This only works for some devices.
@@ -25,6 +25,10 @@
      and future messages to be sent to the device for up to three minutes
 
 ### Fixes
+
+- Database delta is updated on database writes.  This eliminates a number of
+  unnecessary refresh requirements, particularly around pairing.  
+  ([PR 248][P248])
 
 ## [0.7.3]
 
@@ -429,3 +433,4 @@ will add new features.
 [P237]: https://github.com/TD22057/insteon-mqtt/pull/227
 [P197]: https://github.com/TD22057/insteon-mqtt/pull/197
 [P240]: https://github.com/TD22057/insteon-mqtt/pull/240
+[P248]: https://github.com/TD22057/insteon-mqtt/pull/248

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -184,6 +184,7 @@ class Device:
         """
         self.delta = delta
         if delta is not None:
+            self.delta = self.delta % 256  # Roll over db if it goes past 256
             self.save()
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/db/DeviceModifyManagerI1.py
+++ b/insteon_mqtt/db/DeviceModifyManagerI1.py
@@ -152,6 +152,22 @@ class DeviceModifyManagerI1:
             self.advance_lsb(on_done)
 
     #-------------------------------------------------------------------
+    def handle_lsb_write_response(self, msg, on_done):
+        """Handle Write of LSB
+
+        This is only used to increment the delta for this device.
+
+        Args:
+          msg:     (message.InpStandard) The lsb message reply.  The lsb data
+                   is in the msg.cmd2 field.
+          on_done: (callback) a callback that is passed around and run on the
+                   completion of the modification
+        """
+        # Increment the delta 1
+        self.db.set_delta(self.db.delta + 1)
+        self.handle_lsb_response(self, msg, on_done)
+
+    #-------------------------------------------------------------------
     def write_lsb_byte(self, on_done):
         """Writes the next byte in the record to the device.
 
@@ -165,7 +181,7 @@ class DeviceModifyManagerI1:
         db_msg = Msg.OutStandard.direct(self.db.addr, 0x29,
                                         self.record[self.record_index])
         msg_handler = handler.StandardCmd(db_msg,
-                                          self.handle_lsb_response,
+                                          self.handle_lsb_write_response,
                                           on_done=on_done,
                                           num_retry=self._num_retry)
         self.device.send(db_msg, msg_handler)

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -72,6 +72,8 @@ class DeviceDbModify(Base):
                     # entry, or an marked unused (deletion).
                     LOG.info("Updating entry: %s", self.entry)
                     self.db.add_entry(self.entry)
+                    # Increment the delta 1
+                    self.db.set_delta(self.db.delta + 1)
                     self.on_done(True, "Device database update complete",
                                  self.entry)
 


### PR DESCRIPTION
This should dramatically decrease the number of full refreshes of a device and should speed things up.

- [x] Linters passed
- [x] pytests passed
- [x] no documentation necessary
- [x] test in production

My recollection is that there may be a few other instances in which i1 devices increment this value.  But I think those are all related to peek/poke operations.  I don't think set_flags should cause this to change.

Closes #232 