### PR TITLE
Change Next Write Time Passed to Serial or Hub to be Dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 - Fix error with backlight setting (thanks @tommycw1)([PR 299][P299])
 
+- Small correction to write_time to allow dynamic calculation of time.
+  ([PR 302][P302])
+
 ## [0.7.5]
 
 This is another significant update that both improves the user experience,
@@ -554,3 +557,4 @@ will add new features.
 [P285]: https://github.com/TD22057/insteon-mqtt/pull/285
 [P299]: https://github.com/TD22057/insteon-mqtt/pull/299
 [P303]: https://github.com/TD22057/insteon-mqtt/pull/303
+[P302]: https://github.com/TD22057/insteon-mqtt/pull/302

--- a/insteon_mqtt/Protocol.py
+++ b/insteon_mqtt/Protocol.py
@@ -246,6 +246,18 @@ class Protocol:
             LOG.debug("Setting next write time: %s", print_time)
 
     #-----------------------------------------------------------------------
+    def get_next_write_time(self):
+        """Get the Timestamp of the next Permitted Write
+
+        Used by the Serial and Hub objects to determine when they can write a
+        message.
+
+        Returns:
+          (epoch Seconds): The next time a message can be written
+        """
+        return self._next_write_time
+
+    #-----------------------------------------------------------------------
     def is_addr_in_write_queue(self, addr):
         """Checks whether a message to the specified address already exists
         in the _write_queue
@@ -546,7 +558,7 @@ class Protocol:
         # Write the message to the PLM modem.  The message will only be sent
         # when the current time is after the next write time as tracked by
         # the link.
-        self.link.write(msg_bytes, self._next_write_time)
+        self.link.write(msg_bytes, self.get_next_write_time)
         self._write_status = WriteStatus.PENDING_WRITE
 
     #-----------------------------------------------------------------------

--- a/tests/message/test_Timed.py
+++ b/tests/message/test_Timed.py
@@ -32,7 +32,8 @@ class Test_Timed:
         obj.send(protocol)
 
         last = link.mock_calls[-1]
-        assert last == mock.call.write(msg.to_bytes(), 0)
+        assert last == mock.call.write(msg.to_bytes(),
+                                       protocol.get_next_write_time)
 
     #-----------------------------------------------------------------------
 

--- a/tests/network/test_Hub.py
+++ b/tests/network/test_Hub.py
@@ -88,7 +88,7 @@ class Test_Hub:
     #-----------------------------------------------------------------------
     @pytest.mark.parametrize("write,t,expected,buffer,calls", [
         (None, None, None, 0, 0),
-        (bytes([0x00]), None, bytes([0x00]), 0, 1),
+        (bytes([0x00]), time.time(), bytes([0x00]), 0, 1),
         (bytes([0x00]), time.time() + 10, None, 1, 0),
     ])
     def test_write(self, test_hub, write, t, expected, buffer, calls):
@@ -98,7 +98,9 @@ class Test_Hub:
             test_hub.poll(time.time())
             mock.patch.object(test_hub.client, 'write')
             if write is not None:
-                test_hub.write(write, after_time=t)
+                def time_call():
+                    return t
+                test_hub.write(write, time_call)
             test_hub._write_to_hub(time.time())
             args_list = test_hub.signal_wrote.emit.call_args_list
             assert test_hub.signal_wrote.emit.call_count == calls

--- a/tests/network/test_Serial.py
+++ b/tests/network/test_Serial.py
@@ -47,7 +47,9 @@ class Test_Serial():
 
     def test_write_to_link_too_soon(self, test_device):
         t = time.time()
-        test_device._write_buf.append((bytes(8), time.time() + 5))
+        def call_time():
+            return time.time() + 5
+        test_device._write_buf.append((bytes(8), call_time))
         with patch.object(test_device.signal_needs_write, 'emit') as mock_emit:
             test_device.write_to_link(t)
             mock_emit.assert_not_called()
@@ -55,7 +57,9 @@ class Test_Serial():
     def test_write_to_link_partial(self, test_device):
         test_device.client.write_max = 4
         msg_time = time.time()
-        test_device._write_buf.append((bytes(8), msg_time))
+        def call_time():
+            return msg_time
+        test_device._write_buf.append((bytes(8), call_time))
         t = time.time()
         with patch.object(test_device.signal_needs_write, 'emit') as needs_emit:
             with patch.object(test_device.signal_wrote, 'emit') as wrote_emit:
@@ -66,7 +70,7 @@ class Test_Serial():
                 # Should still be 4 bytes in there
                 assert len(test_device._write_buf[0][0]) == 4
                 # After time should be the same
-                assert test_device._write_buf[0][1] == msg_time
+                assert test_device._write_buf[0][1] == call_time
                 # This should cause the rest of the data to be written
                 test_device.write_to_link(t)
                 needs_emit.assert_called_once_with(test_device, False)
@@ -78,7 +82,9 @@ class Test_Serial():
             raise Exception("Fake Serial", "Broken", "Test")
         test_device.client.write = write
         msg_time = time.time()
-        test_device._write_buf.append((bytes(8), msg_time))
+        def call_time():
+            return msg_time
+        test_device._write_buf.append((bytes(8), call_time))
         t = time.time()
         test_device.write_to_link(t)
         assert "Serial write error" in caplog.text


### PR DESCRIPTION
The write time was previously a timestamp that became fixed as
soon as the protocol wrote it to the Serial or Hub object.  The
Serial or Hub object would then sit on the message until that
time.

This design overlooked the possibility that the next write time
could change after the protcol sent the message to the Serial or
Hub.  This can happen if another message arrives, and the wait
time needs to be extended, or if a Link Cleanup report arrives
which could decrease the wait time.  This likely didn't cause
many errors, but wasn't quite right.

Now the write time is passed as a function which returns the
dynamic write time, so that the Serial and Hub ge the most up to
date calculation.

- [x] Unit tests updated
- [x] documentation updated.