### PR TITLE
Check the Modem Address on Startup

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,7 +37,10 @@ jobs:
     - name: Test with pytest
       run: |
         # Skips creating coverage stats for covered items
-        pytest --cache-clear --cov-report term:skip-covered --no-cov-on-fail --cov=insteon_mqtt tests/ | tee pytest-coverage.txt
+        # Set pipefail so that tee doesn't override the exit code
+        set -o pipefail
+        pytest --cache-clear --cov-report term:skip-covered --cov=insteon_mqtt tests/ | tee pytest-coverage.txt
+        set +o pipefail
 #     - name: Comment coverage
 #       uses: coroo/pytest-coverage-commentator@v1.0.2
 #       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,9 +37,8 @@ jobs:
     - name: Test with pytest
       run: |
         # Skips creating coverage stats for covered items
-        pytest --cache-clear --cov-report term:skip-covered --cov=insteon_mqtt tests/ | tee pytest-coverage.txt
+        pytest --cache-clear --cov-report term:skip-covered --no-cov-on-fail --cov=insteon_mqtt tests/ | tee pytest-coverage.txt
 #     - name: Comment coverage
 #       uses: coroo/pytest-coverage-commentator@v1.0.2
 #       with:
 #         pytest-coverage: pytest-coverage.txt
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Additions
 
+- There is no longer a need to set the Modem hex address in config.yaml.
+  ([PR 303][P303])
+
 ### Fixes
 
 - Fix error with backlight setting (thanks @tommycw1)([PR 299][P299])
@@ -550,3 +553,4 @@ will add new features.
 [I292]: https://github.com/TD22057/insteon-mqtt/issues/292
 [P285]: https://github.com/TD22057/insteon-mqtt/pull/285
 [P299]: https://github.com/TD22057/insteon-mqtt/pull/299
+[P303]: https://github.com/TD22057/insteon-mqtt/pull/303

--- a/config.yaml
+++ b/config.yaml
@@ -52,7 +52,9 @@ insteon:
   ######
 
   # modem Insteon hex address
-  address: 44.85.11
+  # You do not need to specify this.  If it is defined, this address will be
+  # used even if it does not match what the modem reports.
+  # address: 44.85.11
 
   # Device database file storage location.
   #storage: '/var/lib/insteon-mqtt'

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -135,6 +135,10 @@ class Modem:
         - devices   List of devices.  Each device is a type and insteon
                     address of the device.
 
+        This funciton is the first of 2 load_config steps.  It initializes the
+        protocol and checks the Modem address.  Step_2 below, continues the
+        rest of the config loading if the Modem address check is successful.
+
         Args:
           data (dict):  Configuration data to load.
         """
@@ -152,7 +156,6 @@ class Modem:
         # Query the modem for its address
         callback = functools.partial(self.load_config_step2, config_data=data)
         self.get_addr(on_done=callback)
-        return
 
     #-----------------------------------------------------------------------
     def load_config_step2(self, success, msg, data, config_data=None):

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -210,7 +210,6 @@ class Modem:
             for device in self.devices.values():
                 device.refresh()
 
-
     #-----------------------------------------------------------------------
     def get_addr(self, on_done=None):
         """Ask the Modem to Respond with its Address.

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -119,7 +119,7 @@ class Modem:
         return "Modem"
 
     #-----------------------------------------------------------------------
-    def load_config(self, data, load_protocol=True):
+    def load_config(self, data):
         """Load a configuration dictionary.
 
         This should be the insteon key in the configuration data.  Key inputs
@@ -141,8 +141,7 @@ class Modem:
         LOG.info("Loading configuration data")
 
         # Pass the data to the modem network link.
-        if load_protocol:
-            self.protocol.load_config(data)
+        self.protocol.load_config(data)
 
         if 'address' in data:
             # Read the modem address from config if specified
@@ -177,6 +176,7 @@ class Modem:
                           "the address in config.yaml")
                 LOG.error("Unable to continue EXITING.")
                 sys.exit()
+                return
             else:
                 LOG.error("Unable to get modem address, using address in "
                           "config %s", self.addr)

--- a/insteon_mqtt/handler/ModemInfo.py
+++ b/insteon_mqtt/handler/ModemInfo.py
@@ -42,10 +42,6 @@ class ModemInfo(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
-        # InpUserReset is sent when the user triggers a factory reset
-        #     on the physical modem.
-        # OutResetModem is sent when we send that command to the modem
-        #     to reset it and we'll get an ack/nak back.
         if isinstance(msg, (Msg.OutModemInfo)):
             if msg.is_ack:
                 self.on_done(True, "Modem get info success", msg)

--- a/insteon_mqtt/handler/ModemInfo.py
+++ b/insteon_mqtt/handler/ModemInfo.py
@@ -1,0 +1,60 @@
+#===========================================================================
+#
+# Modem get_info handler.
+#
+#===========================================================================
+from .. import log
+from .. import message as Msg
+from .Base import Base
+
+LOG = log.get_logger()
+
+
+class ModemInfo(Base):
+    """Modem get_info handler.
+
+    This is primarily used to get the modem address on startup.
+    """
+    def __init__(self, modem, on_done=None):
+        """Constructor
+
+        Args
+          modem (Modem):  The Insteon modem object.
+          on_done: The finished callback.  Calling signature:
+                   on_done( bool success, str message, data )
+        """
+        super().__init__(on_done)
+
+        self.modem = modem
+
+    #-----------------------------------------------------------------------
+    def msg_received(self, protocol, msg):
+        """See if we can handle the message.
+
+        If we get an ACK of the user reset, we'll clear the modem database.
+
+        Args:
+          protocol  (Protocol):  The Insteon Protocol object
+          msg:  Insteon message object that was read.
+
+        Returns:
+          Msg.UNKNOWN if we can't handle this message.
+          Msg.CONTINUE if we handled the message and expect more.
+          Msg.FINISHED if we handled the message and are done.
+        """
+        # InpUserReset is sent when the user triggers a factory reset
+        #     on the physical modem.
+        # OutResetModem is sent when we send that command to the modem
+        #     to reset it and we'll get an ack/nak back.
+        if isinstance(msg, (Msg.OutModemInfo)):
+            if msg.is_ack:
+                self.on_done(True, "Modem get info success", msg)
+            else:
+                LOG.error("Modem get_info failed.")
+                self.on_done(False, "Modem get_info failed", msg)
+
+            return Msg.FINISHED
+
+        return Msg.UNKNOWN
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/__init__.py
+++ b/insteon_mqtt/handler/__init__.py
@@ -40,6 +40,7 @@ from .ExtendedCmdResponse import ExtendedCmdResponse
 from .ModemDbGet import ModemDbGet
 from .ModemDbSearch import ModemDbSearch
 from .ModemDbModify import ModemDbModify
+from .ModemInfo import ModemInfo
 from .ModemLinkComplete import ModemLinkComplete
 from .ModemLinkStart import ModemLinkStart
 from .ModemReset import ModemReset

--- a/insteon_mqtt/message/OutModemInfo.py
+++ b/insteon_mqtt/message/OutModemInfo.py
@@ -48,7 +48,8 @@ class OutModemInfo(Base):
                             is_ack=is_ack)
 
     #-----------------------------------------------------------------------
-    def __init__(self, addr=None, dev_cat=None, sub_cat=None, firmware=None, is_ack=None):
+    def __init__(self, addr=None, dev_cat=None, sub_cat=None, firmware=None,
+                 is_ack=None):
         """Constructor
 
         Args:

--- a/insteon_mqtt/message/OutModemInfo.py
+++ b/insteon_mqtt/message/OutModemInfo.py
@@ -1,0 +1,82 @@
+#===========================================================================
+#
+# Output insteon get_info PLM modem message.
+#
+#===========================================================================
+from .Base import Base
+from ..Address import Address
+
+
+class OutModemInfo(Base):
+    """Command to reset the PLM modem.
+
+    Send this command to get the address and model information from the modem.
+
+    The modem will respond with an echo/ACK of this message with the requested
+    information.
+    """
+    msg_code = 0x60
+    fixed_msg_size = 9
+
+    #-----------------------------------------------------------------------
+    @classmethod
+    def from_bytes(cls, raw):
+        """Read the message from a byte stream.
+
+        This should only be called if raw[1] == msg_code and len(raw) >=
+        msg_size().
+
+        You cannot pass the output of to_bytes() to this.  to_bytes() is used
+        to output to the PLM but the modem sends back the same message with
+        an extra ack byte which this function can read.
+
+        Args:
+          raw (bytes):  The current byte stream to read from.
+
+        Returns:
+          Returns the constructed OutResetModem object.
+        """
+        assert len(raw) >= cls.fixed_msg_size
+        assert raw[0] == 0x02 and raw[1] == cls.msg_code
+        addr = Address.from_bytes(raw, 2)
+        is_ack = raw[8] == 0x06
+
+        return OutModemInfo(addr=addr,
+                            dev_cat=raw[5],
+                            sub_cat=raw[6],
+                            firmware=raw[7],
+                            is_ack=is_ack)
+
+    #-----------------------------------------------------------------------
+    def __init__(self, addr=None, dev_cat=None, sub_cat=None, firmware=None, is_ack=None):
+        """Constructor
+
+        Args:
+          is_ack (bool):  True for ACK, False for NAK.  None for output
+                 commands to the modem.
+        """
+        super().__init__()
+
+        self.addr = addr
+        self.dev_cat = dev_cat
+        self.sub_cat = sub_cat
+        self.firmware = firmware
+        self.is_ack = is_ack
+
+    #-----------------------------------------------------------------------
+    def to_bytes(self):
+        """Convert the message to a byte array.
+
+        Returns:
+          bytes:  Returns the message as bytes.
+        """
+        return bytes([0x02, self.msg_code])
+
+    #-----------------------------------------------------------------------
+    def __str__(self):
+        ack = "" if self.is_ack is None else " ack: %s" % str(self.is_ack)
+        return "OutModemInfo%s" % ack
+
+    #-----------------------------------------------------------------------
+
+#===========================================================================

--- a/insteon_mqtt/message/__init__.py
+++ b/insteon_mqtt/message/__init__.py
@@ -48,6 +48,7 @@ from .OutAllLinkCancel import OutAllLinkCancel
 from .OutAllLinkGetFirst import OutAllLinkGetFirst
 from .OutAllLinkGetNext import OutAllLinkGetNext
 from .OutAllLinkUpdate import OutAllLinkUpdate
+from .OutModemInfo import OutModemInfo
 from .OutModemLinking import OutModemLinking
 from .OutModemScene import OutModemScene
 from .OutResetModem import OutResetModem
@@ -75,6 +76,7 @@ types = {
     0x5c : Unreachable,
 
     # host -> modem messages
+    0x60 : OutModemInfo,
     0x61 : OutModemScene,
     0x62 : OutStandard,  # Handles reading standard and extended
     0x64 : OutModemLinking,

--- a/tests/handler/test_ModemInfo.py
+++ b/tests/handler/test_ModemInfo.py
@@ -1,0 +1,40 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/handler/ModemInfo.py
+#
+# pylint: disable=attribute-defined-outside-init
+#===========================================================================
+import insteon_mqtt as IM
+import insteon_mqtt.message as Msg
+import helpers as H
+
+
+class Test_ModemInfo:
+    def test_acks(self, tmpdir):
+        calls = []
+
+        def callback(success, msg, done):
+            calls.append((success, msg, done))
+
+        modem = H.main.MockModem(tmpdir)
+        proto = H.main.MockProtocol()
+        handler = IM.handler.ModemInfo(modem, callback)
+
+        #Try a good message
+        msg = Msg.OutModemInfo(addr=IM.Address('11.22.33'), dev_cat=0x44,
+                               sub_cat=0x55, firmware=0x66, is_ack=True)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert calls[0][0]
+
+        #Try a NAK message
+        msg = Msg.OutModemInfo(addr=IM.Address('11.22.33'), dev_cat=0x44,
+                               sub_cat=0x55, firmware=0x66, is_ack=False)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert not calls[1][0]
+
+        #Wrong Message
+        msg = Msg.OutResetModem(is_ack=True)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN

--- a/tests/message/test_OutModemInfo.py
+++ b/tests/message/test_OutModemInfo.py
@@ -1,0 +1,38 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/message/OutModemInfo.py
+#
+#===========================================================================
+import insteon_mqtt as IM
+import insteon_mqtt.message as Msg
+
+
+class Test_OutModemInfo:
+    #-----------------------------------------------------------------------
+    def test_out(self):
+        obj = Msg.OutModemInfo()
+        assert obj.fixed_msg_size == 9
+
+        b = obj.to_bytes()
+        rt = bytes([0x02, 0x60])
+        assert b == rt
+
+        str(obj)
+
+    #-----------------------------------------------------------------------
+    def test_in(self):
+        b = bytes([0x02, 0x60, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x06])
+        obj = Msg.OutModemInfo.from_bytes(b)
+
+        assert obj.is_ack is True
+        assert obj.addr == IM.Address('11.22.33')
+        assert obj.dev_cat == 0x44
+        assert obj.sub_cat == 0x55
+        assert obj.firmware == 0x66
+
+        str(obj)
+
+    #-----------------------------------------------------------------------
+
+
+#===========================================================================

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -101,6 +101,8 @@ class Patch_Stack():
         self.modem_obj = modem
         mqtt.load_config(config['mqtt'])
         modem.load_config(config['insteon'])
+        # Simulate a response to the get_info request to trigger config_step2
+        self.write_to_modem('026044851103159E06')
 
     def publish_to_mqtt(self, topic, payload):
         """Simulate sending an mqtt message

--- a/tests/test_Modem.py
+++ b/tests/test_Modem.py
@@ -1,0 +1,89 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/Modem.py
+#
+#===========================================================================
+import pytest
+# from pprint import pprint
+from unittest import mock
+from unittest.mock import call
+import insteon_mqtt as IM
+import insteon_mqtt.message as Msg
+import insteon_mqtt.util as util
+import helpers as H
+
+@pytest.fixture
+def test_device():
+    '''
+    Returns a generically configured modem for testing
+    '''
+    protocol = mock.MagicMock()
+    stack = H.main.MockStack()
+    timed_call = H.main.MockTimedCall()
+    device = IM.Modem(protocol, stack, timed_call)
+    return device
+
+
+class Test_Base_Config():
+    def test_load_config_no_addr(self, test_device):
+        cfg = IM.config.load('config.yaml')
+        test_device.load_config(cfg)
+        # Protocol should load
+        test_device.protocol.load_config.assert_called_once_with(cfg)
+        assert test_device.addr is None
+        test_device.protocol.send.assert_called_once()
+        arg_list = test_device.protocol.send.call_args
+        assert isinstance(arg_list.args[0], Msg.OutModemInfo)
+        assert isinstance(arg_list.args[1], IM.handler.ModemInfo)
+
+    def test_load_config_addr(self, test_device):
+        cfg = IM.config.load('config.yaml')
+        cfg['address'] = '44.85.11'
+        test_device.load_config(cfg)
+        assert test_device.addr == IM.Address('44.85.11')
+
+    def test_load_config_step2_fail_no_addr(self, test_device, tmpdir):
+        cfg = IM.config.load('config.yaml')
+        cfg['storage'] = tmpdir
+        with mock.patch('sys.exit') as mocked:
+            test_device.load_config_step2(False, 'message', None, cfg)
+            mocked.assert_called_once()
+
+    def test_load_config_step2_fail_addr(self, test_device, tmpdir, caplog):
+        cfg = IM.config.load('config.yaml')
+        cfg['storage'] = tmpdir
+        test_device.addr = IM.Address('44.85.11')
+        test_device.load_config_step2(False, 'message', None, cfg)
+        assert 'Unable to get modem address, using address in' in caplog.text
+
+    def test_load_config_step2_success_addr_same(self, test_device, tmpdir,
+                                                 caplog):
+        cfg = IM.config.load('config.yaml')
+        cfg['storage'] = tmpdir
+        test_device.addr = IM.Address('44.85.11')
+        msg = Msg.OutModemInfo(addr=test_device.addr, dev_cat=None,
+                               sub_cat=None, firmware=None, is_ack=True)
+        test_device.load_config_step2(True, 'message', msg, cfg)
+        for record in caplog.records:
+            assert record.levelname != "ERROR"
+
+    def test_load_config_step2_success_addr_diff(self, test_device, tmpdir,
+                                                 caplog):
+        cfg = IM.config.load('config.yaml')
+        cfg['storage'] = tmpdir
+        test_device.addr = IM.Address('44.85.11')
+        msg = Msg.OutModemInfo(addr=IM.Address('44.85.12'), dev_cat=None,
+                               sub_cat=None, firmware=None, is_ack=True)
+        test_device.load_config_step2(True, 'message', msg, cfg)
+        assert 'Modem address in config 44.85.11 does not match address' in caplog.text
+
+    def test_load_config_step2_success_no_addr(self, test_device, tmpdir,
+                                               caplog):
+        cfg = IM.config.load('config.yaml')
+        cfg['storage'] = tmpdir
+        msg = Msg.OutModemInfo(addr=IM.Address('44.85.12'), dev_cat=None,
+                               sub_cat=None, firmware=None, is_ack=True)
+        test_device.load_config_step2(True, 'message', msg, cfg)
+        for record in caplog.records:
+            assert record.levelname != "ERROR"
+        assert test_device.addr == IM.Address('44.85.12')

--- a/tests/util/helpers/main.py
+++ b/tests/util/helpers/main.py
@@ -77,3 +77,17 @@ class MockDevice:
         self.protocol.send(msg, msg_handler, high_priority, after)
 
 #===========================================================================
+class MockStack:
+    """Mock insteon_mqtt/network/Stack class
+    """
+    def __init__(self):
+        pass
+
+#===========================================================================
+class MockTimedCall:
+    """Mock insteon_mqtt/network/TimedCall class
+    """
+    def __init__(self):
+        pass
+
+#===========================================================================


### PR DESCRIPTION
This will check the modem address on startup:
If no address is specified in the config file:
1. It will use the address obtained from the modem; OR
2. Fail and exit if no address is obtained.

If an address is specified in config:
1. If the returned address is the same, nothing
2. If the returned address is different, an error is reported,
   and things will continue using the address in the config.

Closes #266 

- [x] Works in testing
- [x] Cleanup code documentation
- [x] Change config.yaml
- [x] Unit Tests