### PR TITLE
Tweak Logging Levels and Messages

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,8 @@
 
 - Catch and delay on PLM reporting busy. ([PR 261][P261])
 
+- Tweak some of the logging to be more clear for users. ([PR 272][P272])
+
 ## [0.7.4]
 
 ### Additions
@@ -485,3 +487,4 @@ will add new features.
 [P261]: https://github.com/TD22057/insteon-mqtt/pull/261
 [P262]: https://github.com/TD22057/insteon-mqtt/pull/262
 [P268]: https://github.com/TD22057/insteon-mqtt/pull/268
+[P272]: https://github.com/TD22057/insteon-mqtt/pull/272

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -1036,8 +1036,8 @@ class Modem:
                          device.addr, group)
                 device.handle_group_cmd(self.addr, msg)
             else:
-                LOG.warning("%s broadcast - device %s not found", self.label,
-                            elem.addr)
+                LOG.info("%s broadcast - device %s not found in config",
+                         self.label, elem.addr)
 
     #-----------------------------------------------------------------------
     def run_command(self, **kwargs):

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -467,8 +467,9 @@ class Protocol:
         # No handler was found for the message.  Shift pass the ID code and
         # look for more messages.  This might be better by having a lookup by
         # msg ID->msg size and use that to skip the whole message.
-        LOG.warning("No read handler found for message type %#04x: %s",
-                    msg.msg_code, msg)
+        # This was likely a dublicate message
+        LOG.info("No read handler found for message type %#04x: %s",
+                 msg.msg_code, msg)
 
     #-----------------------------------------------------------------------
     def _write_finished(self):

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -202,12 +202,6 @@ def pair(args, config):
         }
 
     reply = util.send(config, topic, payload, args.quiet)
-
-    if reply["status"]:
-        print("Pairing may fail if the modem db is out of date.  Try running")
-        print("the following and then re-try the pair command.")
-        print("   insteon-mqtt config.py refresh modem")
-
     return reply["status"]
 
 

--- a/insteon_mqtt/cmd_line/util.py
+++ b/insteon_mqtt/cmd_line/util.py
@@ -12,7 +12,7 @@ from ..mqtt import Reply
 # Time between messages before we decide that the something went wrong and
 # stop.  Currently the server should send enough messages to avoid this but
 # there is no pure right answer for what this should be.
-TIME_OUT = 10
+TIME_OUT = 30
 
 
 #===========================================================================
@@ -70,7 +70,8 @@ def send(config, topic, payload, quiet=False):
         client.loop(timeout=0.5)
 
     if not session["done"]:
-        print("Reply timed out")
+        print("Command line timed out waiting for a reply, the command may " +
+              "still be running.")
 
     client.disconnect()
     return session

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -362,7 +362,7 @@ class Device:
 
         # Otherwise, we don't need to do anything - the entry exists.
         elif entry:
-            LOG.warning("Device %s add db already exists for %s grp %s %s",
+            LOG.info("Device %s add db already exists for %s grp %s %s",
                         self.addr, addr, group, util.ctrl_str(is_controller))
             on_done(True, "Entry already exists", entry)
             return

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -290,8 +290,8 @@ class Modem:
         if exists:
             if exists.data == entry.data:
                 LOG.info("Modem add db already exists for %s grp %s %s",
-                            entry.addr, entry.group,
-                            util.ctrl_str(entry.is_controller))
+                         entry.addr, entry.group,
+                         util.ctrl_str(entry.is_controller))
                 if on_done:
                     on_done(True, "Entry already exists", exists)
                 return

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -289,7 +289,7 @@ class Modem:
         exists = self.find(entry.addr, entry.group, entry.is_controller)
         if exists:
             if exists.data == entry.data:
-                LOG.warning("Modem add db already exists for %s grp %s %s",
+                LOG.info("Modem add db already exists for %s grp %s %s",
                             entry.addr, entry.group,
                             util.ctrl_str(entry.is_controller))
                 if on_done:

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -1059,8 +1059,8 @@ class Base:
                          device.addr, group)
                 device.handle_group_cmd(self.addr, msg)
             else:
-                LOG.warning("%s broadcast - device %s not found", self.label,
-                            elem.addr)
+                LOG.info("%s broadcast - device %s is not in config.",
+                         self.label, elem.addr)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, msg):

--- a/insteon_mqtt/device/BatterySensor.py
+++ b/insteon_mqtt/device/BatterySensor.py
@@ -237,7 +237,7 @@ class BatterySensor(Base):
             if handler:
                 handler(msg)
             else:
-                LOG.error("BatterySensor no handler for group %s", msg.group)
+                LOG.warning("BatterySensor no handler for group %s", msg.group)
 
             # This will find all the devices we're the controller of for this
             # group and call their handle_group_cmd() methods to update their

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -293,7 +293,7 @@ class FanLinc(Dimmer):
         # message.  That's for actuators (switches, motion sensors, etc) to
         # trigger other things to occur.  Since the fan linc is just a
         # responder to other commands, that shouldn't occur.
-        LOG.error("FanLinc unexpected handle_broadcast called: %s", msg)
+        LOG.waring("FanLinc unexpected handle_broadcast called: %s", msg)
         super.handle_broadcast(msg)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/Base.py
+++ b/insteon_mqtt/handler/Base.py
@@ -107,8 +107,8 @@ class Base:
 
         # If we've exhausted the number of sends, end the handler.
         elif not self._msg or self._num_sent > self._num_retry:
-            LOG.warning("Handler timed out - no more retries (%s sent)",
-                        self._num_sent - 1)
+            LOG.error("Handler timed out - no more retries (%s sent)",
+                      self._num_sent - 1)
             self.handle_timeout(protocol)
             return True
 

--- a/insteon_mqtt/handler/ModemDbModify.py
+++ b/insteon_mqtt/handler/ModemDbModify.py
@@ -85,7 +85,8 @@ class ModemDbModify(Base):
         # If we get a NAK message, signal an error and stop.
         if not msg.is_ack:
             LOG.error("Modem db updated failed: %s", msg)
-            self.on_done(False, "Modem database update failed", self.entry)
+            self.on_done(False, "Write to Modem db failed, try running " +
+                         "`refresh modem`", self.entry)
             return Msg.FINISHED
 
         # ACK of a message to delete an existing entry


### PR DESCRIPTION
Warning messages will be outputted in the MQTT messages and the command line, so they should be true warnings that we expect all users to see.

Some of our warnings were more suited as info.

Also improved the text of a few warnings.

Finally increased the command time out now that we have potentially long timeouts on db_get.