### PR TITLE
Subscribe to Topics on New Device

### DIFF
--- a/insteon_mqtt/mqtt/Mqtt.py
+++ b/insteon_mqtt/mqtt/Mqtt.py
@@ -180,8 +180,7 @@ class Mqtt:
         self.devices[device.addr.id] = obj
 
         # If we are already connected we need to subscribe this device
-        if self.link.connected:
-            obj.subscribe(self.link, self.qos)
+        obj.subscribe(self.link, self.qos)
 
     #-----------------------------------------------------------------------
     def handle_cmd(self, client, userdata, message):

--- a/insteon_mqtt/mqtt/Mqtt.py
+++ b/insteon_mqtt/mqtt/Mqtt.py
@@ -179,6 +179,10 @@ class Mqtt:
         # Save the MQTT device so we can find it again.
         self.devices[device.addr.id] = obj
 
+        # If we are already connected we need to subscribe this device
+        if self.link.connected:
+            obj.subscribe(self.link, self.qos)
+
     #-----------------------------------------------------------------------
     def handle_cmd(self, client, userdata, message):
         """MQTT command message callback.


### PR DESCRIPTION
This fixes a bug introduced by #303.  Now that the startup is broken into parts, the MQTT link is established on a different turn through the loop than when all the devices are added.