### PR TITLE
Last Entry Can be Used

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,9 @@
 
 ### Fixes
 
+- Allow for used last entries in DB.  Improve compatibility with devices
+  setup by ISY.  ([PR 255][P255])
+
 - Improved message handling and processing of Pre_NAK messages.
   ([PR 236][P236])
 
@@ -469,3 +472,4 @@ will add new features.
 [P259]: https://github.com/TD22057/insteon-mqtt/pull/259
 [P234]: https://github.com/TD22057/insteon-mqtt/pull/234
 [P236]: https://github.com/TD22057/insteon-mqtt/pull/236
+[P255]: https://github.com/TD22057/insteon-mqtt/pull/255

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -787,9 +787,12 @@ class Device:
 
         seq = CommandSeq(self.device, "Device database update complete", on_done)
 
-        # Shift the current last record down 8 bytes.  Make a copy - we'll
-        # only update our member var if the write works.
-        last = self.last.copy()
+        # Write the new last entry as all 00 which is how it appears on
+        # factory reset
+        flags = Msg.DbFlags(in_use=False, is_controller=False,
+                            is_last_rec=True)
+        last = DeviceEntry(Address(0, 0, 0), 0, self.last.mem_loc, flags,
+                           None, db=self)
         last.mem_loc -= 0x08
 
         # Start by writing the last record - that way if it fails, we don't

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -370,8 +370,8 @@ class Device:
             on_done(True, "Entry already exists", entry)
             return
 
-        LOG.info("Device %s adding db: %s grp %s %s %s", self.addr, addr,
-                 group, util.ctrl_str(is_controller), data)
+        LOG.info("Device %s adding db: %s grp %s %s D: %s", self.addr, addr,
+                 group, util.ctrl_str(is_controller), data.hex())
 
         # If there are entries in the db that are mark unused, we can re-use
         # those memory addresses and just update them w/ the correct


### PR DESCRIPTION
Fix the database object to reflect the possibility that the last entry may not be an unused entry.

If the last entry is used, when adding entries to new memory locations, add an additional blank unused entry so that the last entry is unused.

Not exactly what the original issue was opened about, but this was the result of the review.

Closes #250