### PR TITLE
Improve Error Reporting for Bad MQTT Templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - There is no longer a need to set the Modem hex address in config.yaml.
   ([PR 303][P303])
 
+- Better error reporting when MQTT payload does not match template.
+  ([PR 300][P300])
+
 ### Fixes
 
 - Fix error with backlight setting (thanks @tommycw1)([PR 299][P299])
@@ -558,3 +561,4 @@ will add new features.
 [P299]: https://github.com/TD22057/insteon-mqtt/pull/299
 [P303]: https://github.com/TD22057/insteon-mqtt/pull/303
 [P302]: https://github.com/TD22057/insteon-mqtt/pull/302
+[P300]: https://github.com/TD22057/insteon-mqtt/pull/300

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -236,7 +236,7 @@ class Dimmer:
             reason = data.get("reason", "")
             self.device.set(level=level, mode=mode, reason=reason)
         except:
-            LOG.exception("Invalid switch on/off command: %s", data)
+            LOG.error("Invalid switch on/off command: %s", data)
 
     #-----------------------------------------------------------------------
     def _input_set_level(self, client, data, message):
@@ -265,7 +265,7 @@ class Dimmer:
             # Tell the device to change its level.
             self.device.set(level=level, mode=mode, reason=reason)
         except:
-            LOG.exception("Invalid dimmer command: %s", data)
+            LOG.error("Invalid dimmer command: %s", data)
 
     #-----------------------------------------------------------------------
     def _input_scene(self, client, data, message):
@@ -294,6 +294,6 @@ class Dimmer:
             # Tell the device to trigger the scene command.
             self.device.scene(is_on, group, reason)
         except:
-            LOG.exception("Invalid dimmer command: %s", data)
+            LOG.error("Invalid dimmer command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/EZIO4O.py
+++ b/insteon_mqtt/mqtt/EZIO4O.py
@@ -203,7 +203,7 @@ class EZIO4O:
             reason = data.get("reason", "")
             self.device.set(level=is_on, group=group, mode=mode, reason=reason)
         except:
-            LOG.exception("Invalid EZIO4O on/off command: %s", data)
+            LOG.error("Invalid EZIO4O on/off command: %s", data)
 
     #-----------------------------------------------------------------------
     def _input_scene(self, client, data, message, group):
@@ -233,6 +233,6 @@ class EZIO4O:
             reason = data.get("reason", "")
             self.device.scene(is_on, group, reason)
         except:
-            LOG.exception("Invalid EZIO4O scene command: %s", data)
+            LOG.error("Invalid EZIO4O scene command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/FanLinc.py
+++ b/insteon_mqtt/mqtt/FanLinc.py
@@ -226,6 +226,6 @@ class FanLinc(Dimmer):
             reason = data.get("reason", "")
             self.device.fan_set(fan_speed, reason=reason)
         except:
-            LOG.exception("Invalid fan set speed command: %s", data)
+            LOG.error("Invalid fan set speed command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/IOLinc.py
+++ b/insteon_mqtt/mqtt/IOLinc.py
@@ -166,6 +166,6 @@ class IOLinc:
             is_on = util.parse_on_off(data, have_mode=False)
             self.device.set(is_on)
         except:
-            LOG.exception("Invalid IOLinc on/off command: %s", data)
+            LOG.error("Invalid IOLinc on/off command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -298,7 +298,7 @@ class KeypadLinc:
             reason = data.get("reason", "")
             self.device.set(level, group, mode, reason=reason)
         except:
-            LOG.exception("Invalid KeypadLinc on/off command: %s", data)
+            LOG.error("Invalid KeypadLinc on/off command: %s", data)
             if raise_errors:
                 raise
 
@@ -333,7 +333,7 @@ class KeypadLinc:
             reason = data.get("reason", "")
             self.device.set(level, mode=mode, reason=reason)
         except:
-            LOG.exception("Invalid KeypadLinc level command: %s", data)
+            LOG.error("Invalid KeypadLinc level command: %s", data)
             if raise_errors:
                 raise
 
@@ -401,6 +401,6 @@ class KeypadLinc:
             reason = data.get("reason", "")
             self.device.scene(is_on, group, reason=reason)
         except:
-            LOG.exception("Invalid KeypadLinc command: %s", data)
+            LOG.error("Invalid KeypadLinc command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Modem.py
+++ b/insteon_mqtt/mqtt/Modem.py
@@ -111,6 +111,6 @@ class Modem:
             # Tell the device to trigger the scene command.
             self.device.scene(is_on, group=group, name=name)
         except:
-            LOG.exception("Invalid modem command: %s", data)
+            LOG.error("Invalid modem command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/MsgTemplate.py
+++ b/insteon_mqtt/mqtt/MsgTemplate.py
@@ -99,7 +99,16 @@ class MsgTemplate:
           str:  Returns the rendered topic.  This may be None if the
           constructor or config topic data was None.
         """
-        return self._render(self.topic_str, self.topic, data, silent)
+        try:
+            ret = self._render(self.topic_str, self.topic, data, silent)
+        except jinja2.exceptions.UndefinedError as exc:
+            if not silent:
+                LOG.error("Error rendering topic: %s", exc)
+                LOG.error("Template was: \n%s",
+                          self.topic_str.strip())
+                LOG.error("Data passed was: %s", data)
+            ret = None
+        return ret
 
     #-----------------------------------------------------------------------
     def render_payload(self, data, silent=False):
@@ -114,7 +123,16 @@ class MsgTemplate:
           str:  Returns the rendered payload.  This may be None if the
           constructor or config topic data was None.
         """
-        return self._render(self.payload_str, self.payload, data, silent)
+        try:
+            ret = self._render(self.payload_str, self.payload, data, silent)
+        except jinja2.exceptions.UndefinedError as exc:
+            if not silent:
+                LOG.error("Error rendering payload: %s", exc)
+                LOG.error("Template was: \n%s",
+                          self.payload_str.strip())
+                LOG.error("Data passed was: %s", data)
+            ret = None
+        return ret
 
     #-----------------------------------------------------------------------
     def publish(self, mqtt, data, retain=None):
@@ -176,7 +194,7 @@ class MsgTemplate:
         try:
             return json.loads(value)
         except:
-            LOG.exception("Invalid JSON message %s from template %s", value,
+            LOG.error("Invalid JSON message %s from template %s", value,
                           self.payload_str)
             return None
 
@@ -196,12 +214,6 @@ class MsgTemplate:
         if template is None:
             return None
 
-        try:
-            return template.render(data)
-        except:
-            if not silent:
-                LOG.exception("Error rendering template '%s' with data: %s",
-                              raw, data)
-            return None
+        return template.render(data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Outlet.py
+++ b/insteon_mqtt/mqtt/Outlet.py
@@ -193,7 +193,7 @@ class Outlet:
             reason = data.get("reason", "")
             self.device.set(level=is_on, group=group, mode=mode, reason=reason)
         except:
-            LOG.exception("Invalid Outlet on/off command: %s", data)
+            LOG.error("Invalid Outlet on/off command: %s", data)
 
     #-----------------------------------------------------------------------
     def _input_scene(self, client, data, message, group):
@@ -221,6 +221,6 @@ class Outlet:
             reason = data.get("reason", "")
             self.device.scene(is_on, group, reason)
         except:
-            LOG.exception("Invalid Outlet scene command: %s", data)
+            LOG.error("Invalid Outlet scene command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Switch.py
+++ b/insteon_mqtt/mqtt/Switch.py
@@ -217,7 +217,7 @@ class Switch:
             reason = data.get("reason", "")
             self.device.set(level=is_on, mode=mode, reason=reason)
         except:
-            LOG.exception("Invalid switch on/off command: %s", data)
+            LOG.error("Invalid switch on/off command: %s", data)
 
     #-----------------------------------------------------------------------
     def _input_scene(self, client, data, message):
@@ -247,6 +247,6 @@ class Switch:
             # Tell the device to trigger the scene command.
             self.device.scene(is_on, group, reason)
         except:
-            LOG.exception("Invalid switch scene command: %s", data)
+            LOG.error("Invalid switch scene command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Thermostat.py
+++ b/insteon_mqtt/mqtt/Thermostat.py
@@ -383,7 +383,7 @@ class Thermostat:
             mode = self.device.ModeCommands[mode_str]
             self.device.mode_command(mode)
         except:
-            LOG.exception("Invalid thermostat mode command: %s", data)
+            LOG.error("Invalid thermostat mode command: %s", data)
 
     #-----------------------------------------------------------------------
     def _input_fan(self, client, data, message):
@@ -413,7 +413,7 @@ class Thermostat:
             mode = self.device.FanCommands[mode_str]
             self.device.fan_command(mode)
         except:
-            LOG.exception("Unknown thermostat fan mode command: %s", data)
+            LOG.error("Unknown thermostat fan mode command: %s", data)
 
     #-----------------------------------------------------------------------
     def _input_heat_setpoint(self, client, data, message):
@@ -447,7 +447,7 @@ class Thermostat:
 
             self.device.heat_sp_command(temp_c)
         except:
-            LOG.exception("Invalid thermostat heat setpoint command: %s", data)
+            LOG.error("Invalid thermostat heat setpoint command: %s", data)
 
     #-----------------------------------------------------------------------
     def _input_cool_setpoint(self, client, data, message):
@@ -481,4 +481,4 @@ class Thermostat:
 
             self.device.cool_sp_command(temp_c)
         except:
-            LOG.exception("Invalid thermostat cool setpoint command: %s", data)
+            LOG.error("Invalid thermostat cool setpoint command: %s", data)

--- a/tests/mqtt/test_MsgTemplate.py
+++ b/tests/mqtt/test_MsgTemplate.py
@@ -114,4 +114,25 @@ class Test_MsgTemplate:
             assert rec.levelname == "ERROR"
         assert jdata is None
 
+    #-----------------------------------------------------------------------
+    def test_render_payload_error(self, caplog):
+        # This is a common error where a user uses a plain value instead of
+        # a json object
+        msg = MsgTemplate(topic='insteon/{{address}}/level',
+                          payload='{ "cmd" : "{{json.state.lower()}}", '
+                                  '"level" : {{json.brightness}} }')
+
+        jdata = msg.to_json(b'ON')
+        assert "Error rendering payload" in caplog.text
+        assert jdata is None
+
+    #-----------------------------------------------------------------------
+    def test_render_payload(self, caplog):
+        msg = MsgTemplate(topic='insteon/{{address}}/level',
+                          payload='{ "cmd" : "{{json.state.lower()}}", '
+                                  '"level" : {{json.brightness}} }')
+
+        jdata = msg.to_json(b'{"state": "ON","brightness":255}')
+        assert jdata == {'cmd': 'on', 'level': 255}
+
 #===========================================================================


### PR DESCRIPTION
If a user sends `'ON'` to a level topic expecting to receive a json payload like `{"state": "on","brightness":255}` they currently get the following errors in their log
```
2021-01-03 15:25:42.882 ERROR MsgTemplate: Error rendering template '{ "cmd" : "{{json.state.lower()}}",
  "level" : {% if json.brightness is defined %}
               {{json.brightness}}
            {% else %}
               255
            {% endif %} }
' with data: {'value': 'ON', 'json': None}
Traceback (most recent call last):
  File "/home/krkeegan/projects/insteon-mqtt/insteon_mqtt/mqtt/MsgTemplate.py", line 200, in _render
    return template.render(data)
  File "/home/krkeegan/projects/insteon-mqtt/venv/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/home/krkeegan/projects/insteon-mqtt/venv/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/home/krkeegan/projects/insteon-mqtt/venv/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 1, in top-level template code
  File "/home/krkeegan/projects/insteon-mqtt/venv/lib/python3.8/site-packages/jinja2/environment.py", line 471, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'None' has no attribute 'state'
2021-01-03 15:25:42.883 DEBUG MsgTemplate: Input template render: 'None'
2021-01-03 15:25:42.884 INFO Dimmer: Dimmer input command: None
2021-01-03 15:25:42.884 ERROR Dimmer: Invalid dimmer command: None
Traceback (most recent call last):
  File "/home/krkeegan/projects/insteon-mqtt/insteon_mqtt/mqtt/Dimmer.py", line 259, in _input_set_level
    is_on, mode = util.parse_on_off(data)
  File "/home/krkeegan/projects/insteon-mqtt/insteon_mqtt/mqtt/util.py", line 30, in parse_on_off
    cmd = data.get('cmd').lower()
AttributeError: 'NoneType' object has no attribute 'get'
```
I think most users are overwhelmed with traceback messages.  In this cause it isn't getting us anything, we know there is an error in templating, we don't need a traceback to see that the error is somewhere in Jinga2.

This PR drops these errors down from an exception to an error.  This removes the traceback and attempts to provide the user with a more concise easier to read error message.  All of this data was available in the prior logging, but it was hard to see.

```
2021-01-03 15:30:07.121 ERROR MsgTemplate: Error rendering payload: 'None' has no attribute 'state'
2021-01-03 15:30:07.121 ERROR MsgTemplate: Template was: 
{ "cmd" : "{{json.state.lower()}}",
  "level" : {% if json.brightness is defined %}
               {{json.brightness}}
            {% else %}
               255
            {% endif %} }
2021-01-03 15:30:07.121 ERROR MsgTemplate: Data passed was: {'value': 'ON', 'json': None}
2021-01-03 15:30:07.121 DEBUG MsgTemplate: Input template render: 'None'
2021-01-03 15:30:07.121 INFO Dimmer: Dimmer input command: None
2021-01-03 15:30:07.121 ERROR Dimmer: Invalid dimmer command: None
```
I hope that this will help users diagnose their own errors more easily.

- [x] Tested
- [x] Unit tests included.