### PR TITLE
Add Name to Command Sequence Log

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,7 +25,8 @@
 
 - Catch and delay on PLM reporting busy. ([PR 261][P261])
 
-- Tweak some of the logging to be more clear for users. ([PR 272][P272])
+- Tweak some of the logging to be more clear for users. ([PR 272][P272] &
+  [PR 275][P275])
 
 ## [0.7.4]
 
@@ -494,3 +495,4 @@ will add new features.
 [P268]: https://github.com/TD22057/insteon-mqtt/pull/268
 [P272]: https://github.com/TD22057/insteon-mqtt/pull/272
 [P201]: https://github.com/TD22057/insteon-mqtt/pull/201
+[P275]: https://github.com/TD22057/insteon-mqtt/pull/275

--- a/insteon_mqtt/CommandSeq.py
+++ b/insteon_mqtt/CommandSeq.py
@@ -27,7 +27,8 @@ class CommandSeq:
     this library needs, it works ok.
     """
     #-----------------------------------------------------------------------
-    def __init__(self, device, msg=None, on_done=None, error_stop=True):
+    def __init__(self, device, msg=None, on_done=None, error_stop=True,
+                 name=""):
         """Constructor
 
         Args:
@@ -37,6 +38,7 @@ class CommandSeq:
                    when there is an error or when all the commands finish.
           error_stop (bool): True to stop the sequence if a command fails.
                      False to continue on with the sequence.
+          name (str): A short name used in logging to identify this sequence
         """
         self.device = device
 
@@ -44,6 +46,7 @@ class CommandSeq:
         self.msg = msg
         self.error_stop = error_stop
         self.total = 0
+        self.name = name
 
         # List of Entry objects (see class below) to call for each step in
         # the sequence.
@@ -125,8 +128,8 @@ class CommandSeq:
 
         # Otherwise run the next command.
         else:
-            LOG.debug("Running command %d of %d", self.total + 1 -
-                      len(self.calls), self.total)
+            LOG.debug("CmdSeq %s Running %d of %d", self.name,
+                      self.total + 1 - len(self.calls), self.total)
 
             entry = self.calls.pop(0)
             entry.run(self.device, self.on_done)

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -340,7 +340,7 @@ class Modem:
         # Set the error stop to false so a failed refresh doesn't stop the
         # sequence from trying to refresh other devices.
         seq = CommandSeq(self, "Refresh all complete", on_done,
-                         error_stop=False)
+                         error_stop=False, name="RefreshAll")
 
         # Reload the modem database.
         seq.add(self.refresh, force)
@@ -375,7 +375,7 @@ class Modem:
         # Set the error stop to false so a failed refresh doesn't stop the
         # sequence from trying to refresh other devices.
         seq = CommandSeq(self, "Get Engine all complete", on_done,
-                         error_stop=False)
+                         error_stop=False, name="EngineAll")
 
         # Reload all the device databases.
         for device in self.devices.values():
@@ -671,7 +671,7 @@ class Modem:
             seq = sequence
         else:
             seq = CommandSeq(self, "Sync complete", on_done,
-                             error_stop=False)
+                             error_stop=False, name="ModemSync")
 
         if refresh:
             LOG.ui("Performing DB Refresh of %s device", self.label)
@@ -736,7 +736,7 @@ class Modem:
         # Set the error stop to false so a failed refresh doesn't stop the
         # sequence from trying to refresh other devices.
         seq = CommandSeq(self, "Sync All complete", on_done,
-                         error_stop=False)
+                         error_stop=False, name="SyncAll")
 
         # First the modem database.
         seq.add(self.sync, dry_run=dry_run, refresh=refresh)
@@ -1165,7 +1165,8 @@ class Modem:
         # discussion.
         local_data = self.link_data(is_controller, local_group, local_data)
 
-        seq = CommandSeq(self, "Device db update complete", on_done)
+        seq = CommandSeq(self, "Device db update complete", on_done,
+                         name="ModemDBUpd")
 
         # Create a new database entry for the modem and send it to the modem
         # for updating.
@@ -1223,7 +1224,7 @@ class Modem:
             return
 
         # Add the function delete call to the sequence.
-        seq = CommandSeq(self, "Delete complete", on_done)
+        seq = CommandSeq(self, "Delete complete", on_done, name="ModemDBDel")
         seq.add(self.db.delete_on_device, entry)
 
         # For two way commands, insert a callback so that when the modem

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -784,7 +784,7 @@ class Device:
         # pylint: disable=too-many-locals
 
         seq = CommandSeq(self.device, "Device database update complete",
-                         on_done)
+                         on_done, name="DbAddNew")
 
         last_mem_loc = self.last.mem_loc
 

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -268,7 +268,7 @@ class Base:
         LOG.info("Join Device %s", self.addr)
 
         # Using a sequence so we can pass the on_done function through.
-        seq = CommandSeq(self, "Device joined.", on_done)
+        seq = CommandSeq(self, "Device joined.", on_done, name="JoinSequence")
 
         # First get the engine version.  This process only works and is
         # necessary on I2CS devices.
@@ -299,7 +299,7 @@ class Base:
             return
         else:
             # Build a sequence of calls to do the link.
-            seq = CommandSeq(self, "Operation Complete", on_done)
+            seq = CommandSeq(self, "Join Complete", on_done, name="JoinDevice")
 
             # Put Modem in linking mode first
             seq.add(self.modem.linking)
@@ -377,7 +377,8 @@ class Base:
         LOG.info("Device %s cmd: status refresh", self.label)
 
         # Use a sequence
-        seq = CommandSeq(self, "Device refreshed", on_done)
+        seq = CommandSeq(self, "Device refreshed", on_done,
+                         name="DeviceRefresh")
 
         # This sends a refresh ping which will respond w/ the current
         # database delta field.  The handler checks that against the
@@ -515,7 +516,7 @@ class Base:
             seq = sequence
         else:
             seq = CommandSeq(self, "Sync complete", on_done,
-                             error_stop=False)
+                             error_stop=False, name="DeviceSync")
 
         if refresh:
             LOG.ui("Performing DB Refresh of %s device", self.label)
@@ -1112,7 +1113,8 @@ class Base:
                    "Link will be only one direction",
                    util.ctrl_str(is_controller), remote_addr)
 
-        seq = CommandSeq(self, "Device db update complete", on_done)
+        seq = CommandSeq(self, "Device db update complete", on_done,
+                         name="DeviceDBUpdate")
 
         # Check for a db update - otherwise we could be out of date and not
         # know it in which case the memory addresses to add the record in
@@ -1176,7 +1178,7 @@ class Base:
             on_done(False, "Entry doesn't exist", None)
             return
 
-        seq = CommandSeq(self, "Delete complete", on_done)
+        seq = CommandSeq(self, "Delete complete", on_done, name="DeviceDBDel")
 
         # Check for a db update - otherwise we could be out of date and not
         # know it in which case the memory addresses to add the record in

--- a/insteon_mqtt/device/BatterySensor.py
+++ b/insteon_mqtt/device/BatterySensor.py
@@ -146,7 +146,7 @@ class BatterySensor(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "BatterySensor paired", on_done)
+        seq = CommandSeq(self, "BatterySensor paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -106,7 +106,7 @@ class Dimmer(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "Dimmer paired", on_done)
+        seq = CommandSeq(self, "Dimmer paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -588,7 +588,8 @@ class Dimmer(Base):
                             "are: %s" % unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
-        seq = CommandSeq(self, "Dimmer set_flags complete", on_done)
+        seq = CommandSeq(self, "Dimmer set_flags complete", on_done,
+                         name="SetFlags")
 
         if FLAG_BACKLIGHT in kwargs:
             backlight = util.input_byte(kwargs, FLAG_BACKLIGHT)

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -143,7 +143,8 @@ class EZIO4O(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self.protocol, "EZIO4O paired", on_done)
+        seq = CommandSeq(self.protocol, "EZIO4O paired", on_done,
+                         name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -189,7 +190,8 @@ class EZIO4O(Base):
         LOG.info("EZIO4O %s cmd: status refresh", self.label)
 
         # NOTE: EZIO4O cmd1=0x4F cmd2=0x02 will report the output state.
-        seq = CommandSeq(self.protocol, "Device refreshed", on_done)
+        seq = CommandSeq(self.protocol, "Device refreshed", on_done,
+                         name="DevRefresh")
 
         # This sends a refresh ping which will respond w/ the current
         # database delta field.  The handler checks that against the current

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -101,7 +101,7 @@ class FanLinc(Dimmer):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "FanLinc paired", on_done)
+        seq = CommandSeq(self, "FanLinc paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -147,7 +147,7 @@ class FanLinc(Dimmer):
         """
         LOG.info("Device %s cmd: fan status refresh", self.addr)
 
-        seq = CommandSeq(self, "Refresh complete", on_done)
+        seq = CommandSeq(self, "Refresh complete", on_done, name="DevRefresh")
 
         # Send a 0x19 0x03 command to get the fan speed level.  This sends a
         # refresh ping which will respond w/ the fan level and current

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -284,7 +284,7 @@ class IOLinc(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "IOLinc paired", on_done)
+        seq = CommandSeq(self, "IOLinc paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -323,7 +323,8 @@ class IOLinc(Base):
         """
         LOG.info("IOLinc %s cmd: get operation flags", self.label)
 
-        seq = CommandSeq(self.protocol, "IOlinc get flags done", on_done)
+        seq = CommandSeq(self.protocol, "IOlinc get flags done", on_done,
+                         name="GetFlags")
 
         # This sends a refresh ping which will respond w/ the current
         # database delta field.  The handler checks that against the
@@ -374,7 +375,8 @@ class IOLinc(Base):
             raise Exception("Unknown IOLinc flags input: %s.\n Valid flags " +
                             "are: %s" % unknown, flags)
 
-        seq = CommandSeq(self.protocol, "Device flags set", on_done)
+        seq = CommandSeq(self.protocol, "Device flags set", on_done,
+                         name="SetFLags")
 
         # Loop through flags, sending appropriate command for each flag
         for flag in kwargs:
@@ -501,7 +503,7 @@ class IOLinc(Base):
 
         # NOTE: IOLinc cmd1=0x00 will report the relay state.  cmd2=0x01
         # reports the sensor state which is what we want.
-        seq = CommandSeq(self, "Device refreshed", on_done)
+        seq = CommandSeq(self, "Device refreshed", on_done, name="DevRefresh")
 
         # This sends a refresh ping which will respond w/ the current
         # database delta field.  The handler checks that against the current

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -147,7 +147,7 @@ class KeypadLinc(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "KeypadLinc paired", on_done)
+        seq = CommandSeq(self, "KeypadLinc paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -206,7 +206,7 @@ class KeypadLinc(Base):
         # Send a 0x19 0x01 command to get the LED light on/off flags.
         LOG.info("KeypadLinc %s cmd: keypad status refresh", self.addr)
 
-        seq = CommandSeq(self, "Refresh complete", on_done)
+        seq = CommandSeq(self, "Refresh complete", on_done, name="DevRefresh")
 
         # TODO: change this to 0x2e get extended which reads on mask, off
         # mask, on level, led brightness, non-toggle mask, led bit mask (led
@@ -791,7 +791,8 @@ class KeypadLinc(Base):
 
         # Otherwise use the level changing command.
         else:
-            seq = CommandSeq(self, "Backlight level", on_done)
+            seq = CommandSeq(self, "Backlight level", on_done,
+                             name="SetBacklight")
 
             # Bound to 0x11 <= level <= 0x7f per page 157 of insteon dev guide.
             level = max(0x11, min(level, 0x7f))
@@ -953,7 +954,7 @@ class KeypadLinc(Base):
 
         # Start a command sequence so we can call the flag methods in series.
         seq = CommandSeq(self, "KeypadLinc set_flags complete",
-                         on_done)
+                         on_done, name="SetFlags")
 
         # Get the group if it was set.
         group = util.input_integer(kwargs, FLAG_GROUP)

--- a/insteon_mqtt/device/Leak.py
+++ b/insteon_mqtt/device/Leak.py
@@ -93,7 +93,7 @@ class Leak(BatterySensor):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "LeakSensor paired", on_done)
+        seq = CommandSeq(self, "LeakSensor paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -143,7 +143,8 @@ class Motion(BatterySensor):
             raise Exception("Unknown Motion flags input: %s.\n Valid flags "
                             "are: %s" % (unknown, flags))
 
-        seq = CommandSeq(self, "Motion Set Flags Success", on_done)
+        seq = CommandSeq(self, "Motion Set Flags Success", on_done,
+                         name="SetFlags")
 
         # For some flags we need to know the existing bit before we change it.
         # So to insure that we are starting from the correct values, get the

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -97,7 +97,7 @@ class Outlet(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "Outlet paired", on_done)
+        seq = CommandSeq(self, "Outlet paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -145,7 +145,7 @@ class Outlet(Base):
         """
         LOG.info("Outlet %s cmd: status refresh", self.label)
 
-        seq = CommandSeq(self, "Device refreshed", on_done)
+        seq = CommandSeq(self, "Device refreshed", on_done, name="DevRefresh")
 
         # This sends a refresh ping which will respond w/ the current
         # database delta field.  The handler checks that against the current
@@ -414,7 +414,8 @@ class Outlet(Base):
                             "are: %s" % unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
-        seq = CommandSeq(self, "Outlet set_flags complete", on_done)
+        seq = CommandSeq(self, "Outlet set_flags complete", on_done,
+                         name="DevSetFlags")
 
         if FLAG_BACKLIGHT in kwargs:
             backlight = util.input_byte(kwargs, FLAG_BACKLIGHT)

--- a/insteon_mqtt/device/Remote.py
+++ b/insteon_mqtt/device/Remote.py
@@ -146,7 +146,7 @@ class Remote(BatterySensor):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "Remote paired", on_done)
+        seq = CommandSeq(self, "Remote paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.

--- a/insteon_mqtt/device/SmokeBridge.py
+++ b/insteon_mqtt/device/SmokeBridge.py
@@ -87,7 +87,7 @@ class SmokeBridge(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "SmokeBridge paired", on_done)
+        seq = CommandSeq(self, "SmokeBridge paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -130,7 +130,7 @@ class SmokeBridge(Base):
         """
         LOG.info("Smoke bridge %s cmd: status refresh", self.addr)
 
-        seq = CommandSeq(self, "Device refreshed", on_done)
+        seq = CommandSeq(self, "Device refreshed", on_done, name="DevRefresh")
 
         # There is no way to get the current device status but we can request
         # the all link database delta so get that.  See smoke bridge dev

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -92,7 +92,7 @@ class Switch(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "Switch paired", on_done)
+        seq = CommandSeq(self, "Switch paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -345,7 +345,8 @@ class Switch(Base):
                             "are: %s" % unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
-        seq = CommandSeq(self, "Switch set_flags complete", on_done)
+        seq = CommandSeq(self, "Switch set_flags complete", on_done,
+                         name="DevSetFlags")
 
         if FLAG_BACKLIGHT in kwargs:
             backlight = util.input_byte(kwargs, FLAG_BACKLIGHT)

--- a/insteon_mqtt/device/Thermostat.py
+++ b/insteon_mqtt/device/Thermostat.py
@@ -167,7 +167,7 @@ class Thermostat(Base):
         # call finishes and works before calling the next one.  We have to do
         # this for device db manipulation because we need to know the memory
         # layout on the device before making changes.
-        seq = CommandSeq(self, "Thermostat paired", on_done)
+        seq = CommandSeq(self, "Thermostat paired", on_done, name="DevPair")
 
         # Start with a refresh command - since we're changing the db, it must
         # be up to date or bad things will happen.
@@ -223,7 +223,7 @@ class Thermostat(Base):
         """
         LOG.info("Device %s cmd: fan status refresh", self.addr)
 
-        seq = CommandSeq(self, "Refresh complete", on_done)
+        seq = CommandSeq(self, "Refresh complete", on_done, name="DevRefresh")
 
         # Send a 0x19 0x03 command to get the fan speed level.  This sends a
         # refresh ping which will respond w/ the fan level and current

--- a/tests/test_Scenes.py
+++ b/tests/test_Scenes.py
@@ -648,7 +648,7 @@ class Test_Scenes:
         # Make sure link data matches scene config & DB entry:
         assert scenes.entries[0].responders[0].link_data == [255, 23, 1]
         # Compute if any DB changes needed to implement scenes
-        seq = CommandSeq(modem.protocol, "Sync complete")
+        seq = CommandSeq(modem.protocol, "Sync complete", name="test")
         fanlinc.sync(dry_run=True, refresh=False, sequence=seq)
         # Uncomment the next two lines to see what sequence would do:
         #IM.log.initialize()


### PR DESCRIPTION
Reading nested command sequences out of a log was becoming a bit tedious.  This just adds a name to the log to try and make it a bit easier.