### PR TITLE
Add 2842 Motion Sensor Battery Request; No Retries for Battery Devices when Briefly Awake

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,10 @@
   can be identified.  Commands will no longer fail because the modem database
   is out of date. ([PR 279][P279])
 
+- Enable querying the battery on 2842 Motion sensors.  Helpful if using
+  batteries with voltages other than those expected from alkaline batteries.
+  ([PR 282][P282])
+
 ### Fixes
 
 - Allow for used last entries in DB.  Improve compatibility with devices
@@ -64,7 +68,7 @@
 
 - Added support for querying the battery on a mini-remote.  The battery state
   will be automatically queried when the device wakes up if is has been 4 days
-  since the last battery check and will emit messages on the low_battery
+  since the last battery check and will emit messages on the battery
   topic. ([PR 244][P244])
 
 - Added support for Smartenit EZIO4O 4 relay output module (thanks @embak)
@@ -508,3 +512,4 @@ will add new features.
 [P275]: https://github.com/TD22057/insteon-mqtt/pull/275
 [P277]: https://github.com/TD22057/insteon-mqtt/pull/277
 [P279]: https://github.com/TD22057/insteon-mqtt/pull/279
+[P282]: https://github.com/TD22057/insteon-mqtt/pull/282

--- a/config.yaml
+++ b/config.yaml
@@ -371,7 +371,7 @@ mqtt:
   #       device_class: 'motion'
   #
   #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/low_battery'
+  #       state_topic: 'insteon/aa.bb.cc/battery'
   #       device_class: 'battery'
   battery_sensor:
     # Output state change topic and payload.  This message is sent

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -473,7 +473,7 @@ Switch, KeypadLinc, and Dimmer all support the flags:
      and will alternate on an doff signals
 
   KeypadLinc and Dimmer support the flags:
-   
+
    - ramp_rate: float in the range of 0.5 to 540 seconds which sets the default ramp
      rate that will be used when the button is pressed
 
@@ -566,6 +566,39 @@ next three minutes.
   ```
   { "cmd": "awake" }
   ```
+
+
+### Force a Battery Voltage Check
+
+Supported: Remote and Motion only
+
+The next time the device is awake, this will send a request for the battery
+voltage.  If it is low, it will trigger an event on the low_voltage topic.
+
+  ```
+  { "cmd": "get_battery_voltage" }
+    ```
+
+
+### Set the Low Battery Voltage
+
+Supported: Motion only
+
+Sets the value at which the battery in the device will be determined to be
+low.  Only used on devices that support battery voltage checks and have
+removable batteries.  Which is currently only the Motion sensor.  The default
+low battery voltage for the motion sensor is 7.0.  The normal low voltage
+message would have been sent on group 3 when this voltage is reached anyways.
+
+This is useful for those of us using Li-Ion batteries in the motion sensors
+which have an initial voltage of 7.8 at best, and a low voltage well below
+that of a normal alkaline battery.  When using these batteries, the low
+voltage message on group 3 is likely never sent, because the battery is always
+below the expected value
+
+  ```
+  { "cmd": "set_low_battery_voltage", "voltage": 7.0 }
+    ```
 
 ---
 

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -330,4 +330,16 @@ def get_battery_voltage(args, config):
 
     reply = util.send(config, topic, payload, args.quiet)
     return reply["status"]
+
+
+#===========================================================================
+def set_low_battery_voltage(args, config):
+    topic = "%s/%s" % (args.topic, args.address)
+    payload = {
+        "cmd" : "set_low_battery_voltage",
+        "voltage" : args.voltage
+        }
+
+    reply = util.send(config, topic, payload, args.quiet)
+    return reply["status"]
 #===========================================================================

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -268,17 +268,6 @@ def parse_args(args):
     sp.set_defaults(func=device.pair)
 
     #---------------------------------------
-    # device.pair command
-    sp = sub.add_parser("refresh", help="Refresh device/modem state and "
-                        "all link database.")
-    sp.add_argument("-f", "--force", action="store_true",
-                    help="Force the device database to be downloaded.")
-    sp.add_argument("-q", "--quiet", action="store_true",
-                    help="Don't print any command results to the screen.")
-    sp.add_argument("address", help="Device address or name.")
-    sp.set_defaults(func=device.refresh)
-
-    #---------------------------------------
     # device.db_add add ctrl/rspdr command
     sp = sub.add_parser("db-add", help="Add the device/modem as the "
                         "controller or responder of another device.  The "
@@ -405,6 +394,17 @@ def parse_args(args):
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=device.get_battery_voltage)
+
+    #---------------------------------------
+    # device.set_low_battery_voltage
+    # Only works on some battery devices, notably those with removable batts
+    sp = sub.add_parser("set-low-battery-voltage", help="Sets the threshold "
+                        "voltage at which a battery will be signaled as low.")
+    sp.add_argument("address", help="Device address or name.")
+    sp.add_argument("voltage", type=float, help="Low voltage as float.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=device.set_low_battery_voltage)
 
     return p.parse_args(args)
 

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -3,6 +3,7 @@
 # Insteon battery powered motion sensor
 #
 #===========================================================================
+import time
 from .BatterySensor import BatterySensor
 from ..CommandSeq import CommandSeq
 from .. import log
@@ -57,6 +58,11 @@ class Motion(BatterySensor):
     """
     type_name = "motion_sensor"
 
+    # This defines what is the minimum time between battery status requests
+    # for devices that support it.  Value is in seconds
+    # Currently set at 4 Days
+    BATTERY_TIME = (60 * 60) * 24 * 4
+
     def __init__(self, protocol, modem, address, name=None):
         """Constructor
 
@@ -80,6 +86,8 @@ class Motion(BatterySensor):
         # base class defined commands.
         self.cmd_map.update({
             'set_flags' : self.set_flags,
+            'set_low_battery_voltage': self.set_low_battery_voltage,
+            'get_battery_voltage' : self._get_ext_flags,
             })
 
         # Set default values for bits.  These should always be updated prior
@@ -87,6 +95,86 @@ class Motion(BatterySensor):
         self.led_on = 1
         self.night_only = 0
         self.on_only = 0
+
+        # This allows for a short timer between sending automatic battery
+        # requests.  Otherwise, a request may get queued multiple times
+        self._battery_request_time = 0
+
+    #-----------------------------------------------------------------------
+    @property
+    def battery_voltage_time(self):
+        """Returns the timestamp of the last battery voltage report from the
+        saved metadata
+        """
+        meta = self.db.get_meta('Motion')
+        ret = 0
+        if isinstance(meta, dict) and 'battery_voltage_time' in meta:
+            ret = meta['battery_voltage_time']
+        return ret
+
+    #-----------------------------------------------------------------------
+    @battery_voltage_time.setter
+    def battery_voltage_time(self, val):
+        """Saves the timestamp of the last battery voltage report to the
+        database metadata
+        Args:
+          val:    (timestamp) time.time() value
+        """
+        meta = {'battery_voltage_time': val}
+        existing = self.db.get_meta('Motion')
+        if isinstance(existing, dict):
+            existing.update(meta)
+            self.db.set_meta('Motion', existing)
+        else:
+            self.db.set_meta('Motion', meta)
+
+    #-----------------------------------------------------------------------
+    @property
+    def battery_low_voltage(self):
+        """Returns the voltage below which the battery will be deemed to be
+        low.  The default value is 7.0 volts.
+        """
+        meta = self.db.get_meta('Motion')
+        ret = 7.0
+        if isinstance(meta, dict) and 'battery_low_voltage' in meta:
+            ret = meta['battery_low_voltage']
+        return ret
+
+    #-----------------------------------------------------------------------
+    @battery_low_voltage.setter
+    def battery_low_voltage(self, val):
+        """Saves the voltage below which the battery will be deemed to be
+        low.
+        Args:
+          val:    (float) Low voltage number
+        """
+        meta = {'battery_low_voltage': val}
+        existing = self.db.get_meta('Motion')
+        if isinstance(existing, dict):
+            existing.update(meta)
+            self.db.set_meta('Motion', existing)
+        else:
+            self.db.set_meta('Motion', meta)
+
+    #-----------------------------------------------------------------------
+    def set_low_battery_voltage(self, on_done, voltage=None):
+        """Set low voltage value.
+
+        Called from the mqtt command functions or cmd_line
+
+        Args:
+          voltage: (float) The low voltage value
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        if voltage is not None:
+            LOG.info("Motion %s cmd: set low voltage= %s", self.label, voltage)
+            self.battery_low_voltage = voltage
+            on_done(True, "Low voltage set.", None)
+        else:
+            LOG.warning("Motion %s set_low_voltage cmd requires volage key.",
+                        self.label)
+            on_done(False, "Low voltage not specified.", None)
 
     #-----------------------------------------------------------------------
     def handle_dawn(self, msg):
@@ -206,8 +294,8 @@ class Motion(BatterySensor):
     def _get_ext_flags(self, on_done=None):
         """Get the Insteon operational extended flags field from the device.
 
-        For the motion device, these flags include led_on, night_only, and
-        on_only.
+        For the motion device, these flags include led_on, night_only,
+        on_only, as well as the battery voltage and current light level.
 
         Args:
           on_done: Finished callback.  This is called when the command has
@@ -227,9 +315,14 @@ class Motion(BatterySensor):
     def handle_ext_flags(self, msg, on_done):
         """Handle replies to the _get_ext_flags command.
 
-        Data 6 of the extended response contains the bits we are interested
-        in.  This parses them out and stores their value for use in setting
-        flags.
+        Data 6 of the extended response contains the bits for led_on,
+        night_only, and on_only.  This parses them out and stores their value
+        for use in setting flags.
+
+        Data 11 contains the light level from 0-255.  Not currently used for
+        anything.
+
+        Data 12 of the extended response contains the battery voltage /10.
 
         Args:
           msg (message.InpExtended):  The message reply.  The current
@@ -242,6 +335,18 @@ class Motion(BatterySensor):
         self.led_on = util.bit_get(msg.data[5], 3)
         self.night_only = util.bit_get(msg.data[5], 2)
         self.on_only = util.bit_get(msg.data[5], 1)
+
+        # D11 has the light level, not doing anything with that now.
+
+        # D12 voltage, but remember starts at 0
+        batt_volt = msg.data[11] / 10
+        LOG.info("Remote %s battery voltage is %s", self.label,
+                 batt_volt)
+        self.battery_voltage_time = time.time()
+        # Signal low battery
+        self.signal_low_battery.emit(self,
+                                     batt_volt <= self.battery_low_voltage)
+
         on_done(True, "Operation complete", msg.data[5])
 
     #-----------------------------------------------------------------------
@@ -316,5 +421,45 @@ class Motion(BatterySensor):
         msg_handler = handler.StandardCmd(msg, self.handle_ext_cmd,
                                           on_done)
         self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def auto_check_battery(self):
+        """Queues a Battery Voltage Request if Necessary
+
+        If the device supports it, and the requisite amount of time has
+        elapsed, queue a battery request.
+        """
+        if (self.db.desc is not None and
+                self.db.desc.model.split("-")[0] == "2842"):
+            # This is a device that supports battery requests
+            last_checked = self.battery_voltage_time
+            # Don't send this message more than once every 5 minutes no
+            # matter what
+            if (last_checked + self.BATTERY_TIME <= time.time() and
+                    self._battery_request_time + 300 <= time.time()):
+                self._battery_request_time = time.time()
+                LOG.info("Remote %s: Auto requesting battery voltage",
+                         self.label)
+                self._get_ext_flags(None)
+
+    #-----------------------------------------------------------------------
+    def awake(self, on_done):
+        """Injects a Battery Voltage Request if Necessary
+
+        Queue a battery request that should go out now, since the device is
+        awake.
+        """
+        self.auto_check_battery()
+        super().awake(on_done)
+
+    #-----------------------------------------------------------------------
+    def _pop_send_queue(self):
+        """Injects a Battery Voltage Request if Necessary
+
+        Queue a battery request that should go out now, since the device is
+        awake.
+        """
+        self.auto_check_battery()
+        super()._pop_send_queue()
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -172,7 +172,7 @@ class Motion(BatterySensor):
             self.battery_low_voltage = voltage
             on_done(True, "Low voltage set.", None)
         else:
-            LOG.warning("Motion %s set_low_voltage cmd requires volage key.",
+            LOG.warning("Motion %s set_low_voltage cmd requires voltage key.",
                         self.label)
             on_done(False, "Low voltage not specified.", None)
 
@@ -340,7 +340,7 @@ class Motion(BatterySensor):
 
         # D12 voltage, but remember starts at 0
         batt_volt = msg.data[11] / 10
-        LOG.info("Remote %s battery voltage is %s", self.label,
+        LOG.info("Motion %s battery voltage is %s", self.label,
                  batt_volt)
         self.battery_voltage_time = time.time()
         # Signal low battery
@@ -438,7 +438,7 @@ class Motion(BatterySensor):
             if (last_checked + self.BATTERY_TIME <= time.time() and
                     self._battery_request_time + 300 <= time.time()):
                 self._battery_request_time = time.time()
-                LOG.info("Remote %s: Auto requesting battery voltage",
+                LOG.info("Motion %s: Auto requesting battery voltage",
                          self.label)
                 self._get_ext_flags(None)
 

--- a/insteon_mqtt/handler/Base.py
+++ b/insteon_mqtt/handler/Base.py
@@ -57,6 +57,19 @@ class Base:
         self._msg = None
 
     #-----------------------------------------------------------------------
+    def set_retry_num(self, retry_num):
+        """Used to set the number of retrie
+
+        The number of times to retry the message if the handler times out
+        without returning Msg.FINISHED. This count does not include the initial
+        sending so a retry of 3 will send once and then retry 3 more times.
+
+        Args:
+           retry_num (int):  The number of retries
+        """
+        self._num_retry = retry_num
+
+    #-----------------------------------------------------------------------
     def sending_message(self, msg):
         """Messaging being sent callback.
 

--- a/tests/cmd_line/test_device.py
+++ b/tests/cmd_line/test_device.py
@@ -55,3 +55,58 @@ class Test_device:
         self.check_call(IM.cmd_line.util.send, args, config, topic, payload)
 
     #-----------------------------------------------------------------------
+    def test_awake(self, mocker):
+        mocker.patch('insteon_mqtt.cmd_line.util.send')
+        IM.cmd_line.util.send.return_value = {"status" : 10}
+
+        args = helpers.Data(topic="cmd_topic", force=False, quiet=True,
+                            address="aa.bb.cc")
+        config = helpers.Data(a=1, b=2)
+
+        r = IM.cmd_line.device.awake(args, config)
+        assert r == 10
+
+        topic = "%s/%s" % (args.topic, args.address)
+        payload = {
+            "cmd" : "awake",
+            }
+        self.check_call(IM.cmd_line.util.send, args, config, topic, payload)
+
+    #-----------------------------------------------------------------------
+    def test_get_battery_voltage(self, mocker):
+        mocker.patch('insteon_mqtt.cmd_line.util.send')
+        IM.cmd_line.util.send.return_value = {"status" : 10}
+
+        args = helpers.Data(topic="cmd_topic", force=False, quiet=True,
+                            address="aa.bb.cc")
+        config = helpers.Data(a=1, b=2)
+
+        r = IM.cmd_line.device.get_battery_voltage(args, config)
+        assert r == 10
+
+        topic = "%s/%s" % (args.topic, args.address)
+        payload = {
+            "cmd" : "get_battery_voltage",
+            }
+        self.check_call(IM.cmd_line.util.send, args, config, topic, payload)
+
+    #-----------------------------------------------------------------------
+    def test_set_low_battery_voltage(self, mocker):
+        mocker.patch('insteon_mqtt.cmd_line.util.send')
+        IM.cmd_line.util.send.return_value = {"status" : 10}
+
+        args = helpers.Data(topic="cmd_topic", force=False, quiet=True,
+                            address="aa.bb.cc", voltage="5.5")
+        config = helpers.Data(a=1, b=2)
+
+        r = IM.cmd_line.device.set_low_battery_voltage(args, config)
+        assert r == 10
+
+        topic = "%s/%s" % (args.topic, args.address)
+        payload = {
+            "cmd" : "set_low_battery_voltage",
+            "voltage" : args.voltage,
+            }
+        self.check_call(IM.cmd_line.util.send, args, config, topic, payload)
+
+    #-----------------------------------------------------------------------

--- a/tests/device/test_BatterySensorDev.py
+++ b/tests/device/test_BatterySensorDev.py
@@ -2,15 +2,16 @@
 #
 # Tests for: insteont_mqtt/device/BatterySensor.py
 #
+# pylint: disable=W0621,W0212
 #===========================================================================
-import pytest
-# from pprint import pprint
 from unittest import mock
 from unittest.mock import call
+import pytest
+# from pprint import pprint
 import insteon_mqtt as IM
-import insteon_mqtt.device.BatterySensor as BatterySensor
+import insteon_mqtt.device as Device
 import insteon_mqtt.message as Msg
-import insteon_mqtt.util as util
+# import insteon_mqtt.util as util
 import helpers as H
 
 @pytest.fixture
@@ -21,13 +22,13 @@ def test_device(tmpdir):
     protocol = H.main.MockProtocol()
     modem = H.main.MockModem(tmpdir)
     addr = IM.Address(0x01, 0x02, 0x03)
-    device = BatterySensor(protocol, modem, addr)
+    device = Device.BatterySensor(protocol, modem, addr)
     return device
 
 
 class Test_Base_Config():
     def test_pair(self, test_device):
-        with mock.patch.object(IM.CommandSeq, 'add'):
+        with mock.patch.object(IM.CommandSeq, 'add') as mocked:
             test_device.pair()
             calls = [
                 call(test_device.refresh),
@@ -38,8 +39,8 @@ class Test_Base_Config():
                 call(test_device.db_add_ctrl_of, 0x04, test_device.modem.addr, 0x01,
                      refresh=False),
             ]
-            IM.CommandSeq.add.assert_has_calls(calls)
-            assert IM.CommandSeq.add.call_count == 4
+            mocked.assert_has_calls(calls)
+            assert mocked.call_count == 4
 
     @pytest.mark.parametrize("cmd1,expected", [
         (Msg.CmdType.ON, True),
@@ -47,7 +48,7 @@ class Test_Base_Config():
         (Msg.CmdType.LINK_CLEANUP_REPORT, None),
     ])
     def test_broadcast_1(self, test_device, cmd1, expected):
-        with mock.patch.object(BatterySensor, '_set_is_on') as mocked:
+        with mock.patch.object(Device.BatterySensor, '_set_is_on') as mocked:
             flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
             group = IM.Address(0x00, 0x00, 0x01)
             addr = IM.Address(0x01, 0x02, 0x03)
@@ -91,3 +92,45 @@ class Test_Base_Config():
                 mocked.assert_called_once_with(test_device, expected)
             else:
                 mocked.assert_not_called()
+
+    def test_pop_queue_and_awake1(self, test_device):
+        # test with empty queue
+        test_device._pop_send_queue()
+        assert len(test_device.protocol.sent) == 0
+        #Queue a message
+        msg = Msg.OutStandard.direct(test_device.addr, 0x11, 0xff)
+        msg_handler = IM.handler.StandardCmd(msg, None, None)
+        test_device.send(msg, msg_handler)
+        # Message hasn't been sent and is queued
+        assert len(test_device.protocol.sent) == 0
+        assert len(test_device._send_queue) == 1
+        # Pretend we got a message from the device and none already sending
+        test_device.protocol.addr_in_queue = False
+        test_device._pop_send_queue()
+        assert len(test_device.protocol.sent) == 1
+        assert len(test_device._send_queue) == 0
+        assert msg_handler._num_retry == 0
+
+    def test_pop_queue_and_awake2(self, test_device):
+        #Queue a message
+        msg = Msg.OutStandard.direct(test_device.addr, 0x11, 0xff)
+        msg_handler = IM.handler.StandardCmd(msg, None, None)
+        test_device.send(msg, msg_handler)
+        # Pretend we got a message from the device and one already sending
+        test_device.protocol.addr_in_queue = True
+        test_device._pop_send_queue()
+        assert len(test_device.protocol.sent) == 0
+        assert len(test_device._send_queue) == 1
+
+    def test_pop_queue_and_awake3(self, test_device):
+        #Queue a message
+        msg = Msg.OutStandard.direct(test_device.addr, 0x11, 0xff)
+        msg_handler = IM.handler.StandardCmd(msg, None, None)
+        test_device.send(msg, msg_handler)
+        # Pretend we called awake
+        def on_done(*args):
+            pass
+        test_device.awake(on_done)
+        assert len(test_device.protocol.sent) == 1
+        assert len(test_device._send_queue) == 0
+        assert msg_handler._num_retry > 0

--- a/tests/util/helpers/main.py
+++ b/tests/util/helpers/main.py
@@ -45,6 +45,7 @@ class MockProtocol:
         self.signal_received = IM.Signal()
         self.signal_msg_finished = IM.Signal()
         self.sent = []
+        self.addr_in_queue = False
 
     def clear(self):
         self.sent = []
@@ -57,6 +58,9 @@ class MockProtocol:
 
     def set_wait_time(self, seconds):
         pass
+
+    def is_addr_in_write_queue(self, *args):
+        return self.addr_in_queue
 
 #===========================================================================
 class MockDevice:


### PR DESCRIPTION
The 2842 Motion Sensor can be queried for its battery voltage.  This is helpful, because I use Li-Ion batteries in these devices and their initial voltage is below what is deemed a low battery, so I never get low battery warnings from these devices.

This adds a feature allowing the user to select what a low voltage is, and then queries the battery voltage in the same way the Remote works.

I also removed retries on Battery devices for messages sent in response to the device being awake.  If the first message doesn't make it, the device will be asleep by the time a retry is done.  This does not apply when a device is manually marked awake.

I still new to write the unit tests.  But this is working on my setup.