### PR TITLE
Parse, report and delay on receiving a PLM Busy Signal

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,7 +14,9 @@
 
 - Don't treat broadcast messages from different groups as duplicate.  Fixes
   a bug where sequential presses of a button on a keypadlinc may not emit
-  mqtt messages as they should.  ([PR 256][P256])
+  mqtt messages as they should.  (thanks @tstabrawa)([PR 256][P256])
+
+- Catch and delay on PLM reporting busy. ([PR 261][P261])
 
 ## [0.7.4]
 
@@ -478,3 +480,4 @@ will add new features.
 [P236]: https://github.com/TD22057/insteon-mqtt/pull/236
 [P255]: https://github.com/TD22057/insteon-mqtt/pull/255
 [P256]: https://github.com/TD22057/insteon-mqtt/pull/256
+[P261]: https://github.com/TD22057/insteon-mqtt/pull/261

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -299,6 +299,17 @@ class Protocol:
             #LOG.debug("Searching message (len %d): %s... ",
             #               len(self._buf), util.to_hex(self._buf,20))
 
+            # Look for PLM slow down messages
+            start = self._buf.find(0x15)
+            if start == 0:
+                LOG.info("PLM is busy, pausing briefly")
+                # Pause for 1/3 of a second if we are not already waiting
+                # longer
+                if self._next_write_time + .3 < time.time():
+                    self._next_write_time = time.time() + .3
+                self._buf = self._buf[1:]
+                continue
+
             # Find a message start token.  Note that this token could also
             # appear in the middle of a message so we can't be totally sure
             # it's a message until we try to parse it.  If there is no


### PR DESCRIPTION
These are rare since we do a good job with our message timings but I think they are still happening for some people.  Right now when they happen they most likely get reported as lacking a 0x02 starting byte.

This adds a brief delay if one doesn't already exist and reports the info message to the log.