### PR TITLE
Unbound Backlight Brightness; Turn Backlight Off at 0x00

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -453,8 +453,9 @@ Switch, KeypadLinc, and Dimmer all support the flags:
    - backlight: changes the LED backlight level on the device.  Insteon
      documentation defines the range from 0x11 - 0x7F, however, levels below
      0x11 appear to work on some devices, and levels above 0x7F may also work.
-     Setting to 0x00 will turn off the backlight, any other value will turn
-     on the backlight.
+     Switches and dimmers go as low as 0x04 and KeypadLincs go all the way
+     down to 0x01. Setting to 0x00 will turn off the backlight, any other
+     value will turn on the backlight.
    - on_level: integer in the range 0x00-0xff which sets the on level that will
      be used when the button is pressed.
    - load_attached: 0/1 to attach or detach the load from the group 1 button.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -450,8 +450,11 @@ The MQTT format of the command is:
 
 Switch, KeypadLinc, and Dimmer all support the flags:
 
-   - backlight: integer in the range 0x00-0x7f which changes the LED backlight
-     level on the device.
+   - backlight: changes the LED backlight level on the device.  Insteon
+     documentation defines the range from 0x11 - 0x7F, however, levels below
+     0x11 appear to work on some devices, and levels above 0x7F may also work.
+     Setting to 0x00 will turn off the backlight, any other value will turn
+     on the backlight.
    - on_level: integer in the range 0x00-0xff which sets the on level that will
      be used when the button is pressed.
    - load_attached: 0/1 to attach or detach the load from the group 1 button.

--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -6,7 +6,6 @@
 import io
 import itertools
 import json
-import os
 from ..Address import Address
 from .. import catalog
 from ..CommandSeq import CommandSeq

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -5,7 +5,6 @@
 #===========================================================================
 import io
 import json
-import os
 from ..Address import Address
 from .. import handler
 from .. import log

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -78,7 +78,6 @@ class Dimmer(Base):
             'increment_down' : self.increment_down,
             'scene' : self.scene,
             'set_flags' : self.set_flags,
-            'set_backlight_on' : self.set_backlight_on,
             })
 
         # Special callback to run when receiving a broadcast clean up.  See
@@ -440,49 +439,41 @@ class Dimmer(Base):
 
         The default factory level is 0x1f.
 
+        Per page 157 of insteon dev guide range is between 0x11 and 0x7F,
+        however in practice backlight can be incremented from 0x00 to at least
+        0x7f.
+
         Args:
           level (int): The backlight level in the range [0,255]
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        LOG.info("Dimmer %s setting backlight to %s", self.label, level)
+        seq = CommandSeq(self, "Dimmer set backlight complete", on_done,
+                         name="SetBacklight")
 
-        # Bound to 0x11 <= level <= 0x7f per page 157 of insteon dev guide.
-        # However in practice backlight can be incremented from 0x00 to 0x7f
-        if level:
-            level = min(level, 0x7f)
-
-        # Extended message data - see Insteon dev guide p156.
-        data = bytes([
-            0x01,   # D1 must be group 0x01
-            0x07,   # D2 set global led brightness
-            level,  # D3 brightness level
-            ] + [0x00] * 11)
-
-        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
-
-        # Use the standard command handler which will notify us when the
-        # command is ACK'ed.
-        msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
-        self.send(msg, msg_handler)
-
-    #-----------------------------------------------------------------------
-    def set_backlight_on(self, is_on, on_done=None):
-        """Turn the backlight on or totally off.
-
-        Args:
-          is_on (bool): True to have the backlight on, False for off.
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-        """
-        LOG.info("KeypadLinc %s setting backlight to %s", self.label, is_on)
+        # First set the backlight on or off depending on level value
+        is_on = level > 0
+        LOG.info("Dimmer %s setting backlight to %s", self.label, is_on)
         cmd = 0x09 if is_on else 0x08
         msg = Msg.OutExtended.direct(self.addr, 0x20, cmd, bytes([0x00] * 14))
+        msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
+        seq.add_msg(msg, msg_handler)
 
-        # This callback changes self._backlight if the command works.
-        callback = functools.partial(self.handle_backlight_on, is_on=is_on)
-        msg_handler = handler.StandardCmd(msg, callback, on_done)
-        self.send(msg, msg_handler)
+        if is_on:
+            # Second set the level only if on
+            LOG.info("Dimmer %s setting backlight to %s", self.label, level)
+            # Extended message data - see Insteon dev guide p156.
+            data = bytes([
+                0x01,   # D1 must be group 0x01
+                0x07,   # D2 set global led brightness
+                level,  # D3 brightness level
+                ] + [0x00] * 11)
+
+            msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+            msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
+            seq.add_msg(msg, msg_handler)
+
+        seq.run()
 
     #-----------------------------------------------------------------------
     def get_flags(self, on_done=None):
@@ -636,7 +627,6 @@ class Dimmer(Base):
         # Check the input flags to make sure only ones we can understand were
         # passed in.
         FLAG_BACKLIGHT = "backlight"
-        FLAG_BACKLIGHT_ON = "backlight_on"
         FLAG_ON_LEVEL = "on_level"
         FLAG_RAMP_RATE = "ramp_rate"
         flags = set([FLAG_BACKLIGHT, FLAG_ON_LEVEL, FLAG_RAMP_RATE])
@@ -652,10 +642,6 @@ class Dimmer(Base):
         if FLAG_BACKLIGHT in kwargs:
             backlight = util.input_byte(kwargs, FLAG_BACKLIGHT)
             seq.add(self.set_backlight, backlight)
-
-        if FLAG_BACKLIGHT_ON in kwargs:
-            is_on = util.input_byte(kwargs, FLAG_BACKLIGHT_ON)
-            seq.add(self.set_backlight_on, is_on)
 
         if FLAG_ON_LEVEL in kwargs:
             on_level = util.input_byte(kwargs, FLAG_ON_LEVEL)
@@ -847,19 +833,6 @@ class Dimmer(Base):
         self._set_level(msg.cmd2, mode, reason)
         on_done(True, "Dimmer state updated to %s" % self._level,
                 msg.cmd2)
-
-    #-----------------------------------------------------------------------
-    def handle_backlight_on(self, msg, on_done, is_on):
-        """Callback for handling turning the backlight on and off.
-
-        Args:
-          msg (InpStandard):  The response message from the command.
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-          is_on (bool): True if the backlight is being turned on, False for
-                off.
-        """
-        on_done(True, "backlight set to %s" % is_on, None)
 
     #-----------------------------------------------------------------------
     def handle_scene(self, msg, on_done, reason=""):

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -470,7 +470,8 @@ class Dimmer(Base):
                 ] + [0x00] * 11)
 
             msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
-            msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
+            msg_handler = handler.StandardCmd(msg, self.handle_backlight,
+                                              on_done)
             seq.add_msg(msg, msg_handler)
 
         seq.run()

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -317,32 +317,42 @@ class Outlet(Base):
 
         The default factory level is 0x1f.
 
+        Per page 157 of insteon dev guide range is between 0x11 and 0x7F,
+        however in practice backlight can be incremented from 0x00 to at least
+        0x7f.
+
         Args:
           level (int):  The backlight level in the range [0,255]
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        LOG.info("Outlet %s setting backlight to %s", self.label, level)
+        seq = CommandSeq(self, "Outlet set backlight complete", on_done,
+                         name="SetBacklight")
 
-        # Bound to 0x11 <= level <= 0xff per page 157 of insteon dev guide.
-        # 0x00 is used to disable the backlight so allow that explicitly.
-        if level:
-            level = max(0x11, min(level, 0xff))
-
-        # Extended message data - see Insteon dev guide p156.
-        data = bytes([
-            0x01,   # D1 must be group 0x01
-            0x07,   # D2 set global led brightness
-            level,  # D3 brightness level
-            ] + [0x00] * 11)
-
-        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
-
-        # Use the standard command handler which will notify us when the
-        # command is ACK'ed.
+        # First set the backlight on or off depending on level value
+        is_on = level > 0
+        LOG.info("Outlet %s setting backlight to %s", self.label, is_on)
+        cmd = 0x09 if is_on else 0x08
+        msg = Msg.OutExtended.direct(self.addr, 0x20, cmd, bytes([0x00] * 14))
         msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
+        seq.add_msg(msg, msg_handler)
 
-        self.send(msg, msg_handler)
+        if is_on:
+            # Second set the level only if on
+            LOG.info("Outlet %s setting backlight to %s", self.label, level)
+
+            # Extended message data - see Insteon dev guide p156.
+            data = bytes([
+                0x01,   # D1 must be group 0x01
+                0x07,   # D2 set global led brightness
+                level,  # D3 brightness level
+                ] + [0x00] * 11)
+
+            msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+            msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
+            seq.add_msg(msg, msg_handler)
+
+        seq.run()
 
     #-----------------------------------------------------------------------
     def set_flags(self, on_done, **kwargs):

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -349,7 +349,8 @@ class Outlet(Base):
                 ] + [0x00] * 11)
 
             msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
-            msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
+            msg_handler = handler.StandardCmd(msg, self.handle_backlight,
+                                              on_done)
             seq.add_msg(msg, msg_handler)
 
         seq.run()

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -282,7 +282,8 @@ class Switch(Base):
                 ] + [0x00] * 11)
 
             msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
-            msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
+            msg_handler = handler.StandardCmd(msg, self.handle_backlight,
+                                              on_done)
             seq.add_msg(msg, msg_handler)
 
         seq.run()

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -64,7 +64,6 @@ class Switch(Base):
             'set' : self.set,
             'scene' : self.scene,
             'set_flags' : self.set_flags,
-            'set_backlight_on' : self.set_backlight_on,
             })
 
         # Special callback to run when receiving a broadcast clean up.  See
@@ -251,50 +250,42 @@ class Switch(Base):
 
         The default factory level is 0x1f.
 
+        Per page 157 of insteon dev guide range is between 0x11 and 0x7F,
+        however in practice backlight can be incremented from 0x00 to at least
+        0x7f.
+
         Args:
           level (int):  The backlight level in the range [0,255]
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        LOG.info("Switch %s setting backlight to %s", self.label, level)
+        seq = CommandSeq(self, "Switch set backlight complete", on_done,
+                         name="SetBacklight")
 
-        # Bound to 0x11 <= level <= 0x7f per page 157 of insteon dev guide.
-        # However in practice backlight can be incremented from 0x00 to 0x7f
-        if level:
-            level = min(level, 0x7f)
-
-        # Extended message data - see Insteon dev guide p156.
-        data = bytes([
-            0x01,   # D1 must be group 0x01
-            0x07,   # D2 set global led brightness
-            level,  # D3 brightness level
-            ] + [0x00] * 11)
-
-        msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
-
-        # Use the standard command handler which will notify us when the
-        # command is ACK'ed.
-        msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
-
-        self.send(msg, msg_handler)
-
-    #-----------------------------------------------------------------------
-    def set_backlight_on(self, is_on, on_done=None):
-        """Turn the backlight on or totally off.
-
-        Args:
-          is_on (bool): True to have the backlight on, False for off.
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-        """
-        LOG.info("KeypadLinc %s setting backlight to %s", self.label, is_on)
+        # First set the backlight on or off depending on level value
+        is_on = level > 0
+        LOG.info("Switch %s setting backlight to %s", self.label, is_on)
         cmd = 0x09 if is_on else 0x08
         msg = Msg.OutExtended.direct(self.addr, 0x20, cmd, bytes([0x00] * 14))
+        msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
+        seq.add_msg(msg, msg_handler)
 
-        # This callback changes self._backlight if the command works.
-        callback = functools.partial(self.handle_backlight_on, is_on=is_on)
-        msg_handler = handler.StandardCmd(msg, callback, on_done)
-        self.send(msg, msg_handler)
+        if is_on:
+            # Second set the level only if on
+            LOG.info("Switch %s setting backlight to %s", self.label, level)
+
+            # Extended message data - see Insteon dev guide p156.
+            data = bytes([
+                0x01,   # D1 must be group 0x01
+                0x07,   # D2 set global led brightness
+                level,  # D3 brightness level
+                ] + [0x00] * 11)
+
+            msg = Msg.OutExtended.direct(self.addr, 0x2e, 0x00, data)
+            msg_handler = handler.StandardCmd(msg, self.handle_backlight, on_done)
+            seq.add_msg(msg, msg_handler)
+
+        seq.run()
 
     #-----------------------------------------------------------------------
     def set_flags(self, on_done, **kwargs):
@@ -316,8 +307,7 @@ class Switch(Base):
         # Check the input flags to make sure only ones we can understand were
         # passed in.
         FLAG_BACKLIGHT = "backlight"
-        FLAG_BACKLIGHT_ON = "backlight_on"
-        flags = set([FLAG_BACKLIGHT, FLAG_BACKLIGHT_ON,])
+        flags = set([FLAG_BACKLIGHT])
         unknown = set(kwargs.keys()).difference(flags)
         if unknown:
             raise Exception("Unknown Switch flags input: %s.\n Valid flags "
@@ -330,10 +320,6 @@ class Switch(Base):
         if FLAG_BACKLIGHT in kwargs:
             backlight = util.input_byte(kwargs, FLAG_BACKLIGHT)
             seq.add(self.set_backlight, backlight)
-
-        if FLAG_BACKLIGHT_ON in kwargs:
-            is_on = util.input_byte(kwargs, FLAG_BACKLIGHT_ON)
-            seq.add(self.set_backlight_on, is_on)
 
         seq.run()
 
@@ -459,19 +445,6 @@ class Switch(Base):
         self._set_is_on(is_on, mode, reason)
         on_done(True, "Switch state updated to on=%s" % self._is_on,
                 self._is_on)
-
-    #-----------------------------------------------------------------------
-    def handle_backlight_on(self, msg, on_done, is_on):
-        """Callback for handling turning the backlight on and off.
-
-        Args:
-          msg (InpStandard):  The response message from the command.
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-          is_on (bool): True if the backlight is being turned on, False for
-                off.
-        """
-        on_done(True, "backlight set to %s" % is_on, None)
 
     #-----------------------------------------------------------------------
     def handle_scene(self, msg, on_done, reason=""):

--- a/tests/device/test_DimmerDev.py
+++ b/tests/device/test_DimmerDev.py
@@ -142,3 +142,41 @@ class Test_Base_Config():
             assert success
         test_device.handle_ext_flags(msg, on_done)
         assert test_device.get_on_level() == 0x1C
+
+    def test_set_backlight(self, test_device):
+        # set_backlight(self, level, on_done=None)
+        test_device.set_backlight(0)
+        assert len(test_device.protocol.sent) == 1
+        assert test_device.protocol.sent[0].msg.cmd1 == 0x20
+        assert test_device.protocol.sent[0].msg.cmd2 == 0x08
+        test_device.protocol.clear()
+
+        def level_bytes(level):
+            data = bytes([
+                0x01,   # D1 must be group 0x01
+                0x07,   # D2 set global led brightness
+                level,  # D3 brightness level
+                ] + [0x00] * 11)
+            return data
+
+        for params in ([1, 0x01], [255, 0xFF], [127, 127]):
+            with mock.patch.object(IM.CommandSeq, 'add_msg'):
+                test_device.set_backlight(params[0])
+                args_list = IM.CommandSeq.add_msg.call_args_list
+                assert IM.CommandSeq.add_msg.call_count == 2
+                # Check the first call
+                assert args_list[0][0][0].cmd1 == 0x20
+                assert args_list[0][0][0].cmd2 == 0x09
+                # Check the first call
+                assert args_list[1][0][0].cmd1 == 0x2e
+                assert args_list[1][0][0].data == level_bytes(params[1])
+
+
+        with mock.patch.object(IM.CommandSeq, 'add_msg'):
+            # test backlight off
+            test_device.set_backlight(0)
+            args_list = IM.CommandSeq.add_msg.call_args_list
+            assert IM.CommandSeq.add_msg.call_count == 1
+            # Check the first call
+            assert args_list[0][0][0].cmd1 == 0x20
+            assert args_list[0][0][0].cmd2 == 0x08

--- a/tests/device/test_KeypadLincDev.py
+++ b/tests/device/test_KeypadLincDev.py
@@ -192,23 +192,27 @@ class Test_KPL():
                 ] + [0x00] * 11)
             return data
 
-        for params in ([1, 0x11], [255, 0x7F], [127, 127]):
+        for params in ([1, 0x01], [255, 0xFF], [127, 127]):
             with mock.patch.object(IM.CommandSeq, 'add_msg'):
                 test_device.set_backlight(params[0])
                 args_list = IM.CommandSeq.add_msg.call_args_list
-                assert IM.CommandSeq.add_msg.call_count == 1
+                assert IM.CommandSeq.add_msg.call_count == 2
                 # Check the first call
-                assert args_list[0][0][0].cmd1 == 0x2e
-                assert args_list[0][0][0].data == level_bytes(params[1])
+                assert args_list[0][0][0].cmd1 == 0x20
+                assert args_list[0][0][0].cmd2 == 0x09
+                # Check the first call
+                assert args_list[1][0][0].cmd1 == 0x2e
+                assert args_list[1][0][0].data == level_bytes(params[1])
 
-        with mock.patch.object(IM.CommandSeq, 'add'):
+
+        with mock.patch.object(IM.CommandSeq, 'add_msg'):
             # test backlight off
-            test_device._backlight = False
-            test_device.set_backlight(1)
-            args_list = IM.CommandSeq.add.call_args_list
-            assert IM.CommandSeq.add.call_count == 1
+            test_device.set_backlight(0)
+            args_list = IM.CommandSeq.add_msg.call_args_list
+            assert IM.CommandSeq.add_msg.call_count == 1
             # Check the first call
-            assert args_list[0][0][1]
+            assert args_list[0][0][0].cmd1 == 0x20
+            assert args_list[0][0][0].cmd2 == 0x08
 
     def test_set_ramp_rate(self, test_device):
         # set_ramp_rate(self, rate, on_done=None)

--- a/tests/device/test_SwitchDev.py
+++ b/tests/device/test_SwitchDev.py
@@ -78,3 +78,41 @@ class Test_Base_Config():
             calls = [call(test_device, IM.on_off.Manual.UP),
                      call(test_device, True, IM.on_off.Mode.MANUAL, 'device')]
             mocked.assert_has_calls(calls)
+
+    def test_set_backlight(self, test_device):
+        # set_backlight(self, level, on_done=None)
+        test_device.set_backlight(0)
+        assert len(test_device.protocol.sent) == 1
+        assert test_device.protocol.sent[0].msg.cmd1 == 0x20
+        assert test_device.protocol.sent[0].msg.cmd2 == 0x08
+        test_device.protocol.clear()
+
+        def level_bytes(level):
+            data = bytes([
+                0x01,   # D1 must be group 0x01
+                0x07,   # D2 set global led brightness
+                level,  # D3 brightness level
+                ] + [0x00] * 11)
+            return data
+
+        for params in ([1, 0x01], [255, 0xFF], [127, 127]):
+            with mock.patch.object(IM.CommandSeq, 'add_msg'):
+                test_device.set_backlight(params[0])
+                args_list = IM.CommandSeq.add_msg.call_args_list
+                assert IM.CommandSeq.add_msg.call_count == 2
+                # Check the first call
+                assert args_list[0][0][0].cmd1 == 0x20
+                assert args_list[0][0][0].cmd2 == 0x09
+                # Check the first call
+                assert args_list[1][0][0].cmd1 == 0x2e
+                assert args_list[1][0][0].data == level_bytes(params[1])
+
+
+        with mock.patch.object(IM.CommandSeq, 'add_msg'):
+            # test backlight off
+            test_device.set_backlight(0)
+            args_list = IM.CommandSeq.add_msg.call_args_list
+            assert IM.CommandSeq.add_msg.call_count == 1
+            # Check the first call
+            assert args_list[0][0][0].cmd1 == 0x20
+            assert args_list[0][0][0].cmd2 == 0x08


### PR DESCRIPTION
This is primarily the work of @tommycw1 from #297.  This fixes #294.

This unbounds the backlight setting.  As @tommycw1 points out, values below the stated value in the documentation seem to work.  How low each device goes seems to vary, I have added documentation to help users.  All devices seem to have an upper limit at 0x7F.  But they all treat values above this as max.  So I have removed the bounding as it is unnecessary.

This also merges the backlight on/off command into the level command.  Setting the backlight to 0x00 will turn it off, and any other value will turn it on.

Tested on:

- [x] Dimmers
- [x] Switches
- [x] Keypadlincs
- [x] Outlets

- [x] Unit Tests Added
- [x] Linters passed.
- [x] Documentation Updated 