### PR TITLE
Remove Need to Refresh Modem Database

### DIFF
--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -1218,10 +1218,10 @@ class Modem:
         # Find teh database entry being deleted.
         entry = self.db.find(addr, group, is_controller)
         if not entry:
-            LOG.warning("Device %s delete no match for %s grp %s %s",
-                        self.addr, addr, group, util.ctrl_str(is_controller))
-            on_done(False, "Entry doesn't exist", None)
-            return
+            # Entry not in cache, but Modem can handle out of sync db
+            LOG.info("Device %s delete no match for %s grp %s %s",
+                     self.addr, addr, group, util.ctrl_str(is_controller))
+            entry = db.ModemEntry(addr, group, is_controller)
 
         # Add the function delete call to the sequence.
         seq = CommandSeq(self, "Delete complete", on_done, name="ModemDBDel")

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -290,14 +290,6 @@ class Modem:
         """
         exists = self.find(entry.addr, entry.group, entry.is_controller)
         if exists:
-            if exists.data == entry.data:
-                LOG.info("Modem add db already exists for %s grp %s %s",
-                         entry.addr, entry.group,
-                         util.ctrl_str(entry.is_controller))
-                if on_done:
-                    on_done(True, "Entry already exists", exists)
-                return
-
             cmd = Msg.OutAllLinkUpdate.Cmd.UPDATE
 
         elif entry.is_controller:

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -354,7 +354,7 @@ class Modem:
                                is_last_rec=False)
         msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.EXISTS, db_flags,
                                    entry.group, entry.addr, bytes(3))
-        msg_handler = handler.ModemDbSearch(self, entry, on_done=on_done)
+        msg_handler = handler.ModemDbSearch(self, on_done=on_done)
 
         # Queue the search message
         seq.add_msg(msg, msg_handler)

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -435,6 +435,9 @@ class Modem:
             else:
                 cmd = Msg.OutAllLinkUpdate.Cmd.ADD_RESPONDER
 
+            db_flags = Msg.DbFlags(in_use=True,
+                                   is_controller=restore.is_controller,
+                                   is_last_rec=False)
             msg2 = Msg.OutAllLinkUpdate(cmd, db_flags, restore.group,
                                         restore.addr, restore.data)
             msg_handler.add_update(msg2, restore)

--- a/insteon_mqtt/handler/ModemDbModify.py
+++ b/insteon_mqtt/handler/ModemDbModify.py
@@ -97,7 +97,7 @@ class ModemDbModify(Base):
         # ACK of an Update an existing entry w/ new data fields.
         elif msg.cmd == Msg.OutAllLinkUpdate.Cmd.UPDATE:
             LOG.info("Updating modem db record for %s grp: %s data: %s",
-                     msg.addr, msg.group, msg.data)
+                     msg.addr, msg.group, msg.data.hex())
 
             assert self.existing_entry
 
@@ -113,7 +113,7 @@ class ModemDbModify(Base):
               msg.cmd == Msg.OutAllLinkUpdate.Cmd.ADD_RESPONDER):
             LOG.info("Adding modem db record for %s type: %s grp: %s data: %s",
                      msg.addr, util.ctrl_str(msg.db_flags.is_controller),
-                     msg.group, msg.data)
+                     msg.group, msg.data.hex())
 
             # This will also save the database.
             self.db.add_entry(self.entry)

--- a/insteon_mqtt/handler/ModemDbModify.py
+++ b/insteon_mqtt/handler/ModemDbModify.py
@@ -43,6 +43,9 @@ class ModemDbModify(Base):
         self.entry = entry
         self.existing_entry = existing_entry
 
+        # Is this a retry of an ADD or UPDATE?  This prevents endless loops
+        self.is_retry = False
+
         # Tuple of (msg, entry) to send next.  If the first calls ACK's,
         # we'll update self.entry and send the next msg and continue until
         # this is empty.
@@ -84,9 +87,69 @@ class ModemDbModify(Base):
 
         # If we get a NAK message, signal an error and stop.
         if not msg.is_ack:
-            LOG.error("Modem db updated failed: %s", msg)
-            self.on_done(False, "Write to Modem db failed, try running " +
-                         "`refresh modem`", self.entry)
+            if msg.cmd == Msg.OutAllLinkUpdate.Cmd.DELETE or self.is_retry:
+                # We should never fail on a DELETE.  If this is a retry then
+                # the matching add/update already failed, which also should not
+                # happen.
+                LOG.error("Modem db update failed: %s", msg)
+                self.on_done(False, "Write to Modem db failed, try running " +
+                             "`refresh modem`", self.entry)
+
+            elif msg.cmd == Msg.OutAllLinkUpdate.Cmd.UPDATE:
+                LOG.info("DB record didn't exist, adding %s grp: %s data: %s",
+                         msg.addr, msg.group, msg.data.hex())
+                # There is no entry matching this on the device.  Create one
+                # instead.  There is no need to delete the wrong cached entry
+                # it will be replaced on when this record is added by the
+                # deduplication in add_entry
+                cmd = Msg.OutAllLinkUpdate.Cmd.ADD_RESPONDER
+                if self.entry.is_controller:
+                    cmd = Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER
+
+                # Create the flags for the entry.
+                db_flags = Msg.DbFlags(in_use=True,
+                                       is_controller=self.entry.is_controller,
+                                       is_last_rec=False)
+
+                # Build the modem database add message.
+                msg = Msg.OutAllLinkUpdate(cmd, db_flags, self.entry.group,
+                                           self.entry.addr, self.entry.data)
+
+                # Set retry to prevent infinite loops
+                self.is_retry = True
+
+                # Send the message.
+                self.db.device.send(msg, self)
+
+            elif (msg.cmd == Msg.OutAllLinkUpdate.Cmd.ADD_RESPONDER or
+                  msg.cmd == Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER):
+                LOG.info("DB record exists, updating %s grp: %s data: %s",
+                         msg.addr, msg.group, msg.data.hex())
+                # There is an entry matching this on the device already.
+                # So save it to the database.  And mark as the existing
+                # entry for after the update.
+                self.db.add_entry(self.entry)
+                self.existing_entry = self.entry
+
+                # Do an update
+                cmd = Msg.OutAllLinkUpdate.Cmd.UPDATE
+
+                # Create the flags for the entry.
+                db_flags = Msg.DbFlags(in_use=True,
+                                       is_controller=self.entry.is_controller,
+                                       is_last_rec=False)
+
+                # Build the modem database update message.
+                msg = Msg.OutAllLinkUpdate(cmd, db_flags, self.entry.group,
+                                           self.entry.addr, self.entry.data)
+
+                # Set retry to prevent infinite loops
+                self.is_retry = True
+
+                # Send the message.
+                self.db.device.send(msg, self)
+
+            # No matter what, all these messages are finished.
             return Msg.FINISHED
 
         # ACK of a message to delete an existing entry

--- a/insteon_mqtt/handler/ModemDbSearch.py
+++ b/insteon_mqtt/handler/ModemDbSearch.py
@@ -1,0 +1,110 @@
+#===========================================================================
+#
+# Modem search all link database handler.
+#
+#===========================================================================
+from .. import log
+from .. import message as Msg
+from .. import util
+from .Base import Base
+
+LOG = log.get_logger()
+
+
+class ModemDbSearch(Base):
+    """PLM Modem database search message handler.
+
+    This will handle a search command which tries to locate all entries that
+    match the passed address and group but not is_controller or any data1-3
+    values.  The search starts with an EXISTS command which finds the first
+    matching entry if it exists.  Subsequent searches use the SEARCH cmd which
+    finds the next entry.  In theory, there should only ever be a maximum of
+    two matching entries (a controller and a responder).
+
+    Commands are acked if the entry is found and nacked if not.
+
+    After an ack, the entry will be returned in a seperate message. Each entry
+    is added to the end of the modem class's database records.
+    """
+    def __init__(self, modem_db, entry, on_done=None):
+        """Constructor
+
+        Args
+          modem_db (db.Modem):  The database to update.
+          entry (db.ModemEntry):  The entry being searched for.  is_controller
+                                  will be ignored
+          on_done:  The finished callback.  Calling signature:
+                    on_done( bool success, str message, data )
+        """
+        super().__init__()
+
+        self.db = modem_db
+        self.on_done = util.make_callback(on_done)
+
+    #-----------------------------------------------------------------------
+    def msg_received(self, protocol, msg):
+        """See if we can handle the message.
+
+        See if the message is the expected ACK of our output or the expected
+        database reply message.  If we get a reply, pass it to the modem
+        database to update it's database with the info.
+
+        Args:
+          protocol (Protocol):  The Insteon Protocol object
+          msg:  Insteon message object that was read.
+
+        Returns:
+          Msg.UNKNOWN if we can't handle this message.
+          Msg.CONTINUE if we handled the message and expect more.
+          Msg.FINISHED if we handled the message and are done.
+        """
+        # Import here - at file scope this makes a circular import which is
+        # ok in Python>=3.5 but not 3.4.
+        from .. import db    # pylint: disable=import-outside-toplevel
+
+        # Message is an ACK/NAK of the record request.
+        if isinstance(msg, (Msg.OutAllLinkUpdate)):
+            # If we get a NAK, then there are no more db records.
+            if not msg.is_ack:
+                LOG.info("Modem database search complete.")
+
+                # Save the database to a local file.
+                self.db.save()
+
+                self.on_done(True, "Database search complete", None)
+                return Msg.FINISHED
+
+            # ACK - keep reading until we get the record we requested.
+            return Msg.CONTINUE
+
+        # Message is the record we requested.
+        if isinstance(msg, Msg.InpAllLinkRec):
+            LOG.info("Adding modem db record for %s grp: %s", msg.addr,
+                     msg.group)
+            if not msg.db_flags.in_use:
+                LOG.info("Ignoring modem db record in_use = False")
+            else:
+                # Create a modem database entry from the message data and
+                # write it into the database.
+                entry = db.ModemEntry(msg.addr, msg.group,
+                                      msg.db_flags.is_controller, msg.data,
+                                      db=self.db)
+                self.db.add_entry(entry)
+                LOG.info("Entry: %s", entry)
+
+            # Request the next record in the PLM database.
+            LOG.info("Modem searching for next db record")
+            db_flags = Msg.DbFlags.from_bytes(bytes(1))
+            msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.SEARCH,
+                                       db_flags, entry.group, entry.addr,
+                                       bytes(3))
+            self.db.device.send(msg, self)
+
+            # Return finished - this way the getnext message will go out.
+            # We'll be used as the handler for that as well which repeats
+            # until we get a nak response (handled above).
+            return Msg.FINISHED
+
+        return Msg.UNKNOWN
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/__init__.py
+++ b/insteon_mqtt/handler/__init__.py
@@ -38,6 +38,7 @@ from .DeviceDbGet import DeviceDbGet
 from .DeviceRefresh import DeviceRefresh
 from .ExtendedCmdResponse import ExtendedCmdResponse
 from .ModemDbGet import ModemDbGet
+from .ModemDbSearch import ModemDbSearch
 from .ModemDbModify import ModemDbModify
 from .ModemLinkComplete import ModemLinkComplete
 from .ModemLinkStart import ModemLinkStart

--- a/tests/db/test_Modem.py
+++ b/tests/db/test_Modem.py
@@ -2,13 +2,14 @@
 #
 # Tests for: insteont_mqtt/db/Modem.py
 #
+# pylint: disable=W0621,W0212
 #===========================================================================
+from unittest import mock
+from unittest.mock import call
 import pytest
 import insteon_mqtt as IM
 import insteon_mqtt.message as Msg
 import helpers as H
-from unittest import mock
-from unittest.mock import call
 
 
 @pytest.fixture
@@ -146,7 +147,7 @@ class Test_Modem:
 
     #-----------------------------------------------------------------------
     def test_delete_post_one(self, test_device, test_entry_dev1_ctrl,
-                               caplog):
+                             caplog):
         # add_on_device(self, entry, on_done=None)
         # test delete of a single entry
         test_device.add_entry(test_entry_dev1_ctrl)
@@ -156,9 +157,9 @@ class Test_Modem:
         db_flags = Msg.DbFlags.from_bytes(bytes(1))
         assert (test_device.device.protocol.sent[0].msg.to_bytes() ==
                 Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE, db_flags,
-                                                   test_entry_dev1_ctrl.group,
-                                                   test_entry_dev1_ctrl.addr,
-                                                   bytes(3)).to_bytes())
+                                     test_entry_dev1_ctrl.group,
+                                     test_entry_dev1_ctrl.addr,
+                                     bytes(3)).to_bytes())
 
     #-----------------------------------------------------------------------
     def test_delete_post_two_first(self, test_device, test_entry_dev1_ctrl,
@@ -174,9 +175,9 @@ class Test_Modem:
         sent = test_device.device.protocol.sent[0]
         assert (sent.msg.to_bytes() ==
                 Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE, db_flags,
-                                                   test_entry_dev1_ctrl.group,
-                                                   test_entry_dev1_ctrl.addr,
-                                                   bytes(3)).to_bytes())
+                                     test_entry_dev1_ctrl.group,
+                                     test_entry_dev1_ctrl.addr,
+                                     bytes(3)).to_bytes())
         assert len(sent.handler.next) == 0
 
     #-----------------------------------------------------------------------
@@ -193,23 +194,22 @@ class Test_Modem:
         sent = test_device.device.protocol.sent[0]
         assert (sent.msg.to_bytes() ==
                 Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE, db_flags,
-                                                   test_entry_dev1_resp.group,
-                                                   test_entry_dev1_resp.addr,
-                                                   bytes(3)).to_bytes())
+                                     test_entry_dev1_resp.group,
+                                     test_entry_dev1_resp.addr,
+                                     bytes(3)).to_bytes())
         assert len(sent.handler.next) == 2
         assert (sent.handler.next[0][0].to_bytes() ==
                 Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE, db_flags,
-                                                   test_entry_dev1_resp.group,
-                                                   test_entry_dev1_resp.addr,
-                                                   bytes(3)).to_bytes())
+                                     test_entry_dev1_resp.group,
+                                     test_entry_dev1_resp.addr,
+                                     bytes(3)).to_bytes())
         db_flags = Msg.DbFlags(in_use=True,
                                is_controller=test_entry_dev1_ctrl.is_controller,
                                is_last_rec=False)
         assert (sent.handler.next[1][0].to_bytes() ==
                 Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER,
-                                                   db_flags,
-                                                   test_entry_dev1_ctrl.group,
-                                                   test_entry_dev1_ctrl.addr,
-                                                   test_entry_dev1_ctrl.data).to_bytes())
+                                     db_flags, test_entry_dev1_ctrl.group,
+                                     test_entry_dev1_ctrl.addr,
+                                     test_entry_dev1_ctrl.data).to_bytes())
 
     #-----------------------------------------------------------------------

--- a/tests/db/test_Modem.py
+++ b/tests/db/test_Modem.py
@@ -3,8 +3,46 @@
 # Tests for: insteont_mqtt/db/Modem.py
 #
 #===========================================================================
+import pytest
 import insteon_mqtt as IM
+import insteon_mqtt.message as Msg
+import helpers as H
+from unittest import mock
+from unittest.mock import call
 
+
+@pytest.fixture
+def test_device(tmpdir):
+    path = tmpdir.join("temp.json")
+    protocol = H.main.MockProtocol()
+    modem = H.main.MockModem(tmpdir)
+    addr = IM.Address(0x01, 0x02, 0x03)
+    device = H.main.MockDevice(protocol, modem, addr)
+    return IM.db.Modem(path=path, device=device)
+
+@pytest.fixture
+def test_entry_dev1_ctrl():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x01
+    is_controller = True
+    return IM.db.ModemEntry(addr, group, is_controller, data)
+
+@pytest.fixture
+def test_entry_dev1_resp():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x01
+    is_controller = False
+    return IM.db.ModemEntry(addr, group, is_controller, data)
+
+@pytest.fixture
+def test_entry_dev2_ctrl():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x01
+    is_controller = False
+    return IM.db.ModemEntry(addr, group, is_controller, data)
 
 class Test_Modem:
     #-----------------------------------------------------------------------
@@ -37,5 +75,141 @@ class Test_Modem:
         assert obj2.entries[0] == obj.entries[0]
         assert obj2.entries[1] == obj.entries[1]
         assert obj2.entries[2] == obj.entries[2]
+
+    #-----------------------------------------------------------------------
+    def test_add_on_device_empty_ctrl(self, test_device, test_entry_dev1_ctrl):
+        # add_on_device(self, entry, on_done=None)
+        # test adding to an entry db with ctrl
+        assert len(test_device) == 0
+        test_device.add_on_device(test_entry_dev1_ctrl)
+        assert (test_device.device.protocol.sent[0].msg.cmd ==
+                Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER)
+        assert (test_device.device.protocol.sent[0].msg.db_flags.to_bytes() ==
+                Msg.DbFlags(in_use=True, is_controller=True,
+                            is_last_rec=False).to_bytes())
+
+    #-----------------------------------------------------------------------
+    def test_add_on_device_empty_resp(self, test_device, test_entry_dev1_resp):
+        # add_on_device(self, entry, on_done=None)
+        # test adding a resp to an empty db
+        assert len(test_device) == 0
+        test_device.add_on_device(test_entry_dev1_resp)
+        assert (test_device.device.protocol.sent[0].msg.cmd ==
+                Msg.OutAllLinkUpdate.Cmd.ADD_RESPONDER)
+        assert (test_device.device.protocol.sent[0].msg.db_flags.to_bytes() ==
+                Msg.DbFlags(in_use=True, is_controller=False,
+                            is_last_rec=False).to_bytes())
+
+    #-----------------------------------------------------------------------
+    def test_add_on_device_update_resp(self, test_device,
+                                       test_entry_dev1_resp):
+        # add_on_device(self, entry, on_done=None)
+        # test calling update on an existing entry
+        test_device.add_entry(test_entry_dev1_resp)
+        test_device.add_on_device(test_entry_dev1_resp)
+        assert (test_device.device.protocol.sent[0].msg.cmd ==
+                Msg.OutAllLinkUpdate.Cmd.UPDATE)
+        assert (test_device.device.protocol.sent[0].msg.db_flags.to_bytes() ==
+                Msg.DbFlags(in_use=True, is_controller=False,
+                            is_last_rec=False).to_bytes())
+
+    #-----------------------------------------------------------------------
+    def test_delete_on_device_update_resp(self, test_device,
+                                          test_entry_dev1_resp,
+                                          test_entry_dev1_ctrl):
+        # add_on_device(self, entry, on_done=None)
+        # test calling delete to ensure that search happens
+        test_device.add_entry(test_entry_dev1_resp)
+        test_device.add_entry(test_entry_dev1_ctrl)
+        assert len(test_device) == 2
+        with mock.patch.object(IM.CommandSeq, 'add_msg') as mocked:
+            test_device.delete_on_device(test_entry_dev1_resp)
+            assert len(test_device) == 0
+            assert mocked.call_count == 1
+            assert (mocked.call_args.args[0].cmd ==
+                    Msg.OutAllLinkUpdate.Cmd.EXISTS)
+        with mock.patch.object(IM.CommandSeq, 'add') as mocked:
+            test_device.delete_on_device(test_entry_dev1_resp)
+            assert len(test_device) == 0
+            assert mocked.call_count == 1
+            calls = [call(test_device._delete_on_device_post_search,
+                          test_entry_dev1_resp)]
+            mocked.assert_has_calls(calls)
+
+    #-----------------------------------------------------------------------
+    def test_delete_post_empty(self, test_device, test_entry_dev1_ctrl,
+                               caplog):
+        # add_on_device(self, entry, on_done=None)
+        # test delete where no entry is on modem
+        test_device._delete_on_device_post_search(test_entry_dev1_ctrl)
+        assert "Entry was not on modem" in caplog.text
+
+    #-----------------------------------------------------------------------
+    def test_delete_post_one(self, test_device, test_entry_dev1_ctrl,
+                               caplog):
+        # add_on_device(self, entry, on_done=None)
+        # test delete of a single entry
+        test_device.add_entry(test_entry_dev1_ctrl)
+        test_device._delete_on_device_post_search(test_entry_dev1_ctrl)
+        assert (test_device.device.protocol.sent[0].msg.cmd ==
+                Msg.OutAllLinkUpdate.Cmd.DELETE)
+        db_flags = Msg.DbFlags.from_bytes(bytes(1))
+        assert (test_device.device.protocol.sent[0].msg.to_bytes() ==
+                Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE, db_flags,
+                                                   test_entry_dev1_ctrl.group,
+                                                   test_entry_dev1_ctrl.addr,
+                                                   bytes(3)).to_bytes())
+
+    #-----------------------------------------------------------------------
+    def test_delete_post_two_first(self, test_device, test_entry_dev1_ctrl,
+                                   test_entry_dev1_resp, caplog):
+        # add_on_device(self, entry, on_done=None)
+        # test deleting the first of two entries
+        test_device.add_entry(test_entry_dev1_ctrl)
+        test_device.add_entry(test_entry_dev1_resp)
+        test_device._delete_on_device_post_search(test_entry_dev1_ctrl)
+        assert (test_device.device.protocol.sent[0].msg.cmd ==
+                Msg.OutAllLinkUpdate.Cmd.DELETE)
+        db_flags = Msg.DbFlags.from_bytes(bytes(1))
+        sent = test_device.device.protocol.sent[0]
+        assert (sent.msg.to_bytes() ==
+                Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE, db_flags,
+                                                   test_entry_dev1_ctrl.group,
+                                                   test_entry_dev1_ctrl.addr,
+                                                   bytes(3)).to_bytes())
+        assert len(sent.handler.next) == 0
+
+    #-----------------------------------------------------------------------
+    def test_delete_post_two_second(self, test_device, test_entry_dev1_ctrl,
+                                    test_entry_dev1_resp, caplog):
+        # add_on_device(self, entry, on_done=None)
+        # test deleting the second of two entries
+        test_device.add_entry(test_entry_dev1_ctrl)
+        test_device.add_entry(test_entry_dev1_resp)
+        test_device._delete_on_device_post_search(test_entry_dev1_resp)
+        assert (test_device.device.protocol.sent[0].msg.cmd ==
+                Msg.OutAllLinkUpdate.Cmd.DELETE)
+        db_flags = Msg.DbFlags.from_bytes(bytes(1))
+        sent = test_device.device.protocol.sent[0]
+        assert (sent.msg.to_bytes() ==
+                Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE, db_flags,
+                                                   test_entry_dev1_resp.group,
+                                                   test_entry_dev1_resp.addr,
+                                                   bytes(3)).to_bytes())
+        assert len(sent.handler.next) == 2
+        assert (sent.handler.next[0][0].to_bytes() ==
+                Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE, db_flags,
+                                                   test_entry_dev1_resp.group,
+                                                   test_entry_dev1_resp.addr,
+                                                   bytes(3)).to_bytes())
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        assert (sent.handler.next[1][0].to_bytes() ==
+                Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER,
+                                                   db_flags,
+                                                   test_entry_dev1_ctrl.group,
+                                                   test_entry_dev1_ctrl.addr,
+                                                   test_entry_dev1_ctrl.data).to_bytes())
 
     #-----------------------------------------------------------------------

--- a/tests/handler/test_ModemDbModify.py
+++ b/tests/handler/test_ModemDbModify.py
@@ -1,0 +1,229 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/handler/ModemDbModify.py
+#
+# pylint: disable=W0621
+#===========================================================================
+# from unittest import mock
+# from unittest.mock import call
+import pytest
+import insteon_mqtt as IM
+import insteon_mqtt.handler as Handler
+import insteon_mqtt.message as Msg
+import helpers as H
+
+@pytest.fixture
+def test_db(tmpdir):
+    #modem_db, entry, existing_entry=None
+    path = tmpdir.join("temp.json")
+    protocol = H.main.MockProtocol()
+    modem = H.main.MockModem(tmpdir)
+    addr = IM.Address(0x01, 0x02, 0x03)
+    device = H.main.MockDevice(protocol, modem, addr)
+    modem.db = IM.db.Modem(path=path, device=device)
+    return modem.db
+
+@pytest.fixture
+def test_entry_dev1_ctrl():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x01
+    is_controller = True
+    return IM.db.ModemEntry(addr, group, is_controller, data)
+
+@pytest.fixture
+def test_entry_dev1_ctrl_mod():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0x12, 0x34, 0x56])
+    group = 0x01
+    is_controller = True
+    return IM.db.ModemEntry(addr, group, is_controller, data)
+
+@pytest.fixture
+def test_entry_dev1_resp():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x01
+    is_controller = False
+    return IM.db.ModemEntry(addr, group, is_controller, data)
+
+@pytest.fixture
+def test_entry_dev2_ctrl():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x01
+    is_controller = False
+    return IM.db.ModemEntry(addr, group, is_controller, data)
+
+class Test_ModemDbModify:
+    def test_delete(self, test_db, test_entry_dev1_ctrl):
+        # delete, no next
+        test_db.add_entry(test_entry_dev1_ctrl)
+        assert len(test_db) == 1
+        handler = Handler.ModemDbModify(test_db, test_entry_dev1_ctrl)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE,
+                                   db_flags,
+                                   test_entry_dev1_ctrl.group,
+                                   test_entry_dev1_ctrl.addr,
+                                   data=None, is_ack=True)
+        handler.msg_received(test_db.device.protocol, msg)
+        assert len(test_db) == 0
+
+    def test_delete2(self, test_db, test_entry_dev1_ctrl,
+                     test_entry_dev1_resp):
+        # delete 2nd entry and then re-add the first
+        test_db.add_entry(test_entry_dev1_ctrl)
+        test_db.add_entry(test_entry_dev1_resp)
+        assert len(test_db) == 2
+        handler = Handler.ModemDbModify(test_db, test_entry_dev1_ctrl)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE,
+                                   db_flags,
+                                   test_entry_dev1_ctrl.group,
+                                   test_entry_dev1_ctrl.addr,
+                                   data=None)
+        # Add update to delete 2nd entry
+        handler.add_update(msg, test_entry_dev1_resp)
+        # Then restore the first
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg2 = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER,
+                                    db_flags, test_entry_dev1_ctrl.group,
+                                    test_entry_dev1_ctrl.addr,
+                                    test_entry_dev1_ctrl.data)
+        handler.add_update(msg2, test_entry_dev1_ctrl)
+        # signal first delete ack
+        msg.is_ack = True
+        handler.msg_received(test_db.device.protocol, msg)
+        assert len(test_db) == 1
+        # signal second delete ack
+        handler.msg_received(test_db.device.protocol, msg)
+        assert len(test_db) == 0
+        # signal final add ack
+        msg2.is_ack = True
+        handler.msg_received(test_db.device.protocol, msg2)
+        assert len(test_db) == 1
+        assert test_db.entries[0] == test_entry_dev1_ctrl
+
+    def test_delete_nak(self, test_db, test_entry_dev1_ctrl, caplog):
+        # delete, no next
+        test_db.add_entry(test_entry_dev1_ctrl)
+        assert len(test_db) == 1
+        handler = Handler.ModemDbModify(test_db, test_entry_dev1_ctrl)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE,
+                                   db_flags,
+                                   test_entry_dev1_ctrl.group,
+                                   test_entry_dev1_ctrl.addr,
+                                   data=None, is_ack=False)
+        handler.msg_received(test_db.device.protocol, msg)
+        assert len(test_db) == 1
+        assert "db update failed" in caplog.text
+
+    def test_update(self, test_db, test_entry_dev1_ctrl,
+                    test_entry_dev1_ctrl_mod):
+        # update clean
+        test_db.add_entry(test_entry_dev1_ctrl)
+        assert len(test_db) == 1
+        handler = Handler.ModemDbModify(test_db, test_entry_dev1_ctrl_mod,
+                                        existing_entry=test_entry_dev1_ctrl)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.UPDATE,
+                                   db_flags,
+                                   test_entry_dev1_ctrl.group,
+                                   test_entry_dev1_ctrl.addr,
+                                   data=bytes(3), is_ack=True)
+        handler.msg_received(test_db.device.protocol, msg)
+        assert len(test_db) == 1
+        assert test_db.entries[0].data == test_entry_dev1_ctrl_mod.data
+
+    def test_add(self, test_db, test_entry_dev1_ctrl):
+        # add clean
+        assert len(test_db) == 0
+        handler = Handler.ModemDbModify(test_db, test_entry_dev1_ctrl)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER,
+                                   db_flags,
+                                   test_entry_dev1_ctrl.group,
+                                   test_entry_dev1_ctrl.addr,
+                                   data=bytes(3), is_ack=True)
+        handler.msg_received(test_db.device.protocol, msg)
+        assert len(test_db) == 1
+        assert test_db.entries[0] == test_entry_dev1_ctrl
+
+    def test_add_nak(self, test_db, test_entry_dev1_ctrl):
+        assert len(test_db) == 0
+        handler = Handler.ModemDbModify(test_db, test_entry_dev1_ctrl)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER,
+                                   db_flags,
+                                   test_entry_dev1_ctrl.group,
+                                   test_entry_dev1_ctrl.addr,
+                                   data=bytes(3), is_ack=False)
+        handler.msg_received(test_db.device.protocol, msg)
+        # entry should be added
+        assert len(test_db) == 1
+        assert len(test_db.device.protocol.sent) == 1
+        assert (test_db.device.protocol.sent[0].msg.cmd ==
+                Msg.OutAllLinkUpdate.Cmd.UPDATE)
+        assert handler.is_retry
+
+    def test_update_nak(self, test_db, test_entry_dev1_ctrl,
+                        test_entry_dev1_ctrl_mod):
+        test_db.add_entry(test_entry_dev1_ctrl)
+        assert len(test_db) == 1
+        handler = Handler.ModemDbModify(test_db, test_entry_dev1_ctrl_mod,
+                                        existing_entry=test_entry_dev1_ctrl)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.UPDATE,
+                                   db_flags,
+                                   test_entry_dev1_ctrl_mod.group,
+                                   test_entry_dev1_ctrl_mod.addr,
+                                   data=bytes(3), is_ack=False)
+        handler.msg_received(test_db.device.protocol, msg)
+        # entry should still be there, it gets updated on next ack
+        assert len(test_db) == 1
+        assert len(test_db.device.protocol.sent) == 1
+        assert (test_db.device.protocol.sent[0].msg.cmd ==
+                Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER)
+        assert handler.is_retry
+
+    def test_prevent_loop(self, test_db, test_entry_dev1_ctrl, caplog):
+        handler = Handler.ModemDbModify(test_db, test_entry_dev1_ctrl_mod,
+                                        existing_entry=test_entry_dev1_ctrl)
+        handler.is_retry = True
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.UPDATE,
+                                   db_flags,
+                                   test_entry_dev1_ctrl.group,
+                                   test_entry_dev1_ctrl.addr,
+                                   data=bytes(3), is_ack=False)
+        handler.msg_received(test_db.device.protocol, msg)
+        # This should fail to prevent infinite loops
+        assert "db update failed" in caplog.text
+
+    def test_wrong_handler(self, test_db, test_entry_dev1_ctrl):
+        handler = Handler.ModemDbModify(test_db, test_entry_dev1_ctrl_mod,
+                                        existing_entry=test_entry_dev1_ctrl)
+        msg = Msg.OutAllLinkCancel()
+        ret = handler.msg_received(test_db.device.protocol, msg)
+        # This should fail to prevent infinite loops
+        assert ret == Msg.UNKNOWN

--- a/tests/handler/test_ModemDbSearch.py
+++ b/tests/handler/test_ModemDbSearch.py
@@ -1,0 +1,117 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/handler/ModemDbSearch.py
+#
+# pylint: disable=W0621
+#===========================================================================
+# from unittest import mock
+# from unittest.mock import call
+import pytest
+import insteon_mqtt as IM
+import insteon_mqtt.handler as Handler
+import insteon_mqtt.message as Msg
+import helpers as H
+
+@pytest.fixture
+def test_db(tmpdir):
+    #modem_db, entry, existing_entry=None
+    path = tmpdir.join("temp.json")
+    protocol = H.main.MockProtocol()
+    modem = H.main.MockModem(tmpdir)
+    addr = IM.Address(0x01, 0x02, 0x03)
+    device = H.main.MockDevice(protocol, modem, addr)
+    modem.db = IM.db.Modem(path=path, device=device)
+    return modem.db
+
+@pytest.fixture
+def test_entry_dev1_ctrl():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x01
+    is_controller = True
+    return IM.db.ModemEntry(addr, group, is_controller, data)
+
+@pytest.fixture
+def test_entry_dev1_ctrl_mod():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0x12, 0x34, 0x56])
+    group = 0x01
+    is_controller = True
+    return IM.db.ModemEntry(addr, group, is_controller, data)
+
+@pytest.fixture
+def test_entry_dev1_resp():
+    addr = IM.Address('12.34.ab')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x01
+    is_controller = False
+    return IM.db.ModemEntry(addr, group, is_controller, data)
+
+class Test_ModemDbModify:
+    def test_ack(self, test_db, test_entry_dev1_ctrl):
+        handler = Handler.ModemDbSearch(test_db)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.EXISTS,
+                                   db_flags,
+                                   test_entry_dev1_ctrl.group,
+                                   test_entry_dev1_ctrl.addr,
+                                   data=None, is_ack=True)
+        ret = handler.msg_received(test_db.device.protocol, msg)
+        assert ret == Msg.CONTINUE
+
+    def test_nack(self, test_db, test_entry_dev1_ctrl):
+        handler = Handler.ModemDbSearch(test_db)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.EXISTS,
+                                   db_flags,
+                                   test_entry_dev1_ctrl.group,
+                                   test_entry_dev1_ctrl.addr,
+                                   data=None, is_ack=False)
+        ret = handler.msg_received(test_db.device.protocol, msg)
+        assert ret == Msg.FINISHED
+
+    def test_wrong_handler(self, test_db, test_entry_dev1_ctrl):
+        handler = Handler.ModemDbSearch(test_db)
+        msg = Msg.OutAllLinkCancel()
+        ret = handler.msg_received(test_db.device.protocol, msg)
+        assert ret == Msg.UNKNOWN
+
+    def test_entry_received(self, test_db, test_entry_dev1_ctrl):
+        handler = Handler.ModemDbSearch(test_db)
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.InpAllLinkRec(db_flags, test_entry_dev1_ctrl.group,
+                                test_entry_dev1_ctrl.addr,
+                                test_entry_dev1_ctrl.data)
+        ret = handler.msg_received(test_db.device.protocol, msg)
+        assert ret == Msg.FINISHED
+        assert len(test_db) == 1
+        assert test_db.entries[0] == test_entry_dev1_ctrl
+        sent = test_db.device.protocol.sent
+        assert len(sent) == 1
+        assert sent[0].msg.cmd == Msg.OutAllLinkUpdate.Cmd.SEARCH
+        assert sent[0].msg.group == test_entry_dev1_ctrl.group
+        assert sent[0].msg.addr == test_entry_dev1_ctrl.addr
+
+    def test_entry_not_used(self, test_db, test_entry_dev1_ctrl):
+        # I don't think this is possible, but we have the code, so test for it
+        handler = Handler.ModemDbSearch(test_db)
+        db_flags = Msg.DbFlags(in_use=False,
+                               is_controller=test_entry_dev1_ctrl.is_controller,
+                               is_last_rec=False)
+        msg = Msg.InpAllLinkRec(db_flags, test_entry_dev1_ctrl.group,
+                                test_entry_dev1_ctrl.addr,
+                                test_entry_dev1_ctrl.data)
+        ret = handler.msg_received(test_db.device.protocol, msg)
+        assert ret == Msg.FINISHED
+        assert len(test_db) == 0
+        sent = test_db.device.protocol.sent
+        assert len(sent) == 1
+        assert sent[0].msg.cmd == Msg.OutAllLinkUpdate.Cmd.SEARCH
+        assert sent[0].msg.group == test_entry_dev1_ctrl.group
+        assert sent[0].msg.addr == test_entry_dev1_ctrl.addr

--- a/tests/util/helpers/main.py
+++ b/tests/util/helpers/main.py
@@ -58,5 +58,18 @@ class MockProtocol:
     def set_wait_time(self, seconds):
         pass
 
+#===========================================================================
+class MockDevice:
+    """Mock insteon_mqtt/Device class
+    """
+    #-----------------------------------------------------------------------
+    def __init__(self, protocol, modem, address, name=None):
+        self.protocol = protocol
+        self.modem = modem
+        self.addr = IM.Address(address)
+        self.name = name
+
+    def send(self, msg, msg_handler, high_priority=False, after=None):
+        self.protocol.send(msg, msg_handler, high_priority, after)
 
 #===========================================================================


### PR DESCRIPTION
So this is pretty cool.  I have reworked the Modem delete/add/modify routines so that they no longer care or require a refresh of the modem database.  This means things like pair, sync, and adding links should no longer fail because the Modem db is out of date.

In short, if you try and add a link that already exists, the modem will return a nak.  At which point we retry the action as an update instead.  The same is true if you try to update a link that doesn't exist.  The delete is a little more complicated and requires us to search the database first, but we can search specifically for these links.  

The cool thing is that this all happens in less than a second, so it isn't even noticable to users.

The only real need to refresh the modem db now is if you want to run sync to delete extraneous entries.  Otherwise, an out of date modem db shouldn't be an issue anymore.

This is also a prime example of how bad the insteon documentation is.  The documentation about these commands is wrong a lot.  I had to poke at things a fair bit to determine how it actually works.

I still have to write some tests to ensure that everything works as intended.  But I have tested all of the various iterations on actual hardware and it works great. 