### PR TITLE
Minor Database Handling Fixes

### DIFF
--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -176,17 +176,14 @@ class Device:
         return delta == self.delta
 
     #-----------------------------------------------------------------------
-    def set_delta(self, delta):
-        """Set the current database delta.
+    def increment_delta(self):
+        """Increments the current database delta by 1
 
-        This records the input delta as the current value.  If the input
-        isn't None, the database is also saved to record this value.
-
-        Args:
-          delta:  (int) The database delta.  None to clear the delta.
+        Bumps up the delta by one, rolling it over to 0 if necessary.  Will
+        ignore a delta which is None.
         """
-        self.delta = delta
-        if delta is not None:
+        if self.delta is not None:
+            self.delta += 1
             self.delta = self.delta % 256  # Roll over db if it goes past 256
             self.save()
 
@@ -275,19 +272,18 @@ class Device:
 
     #-----------------------------------------------------------------------
     def clear(self):
-        """Clear the complete database of entries.
+        """Clear the cached database of entries
 
-        This also removes the saved file if it exists.  It does NOT modify
-        the database on the device.
+        This also saves the empty database to file.  It does NOT modify
+        the database on the device.  Nor does it clear the meta entries in
+        the database file.
         """
         self.delta = None
         self.entries.clear()
         self.unused.clear()
         self.groups.clear()
         self.last.mem_loc = START_MEM_LOC
-
-        if self.save_path and os.path.exists(self.save_path):
-            os.remove(self.save_path)
+        self.save()
 
     #-----------------------------------------------------------------------
     def set_path(self, path):

--- a/insteon_mqtt/db/DeviceModifyManagerI1.py
+++ b/insteon_mqtt/db/DeviceModifyManagerI1.py
@@ -164,7 +164,7 @@ class DeviceModifyManagerI1:
                    completion of the modification
         """
         # Increment the delta 1
-        self.db.set_delta(self.db.delta + 1)
+        self.db.increment_delta()
         self.handle_lsb_response(msg, on_done)
 
     #-------------------------------------------------------------------

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -196,10 +196,7 @@ class Modem:
         self.entries = []
         self.groups = {}
         self.aliases = {}
-        self._meta = {}
-
-        if self.save_path and os.path.exists(self.save_path):
-            os.remove(self.save_path)
+        self.save()
 
     #-----------------------------------------------------------------------
     def find_group(self, group):

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -73,7 +73,7 @@ class DeviceDbModify(Base):
                     LOG.info("Updating entry: %s", self.entry)
                     self.db.add_entry(self.entry)
                     # Increment the delta 1
-                    self.db.set_delta(self.db.delta + 1)
+                    self.db.increment_delta()
                     self.on_done(True, "Device database update complete",
                                  self.entry)
 

--- a/insteon_mqtt/handler/DeviceRefresh.py
+++ b/insteon_mqtt/handler/DeviceRefresh.py
@@ -105,7 +105,7 @@ class DeviceRefresh(Base):
                     # w/ the current value and save the database.
                     def on_done(success, message, data):
                         if success:
-                            self.device.db.set_delta(msg.cmd1)
+                            self.device.db.delta = msg.cmd1
                             LOG.ui("%s database download complete\n%s",
                                    self.addr, self.device.db)
                         self.on_done(success, message, data)

--- a/tests/db/test_Device.py
+++ b/tests/db/test_Device.py
@@ -17,8 +17,13 @@ class Test_Device:
         assert obj.is_current(0) is False
         obj.delta = 1
         assert obj.is_current(1) is True
-        obj.set_delta(None)
+        obj.increment_delta()
         assert obj.is_current(1) is False
+        assert obj.is_current(2) is True
+        # test roll over at 256
+        obj.delta = 255
+        obj.increment_delta()
+        assert obj.is_current(0) is True
 
         assert obj.engine is None
         obj.set_engine(1)
@@ -109,11 +114,15 @@ class Test_Device:
         assert len(obj2.unused) == 1
         assert len(obj2.groups) == 2
 
+        obj2.set_meta('test', 2)
         obj2.clear()
         assert len(obj2) == 0
         assert len(obj2.entries) == 0
         assert len(obj2.unused) == 0
         assert len(obj2.groups) == 0
+        assert len(obj2._meta) == 1
+        assert obj2.get_meta('test') == 2
+
 
     #-----------------------------------------------------------------------
     def test_add_multi_group(self):

--- a/tests/db/test_Device.py
+++ b/tests/db/test_Device.py
@@ -14,9 +14,16 @@ class Test_Device:
         obj = IM.db.Device(IM.Address(0x01, 0x02, 0x03))
         assert len(obj) == 0
 
+        # test that increment delta handles None properly
+        assert obj.delta == None
+        obj.increment_delta()
+        assert obj.delta == None
+        # test that None != 0
         assert obj.is_current(0) is False
+        # test that is_current works as expected
         obj.delta = 1
         assert obj.is_current(1) is True
+        # test that increment works as expected
         obj.increment_delta()
         assert obj.is_current(1) is False
         assert obj.is_current(2) is True

--- a/tests/db/test_Modem.py
+++ b/tests/db/test_Modem.py
@@ -78,6 +78,37 @@ class Test_Modem:
         assert obj2.entries[2] == obj.entries[2]
 
     #-----------------------------------------------------------------------
+    def test_clear(self):
+        obj = IM.db.Modem()
+        assert len(obj) == 0
+
+        addr = IM.Address('12.34.ab')
+        data = bytes([0xff, 0x00, 0x00])
+        e = IM.db.ModemEntry(addr, 0x01, True, data, db=obj)
+        obj.add_entry(e)
+
+        addr = IM.Address('12.34.ac')
+        data = bytes([0xff, 0x00, 0x00])
+        e = IM.db.ModemEntry(addr, 0x01, True, data, db=obj)
+        obj.add_entry(e)
+
+        addr = IM.Address('12.34.ad')
+        data = bytes([0xff, 0x00, 0x00])
+        e = IM.db.ModemEntry(addr, 0x02, True, data, db=obj)
+        obj.add_entry(e)
+
+        assert len(obj) == 3
+
+        obj.set_meta('test', 2)
+        obj.clear()
+        assert len(obj) == 0
+        assert len(obj.entries) == 0
+        assert len(obj.groups) == 0
+        assert len(obj.aliases) == 0
+        assert len(obj._meta) == 1
+        assert obj.get_meta('test') == 2
+
+    #-----------------------------------------------------------------------
     def test_add_on_device_empty_ctrl(self, test_device, test_entry_dev1_ctrl):
         # add_on_device(self, entry, on_done=None)
         # test adding to an entry db with ctrl


### PR DESCRIPTION
This changes the `set_delta` function to `increment_delta`.  Increment is really what was needed, plus this way it gracefully handles a delta of None for example if a user used refresh=False.  Unit tests included.

I also changed the clear function so that it does not delete the db file, but merely clears the entry lists and associated values.  Most importantly it leaves the meta dictionary intact.  So IOLincs will function properly after a refresh, and user settings such as battery level will not be erased.

Partially Fixes #292
Fixes #243