### PR TITLE
Improve on-level handling for dimmers & related devices

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -330,7 +330,7 @@ mqtt:
     # reason is input, is will be passed through to the state_payload.  The
     # output of passing the payload through the template must match the
     # following:
-    #   { "cmd" : "on"/"off", "level" : LEVEL,
+    #   { "cmd" : "on"/"off", ["level" : LEVEL],
     #                         ["mode" : 'normal'/'fast'/'instant'],
     #                         ["fast" : 1/0], ["instant" : 1/0] }
     # where:
@@ -345,13 +345,16 @@ mqtt:
     # NOTE: HASS JSON switch doesn't send brightness in some cases
     # when actuated so handle that here in the template code.  The
     # other HASS MQTT options also have this problem.
+    # This example will use device's configured default on-level if brightness
+    # is not specified.  To use full-brightness instead, add the following to
+    # the json.brightness check below:
+    #    {% else %}
+    #        , "level" : 255
     level_payload: >
-       { "cmd" : "{{json.state.lower()}}",
-         "level" : {% if json.brightness is defined %}
-                      {{json.brightness}}
-                   {% else %}
-                      255
-                   {% endif %} }
+       { "cmd" : "{{json.state.lower()}}"
+         {% if json.brightness is defined %}
+             , "level" : {{json.brightness}}
+         {% endif %} }       
 
     # Scene on/off command.  This triggers the scene broadcast on the switch
     # in the same way clicking the button would.  The inputs are the same as
@@ -813,7 +816,7 @@ mqtt:
     # case either command format is valid.   If reason is input, is will be
     # passed through to the state_payload.  The output of passing the
     # payload through the template must match the following:
-    #   { "cmd" : "on"/"off", "level" : LEVEL,
+    #   { "cmd" : "on"/"off", ["level" : LEVEL],
     #             ["mode" : 'normal'/'fast'/'instant'],
     #             ["fast" : 1/0], ["instant" : 1/0], ["reason" : "..."] }
     # where:
@@ -828,13 +831,16 @@ mqtt:
     # NOTE: HASS JSON switch doesn't send brightness in some cases
     # when actuated so handle that here in the template code.  The
     # other HASS MQTT options also have this problem.
+    # This example will use device's configured default on-level if brightness
+    # is not specified.  To use full-brightness instead, add the following to
+    # the json.brightness check below:
+    #    {% else %}
+    #        , "level" : 255
     dimmer_level_payload: >
-       { "cmd" : "{{json.state.lower()}}",
-         "level" : {% if json.brightness is defined %}
-                      {{json.brightness}}
-                   {% else %}
-                      255
-                   {% endif %} }
+       { "cmd" : "{{json.state.lower()}}"
+         {% if json.brightness is defined %}
+             , "level" : {{json.brightness}}
+         {% endif %} }       
 
     # Scene on/off command.  This triggers the scene broadcast on the switch
     # in the same way clicking the button would.  The inputs are the same as

--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -446,7 +446,6 @@ class Base:
 
     #-----------------------------------------------------------------------
     def get_flags(self, on_done=None):
-
         """Get the Insteon operational flags field from the device.
 
         The flags will be passed to the on_done callback as the data field.

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -466,6 +466,69 @@ class Dimmer(Base):
         self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
+    def get_flags(self, on_done=None):
+        """Hijack base get_flags to inject extended flags request.
+
+        The flags will be passed to the on_done callback as the data field.
+        Derived types may do something with the flags by override the
+        handle_flags method.
+
+        Args:
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        seq = CommandSeq(self, "Dimmer get_flags complete", on_done,
+                         name="GetFlags")
+        seq.add(super().get_flags)
+        seq.add(self._get_ext_flags)
+        seq.run()
+
+    #-----------------------------------------------------------------------
+    def _get_ext_flags(self, on_done=None):
+        """Get the Insteon operational extended flags field from the device.
+
+        For the dimmer device, the flags include on-level and ramp-rate.
+
+        Args:
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        LOG.info("Dimmer %s cmd: get extended operation flags", self.label)
+
+        # Requesting data d1 = 0x01
+        data = bytes([0x01] + [0x00] * 13)
+
+        msg = Msg.OutExtended.direct(self.addr, Msg.CmdType.EXTENDED_SET_GET,
+                                     0x00, data)
+        msg_handler = handler.ExtendedCmdResponse(msg, self.handle_ext_flags,
+                                                  on_done)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def handle_ext_flags(self, msg, on_done):
+        """Handle replies to the _get_ext_flags command.
+
+        Extended message payload is:
+          D8 = on-level
+          D9 = ramp-rate
+
+        Args:
+          msg (message.InpExtended):  The message reply.
+          on_done:  Finished callback.  This is called when the command has
+                    completed.  Signature is: on_done(success, msg, data)
+        """
+        on_level = msg.data[7]
+        self.db.set_meta('on_level', on_level)
+        ramp_rate = msg.data[8]
+        for ramp_key, ramp_value in self.ramp_pretty.items():
+            if ramp_rate <= ramp_key:
+                ramp_rate = ramp_value
+                break
+        LOG.ui("Dimmer %s on_level: %s%% ramp rate: %ss", self.label,
+               on_level / 2.55, ramp_rate)
+        on_done(True, "Operation complete", msg.data[5])
+
+    #-----------------------------------------------------------------------
     def set_on_level(self, level, on_done=None):
         """Set the device default on level.
 

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -495,7 +495,8 @@ class Dimmer(Base):
         """
         LOG.info("Dimmer %s cmd: get extended operation flags", self.label)
 
-        # Requesting data d1 = 0x01
+        # D1 = group (0x01), D2 = 0x00 == Data Request, others ignored,
+        # per Insteon Dev Guide
         data = bytes([0x01] + [0x00] * 13)
 
         msg = Msg.OutExtended.direct(self.addr, Msg.CmdType.EXTENDED_SET_GET,
@@ -519,13 +520,13 @@ class Dimmer(Base):
         """
         on_level = msg.data[7]
         self.db.set_meta('on_level', on_level)
-        ramp_rate = msg.data[8]
+        ramp_rate = msg.data[6]
         for ramp_key, ramp_value in self.ramp_pretty.items():
             if ramp_rate <= ramp_key:
                 ramp_rate = ramp_value
                 break
-        LOG.ui("Dimmer %s on_level: %s%% ramp rate: %ss", self.label,
-               on_level / 2.55, ramp_rate)
+        LOG.ui("Dimmer %s on_level: %s (%.2f%%) ramp rate: %ss", self.label,
+               on_level, on_level / 2.55, ramp_rate)
         on_done(True, "Operation complete", msg.data[5])
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -511,7 +511,7 @@ class Dimmer(Base):
 
         Extended message payload is:
           D8 = on-level
-          D9 = ramp-rate
+          D7 = ramp-rate
 
         Args:
           msg (message.InpExtended):  The message reply.

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -822,7 +822,7 @@ class KeypadLinc(Base):
 
         # Use the standard command handler which will notify us when the
         # command is ACK'ed.
-        callback = functools.partial(self.handle_ack, task="Button on level")
+        callback = functools.partial(self.handle_on_level, level=level)
         msg_handler = handler.StandardCmd(msg, callback, on_done)
 
         self.send(msg, msg_handler)
@@ -1156,6 +1156,36 @@ class KeypadLinc(Base):
         on_done(True, "%s updated" % task, None)
 
     #-----------------------------------------------------------------------
+    def handle_on_level(self, msg, on_done, level):
+        """Callback for handling set_on_level() responses.
+
+        This is called when we get a response to the set_on_level() command.
+        Update stored on-level in device DB and call the on_done callback with
+        the status.
+
+        Args:
+          msg (InpStandard): The response message from the command.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        self.db.set_meta('on_level', level)
+        on_done(True, "Button on level updated", None)
+
+    #-----------------------------------------------------------------------
+    def get_on_level(self):
+        """Look up previously-set on-level in device database, if present
+
+        This is called when we need to look up what is the default on-level
+        (such as when getting an ON broadcast message from the device).
+
+        If on_level is not found in the DB, assumes on-level is full-on.
+        """
+        on_level = self.db.get_meta('on_level')
+        if on_level is None:
+            on_level = 0xff
+        return on_level
+
+    #-----------------------------------------------------------------------
     def handle_backlight_on(self, msg, on_done, is_on):
         """Callback for handling turning the backlight on and off.
 
@@ -1371,19 +1401,36 @@ class KeypadLinc(Base):
             self.broadcast_done = None
             return
 
-        # On/off commands.  How do we tell the level?  It's not in the
-        # message anywhere.
+        # On/off commands.
         elif on_off.Mode.is_valid(msg.cmd1):
             is_on, mode = on_off.Mode.decode(msg.cmd1)
             LOG.info("KeypadLinc %s broadcast grp: %s on: %s mode: %s",
                      self.addr, msg.group, is_on, mode)
 
+            # For an on command, we can update directly.
             if is_on:
-                self._set_level(msg.group, 0xff, mode, reason)
+                # Level isn't provided in the broadcast msg.
+                # What to use depends on which command was received.
+                if msg.group != self._load_group:
+                    # Only load group can be a dimmer, use full-on for others
+                    level = 0xff
+                elif mode == on_off.Mode.FAST:
+                    # Fast-ON command.  Use full-brightness.
+                    level = 0xff
+                else:
+                    # Normal/instant ON command.  Use default on-level.
+                    # Check if we saved the default on-level in the device
+                    # database when setting it.
+                    level = self.get_on_level()
+                    if self._level == level:
+                        # Pressing on again when already at the default on
+                        # level causes the device to go to full-brightness.
+                        level = 0xff
+                self._set_level(msg.group, level, mode, reason)
 
             # For an off command, we need to see if broadcast_done is active.
             # This is a generated broadcast and we need to manually turn the
-            # device off so don't update it's state until that occurs.
+            # device off so don't update its state until that occurs.
             elif not self.broadcast_done:
                 self._set_level(msg.group, 0x00, mode, reason)
 

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -844,7 +844,8 @@ class KeypadLinc(Base):
         """
         LOG.info("Dimmer %s cmd: get extended operation flags", self.label)
 
-        # Requesting data d1 = 0x01
+        # D1 = group (0x01), D2 = 0x00 == Data Request, others ignored,
+        # per Insteon Dev Guide
         data = bytes([0x01] + [0x00] * 13)
 
         msg = Msg.OutExtended.direct(self.addr, Msg.CmdType.EXTENDED_SET_GET,
@@ -873,8 +874,8 @@ class KeypadLinc(Base):
             if ramp_rate <= ramp_key:
                 ramp_rate = ramp_value
                 break
-        LOG.ui("Dimmer %s on_level: %s%% ramp rate: %ss", self.label,
-               on_level / 2.55, ramp_rate)
+        LOG.ui("Dimmer %s on_level: %s (%.2f%%) ramp rate: %ss", self.label,
+               on_level, on_level / 2.55, ramp_rate)
         on_done(True, "Operation complete", msg.data[5])
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -815,6 +815,69 @@ class KeypadLinc(Base):
         self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
+    def get_flags(self, on_done=None):
+        """Hijack base get_flags to inject extended flags request.
+
+        The flags will be passed to the on_done callback as the data field.
+        Derived types may do something with the flags by override the
+        handle_flags method.
+
+        Args:
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        seq = CommandSeq(self, "Dimmer get_flags complete", on_done,
+                         name="GetFlags")
+        seq.add(super().get_flags)
+        seq.add(self._get_ext_flags)
+        seq.run()
+
+    #-----------------------------------------------------------------------
+    def _get_ext_flags(self, on_done=None):
+        """Get the Insteon operational extended flags field from the device.
+
+        For the dimmer device, the flags include on-level and ramp-rate.
+
+        Args:
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        LOG.info("Dimmer %s cmd: get extended operation flags", self.label)
+
+        # Requesting data d1 = 0x01
+        data = bytes([0x01] + [0x00] * 13)
+
+        msg = Msg.OutExtended.direct(self.addr, Msg.CmdType.EXTENDED_SET_GET,
+                                     0x00, data)
+        msg_handler = handler.ExtendedCmdResponse(msg, self.handle_ext_flags,
+                                                  on_done)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def handle_ext_flags(self, msg, on_done):
+        """Handle replies to the _get_ext_flags command.
+
+        Extended message payload is:
+          D8 = on-level
+          D7 = ramp-rate
+
+        Args:
+          msg (message.InpExtended):  The message reply.
+          on_done:  Finished callback.  This is called when the command has
+                    completed.  Signature is: on_done(success, msg, data)
+        """
+        on_level = msg.data[7]
+        self.db.set_meta('on_level', on_level)
+        ramp_rate = msg.data[6]
+        for ramp_key, ramp_value in Dimmer.ramp_pretty.items():
+            if ramp_rate <= ramp_key:
+                ramp_rate = ramp_value
+                break
+        LOG.ui("Dimmer %s on_level: %s%% ramp rate: %ss", self.label,
+               on_level / 2.55, ramp_rate)
+        on_done(True, "Operation complete", msg.data[5])
+
+    #-----------------------------------------------------------------------
     def set_on_level(self, level, on_done=None):
         """Set the device default on level.
 

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -226,7 +226,7 @@ class KeypadLinc(Base):
         seq.add_msg(msg, msg_handler)
 
     #-----------------------------------------------------------------------
-    def on(self, group=0, level=0xff, mode=on_off.Mode.NORMAL, reason="",
+    def on(self, group=0, level=None, mode=on_off.Mode.NORMAL, reason="",
            on_done=None):
         """Turn the device on.
 
@@ -249,7 +249,7 @@ class KeypadLinc(Base):
                 specific button.
           level (int):  If non zero, turn the device on.  Should be in the
                 range 0 to 255.  For non-dimmer groups, it will only look at
-                level=0 or level>0.
+                level=0 or level>0.  If None, use default on-level.
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           reason (str):  This is optional and is used to identify why the
                  command was sent. It is passed through to the output signal
@@ -264,6 +264,24 @@ class KeypadLinc(Base):
         group = self._load_group if group == 0 else group
 
         LOG.debug("load group= %s group= %s", self._load_group, group)
+
+        if level is None:
+            # Not specified - choose brightness as pressing the button would do
+            if group != self._load_group:
+                # Only load group can be a dimmer, use full-on for others
+                level = 0xff
+            if mode == on_off.Mode.FAST:
+                # Fast-ON command.  Use full-brightness.
+                level = 0xff
+            else:
+                # Normal/instant ON command.  Use default on-level.
+                # Check if we saved the default on-level in the device
+                # database when setting it.
+                level = self.get_on_level()
+                if self._level == level:
+                    # Just like with button presses, if already at default on
+                    # level, go to full brightness.
+                    level = 0xff
 
         assert 1 <= group <= 9
         assert 0 <= level <= 0xff
@@ -360,7 +378,7 @@ class KeypadLinc(Base):
         Args:
           level (int):  If non zero, turn the device on.  Should be in the
                 range 0 to 255.  For non-dimmer groups, it will only look at
-                level=0 or level>0.
+                level=0 or level>0.  If None, use default on-level.
           group (int): The group to send the command to.  If the group is 0,
                 it will always be the load (whether it's attached or not).
                 Otherwise it must be in the range [1,8] and controls the
@@ -372,7 +390,12 @@ class KeypadLinc(Base):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        if level:
+        if (level is None) or level:
+            # None/True == use default on-level.  Since true is integer 1,
+            # do an explicit check here to catch that input.
+            if level is True:
+                level = None
+
             self.on(group, level, mode, reason, on_done)
         else:
             self.off(group, mode, reason, on_done)

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -230,9 +230,9 @@ class Dimmer:
         data = self.msg_on_off.to_json(message.payload)
         LOG.info("Dimmer input command: %s", data)
         try:
-            # Tell the device to update it's state.
+            # Tell the device to update its state.
             is_on, mode = util.parse_on_off(data)
-            level = 0 if not is_on else 0xff
+            level = 0 if not is_on else None
             reason = data.get("reason", "")
             self.device.set(level=level, mode=mode, reason=reason)
         except:
@@ -257,10 +257,12 @@ class Dimmer:
         LOG.info("Dimmer input command: %s", data)
         try:
             is_on, mode = util.parse_on_off(data)
-            level = 0 if not is_on else int(data.get('level'))
+            level = '0' if not is_on else data.get('level')
+            if level is not None:
+                level = int(level)
             reason = data.get("reason", "")
 
-            # Tell the device to change it's level.
+            # Tell the device to change its level.
             self.device.set(level=level, mode=mode, reason=reason)
         except:
             LOG.exception("Invalid dimmer command: %s", data)

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -294,7 +294,7 @@ class KeypadLinc:
         LOG.info("KeypadLinc btn %s input command: %s", group, data)
         try:
             is_on, mode = util.parse_on_off(data)
-            level = 0xff if is_on else 0x00
+            level = None if is_on else 0x00
             reason = data.get("reason", "")
             self.device.set(level, group, mode, reason=reason)
         except:
@@ -304,7 +304,7 @@ class KeypadLinc:
 
     #-----------------------------------------------------------------------
     def _input_set_level(self, client, data, message, raise_errors=False):
-        """Handle an input level changechange MQTT message.
+        """Handle an input level change MQTT message.
 
         This is called when we receive a message on the level change MQTT
         topic subscription.  Parse the message and pass the command to the
@@ -327,7 +327,9 @@ class KeypadLinc:
         LOG.info("KeypadLinc input command: %s", data)
         try:
             is_on, mode = util.parse_on_off(data)
-            level = 0 if not is_on else int(data.get('level'))
+            level = '0' if not is_on else data.get('level')
+            if level is not None:
+                level = int(level)
             reason = data.get("reason", "")
             self.device.set(level, mode=mode, reason=reason)
         except:

--- a/tests/device/test_DimmerDev.py
+++ b/tests/device/test_DimmerDev.py
@@ -58,3 +58,63 @@ class Test_Base_Config():
                 mocked.assert_called_once_with(test_device, *expected)
             else:
                 mocked.assert_not_called()
+
+    def test_set_on_level(self, test_device):
+        # set_on_level(self, level, on_done=None)
+        def level_bytes(level):
+            data = bytes([
+                0x01,
+                0x06,
+                level,
+                ] + [0x00] * 11)
+            return data
+        assert(test_device.get_on_level() == 255)
+        for params in ([1, 0x01], [127, 127], [255, 0xFF]):
+            test_device.set_on_level(params[0])
+            assert len(test_device.protocol.sent) == 1
+            assert test_device.protocol.sent[0].msg.cmd1 == 0x2e
+            assert (test_device.protocol.sent[0].msg.data ==
+                    level_bytes(params[1]))
+            test_device.protocol.clear()
+
+        test_device.set_on_level(64)
+
+        # Fake having completed the set_on_level(64) request
+        flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
+        ack = IM.message.InpStandard(test_device.addr.hex,
+                                     test_device.modem.addr.hex,
+                                     flags, 0x2e, 0x00)
+        test_device.handle_on_level(ack, IM.util.make_callback(None), 64)
+        assert(test_device.get_on_level() == 64)
+        test_device.protocol.clear()
+
+        # Try multiple button presses in a row; confirm that level goes to
+        # default on-level then to full brightness, as expected.
+        # Fast-on should always go to full brightness.
+        params = [
+            (Msg.CmdType.ON, 0x00, [64, IM.on_off.Mode.NORMAL, 'device']),
+            (Msg.CmdType.ON, 0x00, [255, IM.on_off.Mode.NORMAL, 'device']),
+            (Msg.CmdType.ON, 0x00, [64, IM.on_off.Mode.NORMAL, 'device']),
+            (Msg.CmdType.OFF, 0x00, [0, IM.on_off.Mode.NORMAL, 'device']),
+            (Msg.CmdType.ON_FAST, 0x00, [255, IM.on_off.Mode.FAST, 'device']),
+            (Msg.CmdType.ON_FAST, 0x00, [255, IM.on_off.Mode.FAST, 'device']),
+            (Msg.CmdType.OFF_FAST, 0x00, [0, IM.on_off.Mode.FAST, 'device']),
+            (Msg.CmdType.ON_INSTANT, 0x00,
+                [64, IM.on_off.Mode.INSTANT, 'device']),
+            (Msg.CmdType.ON_INSTANT, 0x00,
+                [255, IM.on_off.Mode.INSTANT, 'device']),
+            (Msg.CmdType.ON_INSTANT, 0x00,
+                [64, IM.on_off.Mode.INSTANT, 'device'])]
+        for cmd1, cmd2, expected in params:
+            with mock.patch.object(IM.Signal, 'emit') as mocked:
+                print("Trying:", "[%x, %x]" % (cmd1, cmd2))
+                flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
+                group_num = 0x01
+                group = IM.Address(0x00, 0x00, group_num)
+                addr = IM.Address(0x01, 0x02, 0x03)
+                msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
+                test_device.handle_broadcast(msg)
+                if expected is not None:
+                    mocked.assert_called_once_with(test_device, *expected)
+                else:
+                    mocked.assert_not_called()

--- a/tests/device/test_DimmerDev.py
+++ b/tests/device/test_DimmerDev.py
@@ -125,7 +125,7 @@ class Test_Base_Config():
         with mock.patch.object(IM.CommandSeq, 'add'):
             test_device.get_flags()
             calls = [
-                # can't figure out how to define the call to super().get_flags
+                # TODO: figure out how to define the call to super().get_flags
                 call(test_device._get_ext_flags),
             ]
             IM.CommandSeq.add.assert_has_calls(calls)

--- a/tests/device/test_KeypadLincDev.py
+++ b/tests/device/test_KeypadLincDev.py
@@ -367,7 +367,7 @@ class Test_KPL():
         with mock.patch.object(IM.CommandSeq, 'add'):
             test_device.get_flags()
             calls = [
-                # can't figure out how to define the call to super().get_flags
+                # TODO: figure out how to define the call to super().get_flags
                 call(test_device._get_ext_flags),
             ]
             IM.CommandSeq.add.assert_has_calls(calls)

--- a/tests/device/test_KeypadLincDev.py
+++ b/tests/device/test_KeypadLincDev.py
@@ -242,6 +242,8 @@ class Test_KPL():
 
         # Test dimmer
         test_device.is_dimmer = True
+        assert(test_device.get_on_level() == 255)
+
         def level_bytes(level):
             data = bytes([
                 0x01,
@@ -253,8 +255,52 @@ class Test_KPL():
             test_device.set_on_level(params[0])
             assert len(test_device.protocol.sent) == 1
             assert test_device.protocol.sent[0].msg.cmd1 == 0x2e
-            assert test_device.protocol.sent[0].msg.data == level_bytes(params[1])
+            assert (test_device.protocol.sent[0].msg.data ==
+                    level_bytes(params[1]))
             test_device.protocol.clear()
+
+        test_device.set_on_level(64)
+
+        # Fake having completed the set_on_level(64) request
+        flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
+        ack = IM.message.InpStandard(test_device.addr.hex,
+                                     test_device.modem.addr.hex,
+                                     flags, 0x2e, 0x00)
+        test_device.handle_on_level(ack, IM.util.make_callback(None), 64)
+        assert(test_device.get_on_level() == 64)
+        test_device.protocol.clear()
+
+        # Try multiple button presses in a row; confirm that level goes to
+        # default on-level then to full brightness, as expected.
+        # Fast-on should always go to full brightness.
+        params = [
+            (Msg.CmdType.ON, 0x00, [64, IM.on_off.Mode.NORMAL, 'device']),
+            (Msg.CmdType.ON, 0x00, [255, IM.on_off.Mode.NORMAL, 'device']),
+            (Msg.CmdType.ON, 0x00, [64, IM.on_off.Mode.NORMAL, 'device']),
+            (Msg.CmdType.OFF, 0x00, [0, IM.on_off.Mode.NORMAL, 'device']),
+            (Msg.CmdType.ON_FAST, 0x00, [255, IM.on_off.Mode.FAST, 'device']),
+            (Msg.CmdType.ON_FAST, 0x00, [255, IM.on_off.Mode.FAST, 'device']),
+            (Msg.CmdType.OFF_FAST, 0x00, [0, IM.on_off.Mode.FAST, 'device']),
+            (Msg.CmdType.ON_INSTANT, 0x00,
+                [64, IM.on_off.Mode.INSTANT, 'device']),
+            (Msg.CmdType.ON_INSTANT, 0x00,
+                [255, IM.on_off.Mode.INSTANT, 'device']),
+            (Msg.CmdType.ON_INSTANT, 0x00,
+                [64, IM.on_off.Mode.INSTANT, 'device'])]
+        for cmd1, cmd2, expected in params:
+            with mock.patch.object(IM.Signal, 'emit') as mocked:
+                print("Trying:", "[%x, %x]" % (cmd1, cmd2))
+                flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
+                group_num = 0x01
+                group = IM.Address(0x00, 0x00, group_num)
+                addr = IM.Address(0x01, 0x02, 0x03)
+                msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
+                test_device.handle_broadcast(msg)
+                if expected is not None:
+                    mocked.assert_called_once_with(test_device, group_num,
+                                                   *expected)
+                else:
+                    mocked.assert_not_called()
 
     def test_set_flags(self, test_device):
         # set_flags(self, on_done, **kwargs)

--- a/tests/device/test_KeypadLincDev.py
+++ b/tests/device/test_KeypadLincDev.py
@@ -360,3 +360,27 @@ class Test_KPL():
                 mocked.assert_called_once_with(test_device, group_num, *expected)
             else:
                 mocked.assert_not_called()
+
+    def test_get_flags(self, test_device):
+        # This should hijack get flags and should insert a call to
+        # EXTENDED_SET_GET
+        with mock.patch.object(IM.CommandSeq, 'add'):
+            test_device.get_flags()
+            calls = [
+                # can't figure out how to define the call to super().get_flags
+                call(test_device._get_ext_flags),
+            ]
+            IM.CommandSeq.add.assert_has_calls(calls)
+            assert IM.CommandSeq.add.call_count == 2
+
+    def test_handle_ext_flags(self, test_device):
+        from_addr = IM.Address(0x01, 0x02, 0x05)
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
+        data = bytes([0x01, 0x01, 0x00, 0x00, 0x20, 0x20, 0x1c, 0x1c, 0x1f,
+                      0x00, 0x01, 0x00, 0x00, 0x00])
+        msg = Msg.InpExtended(from_addr, test_device.addr, flags,
+                              Msg.CmdType.EXTENDED_SET_GET, 0x00, data)
+        def on_done(success, *args):
+            assert success
+        test_device.handle_ext_flags(msg, on_done)
+        assert test_device.get_on_level() == 0x1C

--- a/tests/mqtt/test_Dimmer.py
+++ b/tests/mqtt/test_Dimmer.py
@@ -209,6 +209,84 @@ class Test_Dimmer:
         link.publish(ltopic, b'asdf', qos, False)
 
     #-----------------------------------------------------------------------
+    def test_input_with_default_on_level(self, setup):
+        mdev, dev, link, proto = setup.getAll(['mdev', 'dev', 'link', 'proto'])
+
+        qos = 2
+        config = {'dimmer' : {
+            'on_off_topic' : 'foo/{{address}}',
+            'on_off_payload' : ('{ "cmd" : "{{json.on.lower()}}",'
+                                '"mode" : "{{json.mode.lower()}}" }'),
+            'level_topic' : 'bar/{{address}}',
+            'level_payload' : ('{ "cmd" : "{{json.on.lower()}}",'
+                               '"mode" : "{{json.mode.lower()}}"'
+                               '{% if json.level is defined %}'
+                               ',"level" : {{json.level}}'
+                               '{% endif %} }')}}
+        mdev.load_config(config, qos=qos)
+
+        mdev.subscribe(link, qos)
+        otopic = link.client.sub[0].topic
+        ltopic = link.client.sub[1].topic
+
+        # Set a default on-level that will be used by MQTT commands that don't
+        # specify a level.
+        assert dev.get_on_level() == 255
+        on_level = 128
+        params = {"on_level" : on_level}
+        dev.set_flags(None, **params)
+        assert proto.sent[0].msg.cmd1 == 0x2e
+        assert proto.sent[0].msg.cmd2 == 0x00
+        assert proto.sent[0].msg.data[0] == 0x01
+        assert proto.sent[0].msg.data[1] == 0x06
+        assert proto.sent[0].msg.data[2] == on_level
+        proto.clear()
+
+        # Fake having completed the set_on_level() request
+        flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
+        ack = IM.message.InpStandard(dev.addr.hex,
+                                     dev.modem.addr.hex,
+                                     flags, 0x2e, 0x00)
+        dev.handle_on_level(ack, IM.util.make_callback(None), on_level)
+        assert dev.get_on_level() == on_level
+
+        # Try multiple commands in a row; confirm for on commands, level goes
+        # to default on-level then to full brightness (just like would be done
+        # if the device's on-button is pressed).
+        # Fast-on should always go to full brightness.
+        on_off_tests = [("OFF", "NORMAL", 0x13, 0x00),
+                        ("ON", "NORMAL", 0x11, on_level),
+                        ("ON", "NORMAL", 0x11, 0xff),
+                        ("ON", "NORMAL", 0x11, on_level),
+                        ("OFF", "FAST", 0x14, 0x00),
+                        ("ON", "FAST", 0x12, 0xff),
+                        ("ON", "FAST", 0x12, 0xff),
+                        ("OFF", "INSTANT", 0x21, 0x00),
+                        ("ON", "INSTANT", 0x21, on_level),
+                        ("ON", "INSTANT", 0x21, 0xff),
+                        ("ON", "INSTANT", 0x21, on_level)]
+        # Try all on/off command tests with each topic
+        for topic in [otopic, ltopic]:
+            for command, mode, cmd1, cmd2 in on_off_tests:
+                payload = '{ "on" : "%s", "mode" : "%s" }' % (command, mode)
+                print("Trying:", topic, "=", payload)
+                link.publish(topic, bytes(payload, 'utf-8'), qos, retain=False)
+                assert len(proto.sent) == 1
+
+                assert proto.sent[0].msg.cmd1 == cmd1
+                assert proto.sent[0].msg.cmd2 == cmd2
+                proto.clear()
+
+                # Fake receiving the ack
+                flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK,
+                                         False)
+                ack = IM.message.InpStandard(dev.addr.hex,
+                                             dev.modem.addr.hex,
+                                             flags, cmd1, cmd2)
+                dev.handle_ack(ack, IM.util.make_callback(None))
+                assert dev._level == cmd2
+
+    #-----------------------------------------------------------------------
     def test_input_on_off_reason(self, setup):
         mdev, link, proto = setup.getAll(['mdev', 'link', 'proto'])
 


### PR DESCRIPTION
Improve on-level handling for dimmers & related devices

- Store default on-level in DB metadata when set-flags commmand succeeds.
- Use stored default on-level to determine new level when receiving "on" broadcast messages.
- Use stored default on-level to handle MQTT messages with unspecified brightness value.
- Note: Previous behavior for handling MQTT messages with unspecified brightness value will remain for existing users, unless config is updated as shown in example config.yaml file).

**Tests performed:**

- [x] Confirmed that all new pytest tests fail before fix and pass after fix
- [x] Confirmed no new flake8 errors
- [x] Confirmed no new pylint errors
- [x] Confirmed all old & new pytest tests are passing
  * Some unrelated tests failed on my system (both before and after these changes were applied).  Old Python version might be to blame.
- [x] Reviewed test coverage report for substantial new gaps (no new gaps found)
- [x] Confirmed changes work in real life
  - Using an i2cs plug-in dimmer module and a KeypadLinc dimmer module:
    - Pressed physical on button several times.  Confirmed that brightness as reported in Home Assistant follows actual brightness of the connected light.
    - Turned device on in Home Assistant.  Observed device went to default on-level instead of full-brightness.
    - Manually sent MQTT to device with unspecified level.  Confirmed device alternated between default on-level and full-brightness like with physical buttons.
- [x] Dog-food testing (~1 week with an older version of these commits on Home Assistant 2020.12.0, no problems observed).  Current code testing is ongoing (~2 days so far with HA version 2020.12.1).