### PR TITLE
Add Platform for Integration Testing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 ### Additions
 
+- More pyTests, up to 66% coverage now. ([PR 262][P262] & [PR 268][P268])
+
 ### Fixes
 
 - Allow for used last entries in DB.  Improve compatibility with devices
@@ -481,3 +483,5 @@ will add new features.
 [P255]: https://github.com/TD22057/insteon-mqtt/pull/255
 [P256]: https://github.com/TD22057/insteon-mqtt/pull/256
 [P261]: https://github.com/TD22057/insteon-mqtt/pull/261
+[P262]: https://github.com/TD22057/insteon-mqtt/pull/262
+[P268]: https://github.com/TD22057/insteon-mqtt/pull/268

--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,7 @@ insteon:
 
     # Dimming devices (outlets, wall switches, lamp modules, etc).
     dimmer:
-      - 3a.29.84: 'lamp2'
+      - 12.29.84: 'lamp2'
       - 48.3d.46
       - 48.b0.ad: 'dim1'
 
@@ -86,8 +86,10 @@ insteon:
 
     # Battery powered mini remotes.
     mini_remote1:  # Single Button Remotes
+      - 12.34.56: 'remote switch'
 
     mini_remote4:  # Remotes with 4 Buttons
+      - 3f.12.d4: 'remote4'
 
     mini_remote8:  # Remotes with 8 Buttons
       - 3f.07.d4: 'remote1'
@@ -97,8 +99,8 @@ insteon:
       - 44.a3.79: 'smoke alarm'
 
     # FanLinc fan controller (dimmer+fan).
-    #fan_linc:
-    #  - 9a.a1.b3
+    fan_linc:
+     - 9a.a1.b3
 
     # KeypadLinc dimmers (dimmer+scene controller).
     keypad_linc:
@@ -109,24 +111,24 @@ insteon:
       - 3c.42.9b: 'kp2'
 
     # Leak sensors.
-    #leak:
-    #  - 21.d6.d9: 'bathroom'
+    leak:
+     - 21.d8.d9: 'bathroom'
 
     # IOLinc relay controllers
     io_linc:
       - 45.33.d4: 'garage'
 
     # On/off ouetlets
-    #outlet:
-    #  - aa.bb.cc: 'outlet'
+    outlet:
+     - aa.11.cc: 'outlet'
 
     # Thermostatus
     thermostat:
-    #  - aa.bb.cc: 'downstairs'
+     - aa.bb.cc: 'downstairs'
 
     # EZIO4O 4 output relay modules
-    #ezio4o:
-    #  - aa.bb.cc: 'relays'
+    ezio4o:
+     - 22.bb.cc: 'relays'
 
 #==========================================================================
 #

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -24,11 +24,14 @@ base directory
 """
 from unittest.mock import patch
 import pytest
+import json
 import insteon_mqtt as IM
 
 
-def test_set_on_roundtrip(stack):
-    # Send on using the set topic
+def test_set_on_functions(stack):
+    #-----------------------
+    # Test the on command
+    # Send on using the set topic, 3a.29.84 is a switch
     stack.publish_to_mqtt('insteon/3a.29.84/set', 'on')
     # Test resulting PLM message
     assert stack.written_msgs[0] == '02623a29840f11ff'
@@ -36,8 +39,20 @@ def test_set_on_roundtrip(stack):
     stack.write_to_modem('02623a29840f11ff06')
     # Return the device ACK
     stack.write_to_modem('02503a298441eee62b11ff')
-    assert (stack.published_topics['insteon/3a.29.84/state'] ==
-            '{ "state" : "ON", "brightness" : 255 }')
+    assert stack.published_topics['insteon/3a.29.84/state'] == 'ON'
+
+    #-----------------------
+    # Test the level command
+    payload = json.dumps({"state" : 'ON', "brightness" : 127})
+    stack.publish_to_mqtt('insteon/12.29.84/level', payload)
+    # Test resulting PLM message
+    assert stack.written_msgs[1] == '02621229840f117f'
+    # Return PLM ACK
+    stack.write_to_modem('02621229840f117f06')
+    # Return the device ACK   1229840f117f06
+    stack.write_to_modem('025012298441eee62b117f')
+    assert (stack.published_topics['insteon/12.29.84/state'] ==
+            '{ "state" : "ON", "brightness" : 127 }')
 
 
 # ===============================================================

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -25,6 +25,7 @@ base directory
 from unittest.mock import patch
 import pytest
 import json
+from insteon_mqtt import log
 import insteon_mqtt as IM
 
 
@@ -76,6 +77,7 @@ class Patch_Stack():
         @patch('insteon_mqtt.config.apply', self._config_apply)
         @patch('sys.argv', ["", "config.yaml", "start"])
         @patch.object(IM.network.Manager, 'active', return_value=False)
+        @patch.object(log, 'initialize')
         def start(*args):
             IM.cmd_line.main()
             # Signal the mqtt link as connected

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -1,0 +1,131 @@
+#===========================================================================
+#
+# Tests for: Integration of Insteon-Mqtt
+#
+# pylint: disable=attribute-defined-outside-init
+#===========================================================================
+# This enables testing of the vast majority of the stack.
+# In order to work, this does not call the loop.select loop.  So anything
+# inside that loop will not be tested.  Similarly the management of the
+# network links is also not tested, such as connection issues.  Links will
+# not be polled unless you do that yourself.
+#
+# However, you can simulate an mqtt command and test the resulting message
+# that would be written to the PLM.  You can also simulate a write to the PLM
+# and test what mqtt messages would be emitted, or what PLM messages are
+# sent in response
+
+import time
+# from unittest import mock
+# from unittest.mock import call
+from unittest.mock import patch
+# import pytest
+import functools
+import insteon_mqtt as IM
+
+published_topics = {}
+subscribed_topics = {}
+written_msgs = []
+plm_link = None
+insteon = None
+
+def patch_insteon_mqtt(args, cfg):
+    """A lightly modified start command
+
+    Mainly removes the loop of loop.select()
+    Also signals a connection of the mqtt client
+    """
+    global plm_link, insteon
+
+    # Always log to the screen if a file isn't active.
+    if not args.log:
+        args.log_screen = True
+
+    # Initialize the logging system either using the command line
+    # inputs or the config file.  If these vars are None, then the
+    # config file logging data is used.
+    IM.log.initialize(args.level, args.log_screen, args.log, config=cfg)
+
+    # Create the network event loop and MQTT and serial modem clients.
+    loop = IM.network.Manager()
+    mqtt_link = IM.network.Mqtt()
+    plm_link = IM.network.Serial()
+    stack_link = IM.network.Stack()
+    timed_link = IM.network.TimedCall()
+
+    # Add the clients to the event loop.
+    loop.add(mqtt_link, connected=False)
+    loop.add(plm_link, connected=False)
+    loop.add_poll(stack_link)
+    loop.add_poll(timed_link)
+
+    # Create the insteon message protocol, modem, and MQTT handler and
+    # link them together.
+    insteon = IM.Protocol(plm_link)
+    modem = IM.Modem(insteon, stack_link, timed_link)
+    mqtt_handler = IM.mqtt.Mqtt(mqtt_link, modem)
+
+    # Load the configuration data into the objects.
+    IM.config.apply(cfg, mqtt_handler, modem)
+
+    # Signal the mqtt link as connected
+    # Ths causes the device mqtt objects to subscribe to topics
+    mqtt_link.signal_connected.emit(mqtt_link, True)
+
+def serial_write(self, msg_bytes, next_write_time):
+    # This captures the messages sent out to the PLM
+    written_msgs.append(msg_bytes)
+
+def mqtt_subscribe(self, topic, qos=0, callback=None):
+    # This captures the calls to subscribe to topics
+    subscribed_topics[topic] = callback
+
+def mqtt_publish(self, topic, payload, qos=0, retain=False):
+    published_topics[topic] = payload
+
+def serial_read(data):
+    plm_link.signal_read.emit(plm_link, data)
+
+class mqtt_msg():
+    # Used to simulate mqtt messages
+    def __init__(self, topic, payload):
+        self.topic = topic
+        self.payload = payload.encode(encoding='UTF-8')
+        self.qos = 0
+        self.retain = False
+
+def patch_all(f):
+    """Gathers all of our patches to make them easily reusable
+
+    Use the @path_all decorator to call them
+    """
+    @patch('sys.argv', ["", "config.yaml", "start"])
+    @patch('insteon_mqtt.cmd_line.start.start', patch_insteon_mqtt)
+    @patch('insteon_mqtt.network.Mqtt.subscribe', mqtt_subscribe)
+    @patch('insteon_mqtt.network.Mqtt.publish', mqtt_publish)
+    @patch('insteon_mqtt.network.Serial.write', serial_write)
+    @functools.wraps(f)
+    def functor(*args, **kwargs):
+        return f(*args, **kwargs)
+    return functor
+
+def start_insteon_mqtt():
+    IM.cmd_line.main()
+
+@patch_all
+def test_set_on_roundtrip():
+    start_insteon_mqtt()
+    # Send on using the set topic
+    msg = mqtt_msg('insteon/3a.29.84/set', 'on')
+    subscribed_topics['insteon/3a.29.84/set'](None, None, msg)
+    # Test resulting PLM message
+    assert written_msgs[0].hex() == '02623a29840f11ff'
+    # Return PLM ACK
+    serial_read(bytes.fromhex('02623a29840f11ff06'))
+    # Return the device ACK
+    serial_read(bytes.fromhex('02503a298441eee62b11ff'))
+    assert published_topics['insteon/3a.29.84/state'] == '{ "state" : "ON", "brightness" : 255 }'
+
+
+        # Test PLM Busy
+        # serial_read(bytes.fromhex('15'))

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -31,7 +31,7 @@ def test_set_on_roundtrip(stack):
     # Send on using the set topic
     stack.publish_to_mqtt('insteon/3a.29.84/set', 'on')
     # Test resulting PLM message
-    assert stack.written_msgs[0].hex() == '02623a29840f11ff'
+    assert stack.written_msgs[0] == '02623a29840f11ff'
     # Return PLM ACK
     stack.write_to_modem('02623a29840f11ff06')
     # Return the device ACK
@@ -47,7 +47,8 @@ def stack():
 
 class Patch_Stack():
     def __init__(self):
-        # Contains an array of all messages sent by the modem
+        # Contains an array of all messages sent by the modem messages are
+        # stored as strings with hexadecimal characters
         self.written_msgs = []
         # Contains a dictionary of the most recent messages sent to each
         # topic, wherein the keys are the topic names
@@ -97,7 +98,7 @@ class Patch_Stack():
 
     def _modem_out(self, msg_bytes, next_write_time):
         # This captures the messages sent out to the PLM
-        self.written_msgs.append(msg_bytes)
+        self.written_msgs.append(msg_bytes.hex())
 
     def write_to_modem(self, data):
         """Simulate the modem receiving a message

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -15,6 +15,12 @@ messages sent to the mqtt server or modem.
 
 Tests can be performed on stack.written_msgs and stack.published_topics
 
+Each test function will create and tear down a full stack fixture.  So use
+sparingly to decrease testing times.
+
+The test devices are created from the sample config.yaml file included in the
+base directory
+
 """
 from unittest.mock import patch
 import pytest


### PR DESCRIPTION
I don't have a lot of experience with pytest and mocking.  So this may be a little bit crude.

I managed to patch enough of the entire stack to enable testing of integration from pushing an mqtt message and testing the resulting message written by the modem.  Similarly the inverse is also possible you can write a modem message and test the resulting mqtt output.  The state machine inside the program is running during all of this, so a sequence of messages can also be sent and the results tested.

Unit testing is still undoubtedly the way to go as it is much more precise and focused.  But there have been times that I would have liked to been able to test in this fashion since I am often reverse engineering from insteon messages.

At the moment, there are only two tests performed here.
