### PR TITLE
Add Pause After Broadcast Received

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,7 +9,7 @@
   [Hub Instructions](https://github.com/TD22057/insteon-mqtt/blob/dev/docs/hub.md)
   ([PR 201][P201])
 
-- More pyTests, up to 75% coverage now. ([PR 262][P262] & [PR 268][P268])
+- More pyTests, up to 76% coverage now. ([PR 262][P262] & [PR 268][P268])
 
 - Significant improvement to the Modem database handling.  There is no longer
   a requirement to perform the command `refresh modem` for anything with the
@@ -42,6 +42,9 @@
 
 - Refactor code around Pair().  Add significant amount of unit tests.
   ([PR 277][P277])
+
+- Improved message timing after receiving a broadcast command from a device.
+  ([PR 284][P284])
 
 ## [0.7.4]
 
@@ -515,3 +518,4 @@ will add new features.
 [P279]: https://github.com/TD22057/insteon-mqtt/pull/279
 [P282]: https://github.com/TD22057/insteon-mqtt/pull/282
 [P288]: https://github.com/TD22057/insteon-mqtt/pull/288
+[P284]: https://github.com/TD22057/insteon-mqtt/pull/284

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -239,10 +239,11 @@ class Protocol:
           wait_time (epoch Seconds): The next time a message can be sent
         """
         if wait_time == 0 or wait_time > self._next_write_time:
-            wait_time = time.time() if wait_time == 0
+            wait_time = time.time() if wait_time == 0 else wait_time
             self._next_write_time = wait_time
-            time = datetime.datetime.fromtimestamp(self._next_write_time).strftime('%H:%M:%S.%f')[:-3]
-            LOG.debug("Setting next write time: %s", time)
+            print_time = datetime.datetime.fromtimestamp(
+                self._next_write_time).strftime('%H:%M:%S.%f')[:-3]
+            LOG.debug("Setting next write time: %s", print_time)
 
     #-----------------------------------------------------------------------
     def is_addr_in_write_queue(self, addr):

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -6,6 +6,7 @@
 import collections
 import enum
 import time
+import datetime
 from . import log
 from . import message as Msg
 from .Signal import Signal
@@ -239,7 +240,8 @@ class Protocol:
         """
         if wait_time == 0 or wait_time > self._next_write_time:
             self._next_write_time = wait_time
-            LOG.debug("Setting next write time: %f", self._next_write_time)
+            time = datetime.datetime.fromtimestamp(self._next_write_time).strftime('%H:%M:%S.%f')[:-3]
+            LOG.debug("Setting next write time: %s", time)
 
     #-----------------------------------------------------------------------
     def is_addr_in_write_queue(self, addr):

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -230,12 +230,16 @@ class Protocol:
     def set_wait_time(self, wait_time):
         """Set the Next Time that a Message Can be Sent to Avoid Collision.
 
-        Next time that a message can be written.
+        Next time that a message can be written.  If the wait time is set to
+        zero, it will cancel all pending wait time.  If the wait time is
+        less than the current pending wait time, it will be ignored.
 
         Args:
           wait_time (epoch Seconds): The next time a message can be sent
         """
-        self._next_write_time = wait_time
+        if wait_time == 0 or wait_time > self._next_write_time:
+            self._next_write_time = wait_time
+            LOG.debug("Setting next write time: %f", self._next_write_time)
 
     #-----------------------------------------------------------------------
     def is_addr_in_write_queue(self, addr):
@@ -303,10 +307,7 @@ class Protocol:
             start = self._buf.find(0x15)
             if start == 0:
                 LOG.info("PLM is busy, pausing briefly")
-                # Pause for 1/3 of a second if we are not already waiting
-                # longer
-                if self._next_write_time + .3 < time.time():
-                    self._next_write_time = time.time() + .3
+                self.set_wait_time(time.time() + .3)
                 self._buf = self._buf[1:]
                 continue
 
@@ -393,8 +394,7 @@ class Protocol:
 
         # Update the next allowed write time based on the number of hops that
         # are remaining on the inbound message.
-        self._next_write_time = msg.expire_time
-        LOG.debug("Setting next write time: %f", self._next_write_time)
+        self.set_wait_time(msg.expire_time)
 
         # See if we have a duplicate message.
         if msg in self._read_history:

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -239,6 +239,7 @@ class Protocol:
           wait_time (epoch Seconds): The next time a message can be sent
         """
         if wait_time == 0 or wait_time > self._next_write_time:
+            wait_time = time.time() if wait_time == 0
             self._next_write_time = wait_time
             time = datetime.datetime.fromtimestamp(self._next_write_time).strftime('%H:%M:%S.%f')[:-3]
             LOG.debug("Setting next write time: %s", time)

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -4,7 +4,6 @@
 #
 #===========================================================================
 import json
-import time
 import os.path
 from .MsgHistory import MsgHistory
 from ..Address import Address

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -1094,18 +1094,6 @@ class Base:
         LOG.debug("Found %s responders in group %s", len(responders), group)
         LOG.debug("Group %s -> %s", group, [i.addr.hex for i in responders])
 
-        # A device broadcast will be followed up a series of cleanup messages
-        # between the devices and sent to the modem.  Don't send anything
-        # during this time to avoid causing a collision.  Time is equal to .5
-        # second of overhead, plus .5 seconds per responer device.  This is
-        # based off the same 87 msec empircal testing performed when designing
-        # misterhouse.  Each device causes a cleanup and an ack.  Assuminng
-        # a max of three hops in each direction that is 6 * .087 or .522 per
-        # device.
-        wait_time = .5 + (len(responders) * .5)
-        LOG.debug("Pausing sending for %s seconds.", wait_time)
-        self.protocol.set_wait_time(time.time() + wait_time)
-
         # For each device that we're the controller of call it's handler for
         # the broadcast message.
         for elem in responders:

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -1102,7 +1102,9 @@ class Base:
         # misterhouse.  Each device causes a cleanup and an ack.  Assuminng
         # a max of three hops in each direction that is 6 * .087 or .522 per
         # device.
-        self.protocol.set_wait_time(time.time() + .5 + (len(responders) * .5))
+        wait_time = .5 + (len(responders) * .5)
+        LOG.debug("Pausing sending for %s seconds.", wait_time)
+        self.protocol.set_wait_time(time.time() + wait_time)
 
         # For each device that we're the controller of call it's handler for
         # the broadcast message.

--- a/insteon_mqtt/handler/Broadcast.py
+++ b/insteon_mqtt/handler/Broadcast.py
@@ -3,6 +3,7 @@
 # Broadcast message handler.
 #
 #===========================================================================
+import time
 from .. import log
 from .. import message as Msg
 from .Base import Base
@@ -72,27 +73,67 @@ class Broadcast(Base):
         if not isinstance(msg, Msg.InpStandard):
             return Msg.UNKNOWN
 
+        # Calculate the total time this process could take
+        # A device broadcast will be followed up a series of cleanup messages
+        # between the devices and sent to the modem.  Don't send anything
+        # during this time to avoid causing a collision.  Time is equal to .5
+        # second of overhead, plus .5 seconds per responer device.  This is
+        # based off the same 87 msec empircal testing performed when designing
+        # misterhouse.  Each device causes a cleanup and an ack.  Assuminng
+        # a max of three hops in each direction that is 6 * .087 or .522 per
+        # device.
+        device = self.modem.find(msg.from_addr)
+        wait_time = 0
+        if device:
+            responders = device.db.find_group(msg.group)
+            wait_time = .5 + (len(responders) * .5)
+
         # Process the all link broadcast.
         if msg.flags.type == Msg.Flags.Type.ALL_LINK_BROADCAST:
-            self._last_broadcast = msg
-            return self._process(msg)
+            if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
+                if self._last_broadcast is None:
+                    # We have no record of the initial broadcast or direct
+                    # cleanup, this is almost certainly an echo of the
+                    # cleanup_report
+                    return Msg.CONTINUE
+                else:
+                    # This is the final broadcast signalling completion.
+                    # Clear duplicate tracking and re-enable sending
+                    self._last_broadcast = None
+                    # First clear wait time
+                    protocol.set_wait_time(0)
+                    # Then set as expire time of this message
+                    protocol.set_wait_time(msg.expire_time)
+                    # cmd2 identifies the number of failed devices
+                    if msg.cmd2 == 0x00:
+                        LOG.debug("Cleanup report for %s, grp %s success.",
+                                  msg.from_addr, msg.group)
+                    else:
+                        text = "Cleanup report for %s, grp %s had %d fails."
+                        LOG.warning(text, msg.from_addr, msg.group, msg.cmd2)
+                    return self._process(msg, protocol, wait_time)
+            else:
+                # This is the initial broadcast or an echo of it.
+                if self._should_process(msg, wait_time):
+                    return self._process(msg, protocol, wait_time)
+                else:
+                    return Msg.CONTINUE
 
         # Clean up message is basically the same data but addressed to the
         # modem.  If we saw the broadcast, we don't need to handle this.  But
         # if we missed the broadcast, this gives us a second chance to
         # trigger the scene.
         elif msg.flags.type == Msg.Flags.Type.ALL_LINK_CLEANUP:
-            if self._should_process(msg):
-                return self._process(msg)
-
-            self._last_broadcast = None
-            return Msg.CONTINUE
+            if self._should_process(msg, wait_time):
+                return self._process(msg, protocol, wait_time)
+            else:
+                return Msg.CONTINUE
 
         # Different message flags than we expected.
         return Msg.UNKNOWN
 
     #-----------------------------------------------------------------------
-    def _process(self, msg):
+    def _process(self, msg, protocol, wait_time):
         """Process the all link broadcast message.
 
         Args:
@@ -112,17 +153,28 @@ class Broadcast(Base):
         LOG.info("Handling all link broadcast for %s '%s'", device.addr,
                  device.name)
 
+        # Save for deduplication detection
+        self._last_broadcast = msg
+
+        # Delay sending, see above
+        LOG.debug("Pausing sending for %s seconds.", wait_time)
+        protocol.set_wait_time(time.time() + wait_time)
+
         # Tell the device about it.  This will look up all the responders for
         # this group and tell them that the scene has been activated.
         device.handle_broadcast(msg)
         return Msg.CONTINUE
 
     #-----------------------------------------------------------------------
-    def _should_process(self, msg):
+    def _should_process(self, msg, wait_time):
         """Should we process a cleanup message?
+
+        Checks if this is a duplicate of a message we have already seen.
 
         Args:
           msg (Msg.InpStandard):  Cleanup message to handle.
+          wait_time (float):      The number of seconds this process could
+                                  take to complate.  Used to find duplicates
 
         Returns:
           bool:  True if the message should be procssed, False otherwise.
@@ -130,11 +182,14 @@ class Broadcast(Base):
         if not self._last_broadcast:
             return True
 
-        # Don't process the cleanup if we just got the corresponding broadcast
-        # message from the same device.
+        # Don't process the message if we just got a corresponding broadcast
+        # message from the same device.  Wait time plus expire time is used
+        # to ignore old messages.  Expire_time adds more time then we need
+        # but the timings don't have to be perfect
         if (self._last_broadcast.from_addr == msg.from_addr and
                 self._last_broadcast.group == msg.group and
-                self._last_broadcast.cmd1 == msg.cmd1):
+                self._last_broadcast.cmd1 == msg.cmd1 and
+                self._last_broadcast.expire_time + wait_time > time.time()):
             return False
 
         return True

--- a/insteon_mqtt/handler/Broadcast.py
+++ b/insteon_mqtt/handler/Broadcast.py
@@ -24,6 +24,11 @@ class Broadcast(Base):
     message gets ignored).  So if we get the broadcast, the cleanup is
     ignored.
 
+    Finally a broadcast LINK_CLEANUP_REPORT is sent.  This message indicates
+    if the device received ACKs from all linked devices or not.  This message
+    indicates that the device is finished sending messages.  However, as
+    broadcast message, it is not guaranteed to be received.
+
     This handler will call device.handle_broadcast(msg) for the device that
     sends the message.
 

--- a/insteon_mqtt/log.py
+++ b/insteon_mqtt/log.py
@@ -71,7 +71,7 @@ def initialize(level=None, screen=None, file=None, config=None):
     log_obj.setLevel(level)
 
     # Add handlers for the optional screen and file output.
-    fmt = '%(asctime)s %(levelname)s %(module)s: %(message)s'
+    fmt = '%(asctime)s.%(msecs)03d %(levelname)s %(module)s: %(message)s'
     datefmt = '%Y-%m-%d %H:%M:%S'
     formatter = logging.Formatter(fmt, datefmt)
 

--- a/insteon_mqtt/message/Flags.py
+++ b/insteon_mqtt/message/Flags.py
@@ -115,7 +115,8 @@ class Flags:
 
     #-----------------------------------------------------------------------
     def __str__(self):
-        return "%s%s mh:%s hl:%s" % (self.type, '' if not self.is_ext else ' ext',
+        return "%s%s mh:%s hl:%s" % (self.type,
+                                     '' if not self.is_ext else ' ext',
                                      self.max_hops, self.hops_left)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/message/Flags.py
+++ b/insteon_mqtt/message/Flags.py
@@ -115,6 +115,7 @@ class Flags:
 
     #-----------------------------------------------------------------------
     def __str__(self):
-        return "%s%s" % (self.type, '' if not self.is_ext else ' ext')
+        return "%s%s mh:%s hl:%s" % (self.type, '' if not self.is_ext else ' ext',
+                                     self.max_hops, self.hops_left)
 
     #-----------------------------------------------------------------------

--- a/tests/handler/test_Broadcast.py
+++ b/tests/handler/test_Broadcast.py
@@ -46,7 +46,7 @@ class Test_Broadcast:
         assert len(calls) == 1
 
         # If broadcast wasn't found, cleanup should be handled.
-        handler._handled = False
+        handler._last_broadcast = None
         r = handler.msg_received(proto, msg)
 
         assert r == Msg.CONTINUE
@@ -86,4 +86,7 @@ class MockProto:
         self.signal_received = IM.Signal()
 
     def add_handler(self, *args):
+        pass
+
+    def set_wait_time(self, *args):
         pass

--- a/tests/handler/test_Broadcast.py
+++ b/tests/handler/test_Broadcast.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=protected-access
 #===========================================================================
+import time
 import insteon_mqtt as IM
 import insteon_mqtt.message as Msg
 
@@ -21,6 +22,7 @@ class Test_Broadcast:
 
         r = handler.msg_received(proto, "dummy")
         assert r == Msg.UNKNOWN
+        assert len(calls) == 0
 
         flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
         msg = Msg.InpStandard(addr, broadcast_to_addr, flags, 0x11, 0x01)
@@ -28,14 +30,29 @@ class Test_Broadcast:
         # no device
         r = handler.msg_received(proto, msg)
         assert r == Msg.UNKNOWN
+        assert len(calls) == 0
 
+        # test good broadcat
+        assert proto.wait_time == 0
         device = IM.device.Base(proto, modem, addr, "foo")
+
+        # add 10 device db entries for this group
+        for count in range(10):
+            e_addr = IM.Address(0x10, 0xab, count)
+            db_flags = Msg.DbFlags(in_use=True, is_controller=True,
+                                   is_last_rec=False)
+            entry = IM.db.DeviceEntry(e_addr, 0x01, count, db_flags,
+                                      bytes([0x01, 0x02, 0x03]))
+            device.db.add_entry(entry)
+
         device.handle_broadcast = calls.append
         modem.add(device)
         r = handler.msg_received(proto, msg)
 
         assert r == Msg.CONTINUE
         assert len(calls) == 1
+        # should be at least 5.5 seconds ahead
+        assert proto.wait_time - time.time() > 5
 
         # cleanup should be ignored since prev was processed.
         flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_CLEANUP, False)
@@ -58,6 +75,7 @@ class Test_Broadcast:
         assert r == Msg.UNKNOWN
 
         # Success Report Broadcast
+        pre_success_time = proto.wait_time
         flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
         success_report_to_addr = IM.Address(0x11, 1, 0x1)
         msg = Msg.InpStandard(addr, addr, flags, 0x06, 0x00)
@@ -65,6 +83,8 @@ class Test_Broadcast:
 
         assert r == Msg.CONTINUE
         assert len(calls) == 3
+        # wait time should be cleared
+        assert proto.wait_time < pre_success_time
 
         # Pretend that a new broadcast message dropped / not received by PLM
 
@@ -84,9 +104,10 @@ class Test_Broadcast:
 class MockProto:
     def __init__(self):
         self.signal_received = IM.Signal()
+        self.wait_time = 0
 
     def add_handler(self, *args):
         pass
 
-    def set_wait_time(self, *args):
-        pass
+    def set_wait_time(self, wait_time):
+        self.wait_time = wait_time

--- a/tests/test_Protocol.py
+++ b/tests/test_Protocol.py
@@ -5,9 +5,14 @@
 # pylint: disable=protected-access
 #===========================================================================
 import time
+import pytest
 import insteon_mqtt as IM
 import insteon_mqtt.message as Msg
 
+@pytest.fixture
+def test_proto():
+    link = MockSerial()
+    return IM.Protocol(link)
 
 class Test_Protocol:
     def test_reads(self):
@@ -56,6 +61,14 @@ class Test_Protocol:
         assert proto._read_history[0] == msg_keep
 
     #-----------------------------------------------------------------------
+    def test_set_wait_time(self, test_proto):
+        assert test_proto._next_write_time == 0
+        test_proto.set_wait_time(5)
+        assert test_proto._next_write_time == 5
+        test_proto.set_wait_time(2)
+        assert test_proto._next_write_time == 5
+        test_proto.set_wait_time(0)
+        assert test_proto._next_write_time > 5
 
 #===========================================================================
 


### PR DESCRIPTION
This pauses sending any messages after receiving a broadcast.  The pause length is calculated based on the known number of responders to which the device will be sending cleanup messages to.  If a cleanup report is received, then the broadcast sequence is finished and the pause is removed if any time is still remaining.

It also adds some reporting on receiving cleanup reports that have failures.  

Milliseconds has been added to the logging times and wait_times are now reported as the ending time instead of seconds to make debugging easier.

Unit tests are updated and this works on my end.