### PR TITLE
Improve UI Error on Unknown Flags in Set Flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Fixes
 
+- Better error reporting to user when bad flags are used in set_flags.
+  ([PR 313][P313])
+
 - Fix error with backlight setting (thanks @tommycw1)([PR 299][P299])
 
 - Small correction to write_time to allow dynamic calculation of time.
@@ -573,3 +576,4 @@ will add new features.
 [P306]: https://github.com/TD22057/insteon-mqtt/pull/306
 [SCENETRIGGER]: https://github.com/TD22057/insteon-mqtt/blob/master/docs/mqtt.md#scene-triggering
 [P308]: https://github.com/TD22057/insteon-mqtt/pull/308
+[P313]: https://github.com/TD22057/insteon-mqtt/pull/313

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,3 +64,38 @@ added.
    # Create html files that show missing lines
    pytest --cov=insteon_mqtt --cov-report html
    ```
+
+# Logging
+
+The user interface is entirely driven by log messages, so some care has to be
+taken to select the proper logging levels.  The following are some
+suggestions.
+
+1. `LOG.exception()` This will generate a `LOG.error()` message, and will
+output a traceback to the log.  This should be used if the source of the error
+is unknown and a traceback would be helpful to diagnose the source.
+2. `LOG.error()` This will generate a message sent to the User Interface.
+This should be used if the users command cannot be carried out.
+3. `LOG.warning()` This will generate a message sent to the User Interface.
+This should be used to warn a user that some anomaly happened, but it probably
+didn't interfere with their request.
+4. `LOG.UI()` This will generate a message sent to the User Interface.  This
+should be used to give direct User Interface responses.  Generally, these are
+expected successful responses.
+5. `LOG.info()` This will only generate a message in the log.  This should
+be used for assisting in debugging.  These should generally include valuable
+information such as the translation of a value or message into something
+readable.
+6. `LOG.debug()` This will only generate a message in the log.  This should
+be used for truly verbose logging.  Messages that say nothing more than "we
+made it to this point in the code" should go here.
+
+Log levels `Error, Warning, and UI` __are all outputted to the user
+interface__, while `exception, debug, and info` __are only written to the
+log__.  So please take into account your audience when selecting a log level
+and the content of  the log message.
+
+Generally, unless you intend to catch an Exception somewhere else in the code
+do not use the generic `raise Exception` as this will only produce an
+exception and traceback in the log, but will not produce any other logging
+message.  Consider using `LOG.exception()` instead.

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -575,8 +575,8 @@ class Dimmer(functions.Scene, Base):
         flags = set([FLAG_BACKLIGHT, FLAG_ON_LEVEL, FLAG_RAMP_RATE])
         unknown = set(kwargs.keys()).difference(flags)
         if unknown:
-            raise Exception("Unknown Dimmer flags input: %s.\n Valid flags "
-                            "are: %s" % unknown, flags)
+            LOG.error("Unknown Dimmer flags input: %s.\n Valid flags "
+                            "are: %s", unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
         seq = CommandSeq(self, "Dimmer set_flags complete", on_done,

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -418,9 +418,9 @@ class EZIO4O(Base):
 
         unknown = set(flags_to_set).difference(valid_flags)
         if unknown:
-            raise Exception(
+            LOG.error(
                 "EZIO4O Unknown flags input: %s.\n Valid "
-                "flags are: %s" % (unknown, valid_flags)
+                "flags are: %s", unknown, valid_flags
             )
 
         # Construct the flag register to write

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -331,8 +331,8 @@ class IOLinc(Base):
                      "momentary_secs"])
         unknown = set(kwargs.keys()).difference(flags)
         if unknown:
-            raise Exception("Unknown IOLinc flags input: %s.\n Valid flags " +
-                            "are: %s" % unknown, flags)
+            LOG.error("Unknown IOLinc flags input: %s.\n Valid flags are: %s",
+                      unknown, flags)
 
         seq = CommandSeq(self.protocol, "Device flags set", on_done,
                          name="SetFLags")

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -912,8 +912,8 @@ class KeypadLinc(functions.Scene, Base):
                      FLAG_GROUP, FLAG_ON_LEVEL, FLAG_RAMP_RATE])
         unknown = set(kwargs.keys()).difference(flags)
         if unknown:
-            raise Exception("Unknown KeypadLinc flags input: %s.\n Valid "
-                            "flags are: %s" % (unknown, flags))
+            LOG.error("Unknown KeypadLinc flags input: %s.\n Valid "
+                      "flags are: %s", unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
         seq = CommandSeq(self, "KeypadLinc set_flags complete",

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -245,8 +245,8 @@ class Motion(BatterySensor):
                      "light_sensitivity"])
         unknown = set(kwargs.keys()).difference(flags)
         if unknown:
-            raise Exception("Unknown Motion flags input: %s.\n Valid flags "
-                            "are: %s" % (unknown, flags))
+            LOG.error("Unknown Motion flags input: %s.\n Valid flags "
+                      "are: %s", unknown, flags)
 
         seq = CommandSeq(self, "Motion Set Flags Success", on_done,
                          name="SetFlags")

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -304,8 +304,8 @@ class Outlet(Base):
         flags = set([FLAG_BACKLIGHT])
         unknown = set(kwargs.keys()).difference(flags)
         if unknown:
-            raise Exception("Unknown Outlet flags input: %s.\n Valid flags "
-                            "are: %s" % unknown, flags)
+            LOG.error("Unknown Outlet flags input: %s.\n Valid flags "
+                      "are: %s", unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
         seq = CommandSeq(self, "Outlet set_flags complete", on_done,

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -253,8 +253,8 @@ class Switch(functions.Scene, Base):
         flags = set([FLAG_BACKLIGHT])
         unknown = set(kwargs.keys()).difference(flags)
         if unknown:
-            raise Exception("Unknown Switch flags input: %s.\n Valid flags "
-                            "are: %s" % unknown, flags)
+            LOG.error("Unknown Switch flags input: %s.\n Valid flags "
+                      "are: %s", unknown, flags)
 
         # Start a command sequence so we can call the flag methods in series.
         seq = CommandSeq(self, "Switch set_flags complete", on_done,

--- a/tests/device/test_IOLincDev.py
+++ b/tests/device/test_IOLincDev.py
@@ -69,12 +69,12 @@ class Test_IOLinc_Set_Flags():
             test_iolinc.set_flags(None)
             assert IM.CommandSeq.add_msg.call_count == 0
 
-    def test_set_flags_unknown(self, test_iolinc):
-        with pytest.raises(Exception):
-            test_iolinc.trigger_reverse = 0
-            with mock.patch.object(IM.CommandSeq, 'add_msg'):
-                test_iolinc.set_flags(None, Unknown=1)
-                assert IM.CommandSeq.add_msg.call_count == 0
+    def test_set_flags_unknown(self, test_iolinc, caplog):
+        test_iolinc.trigger_reverse = 0
+        with mock.patch.object(IM.CommandSeq, 'add_msg'):
+            test_iolinc.set_flags(None, Unknown=1)
+            assert IM.CommandSeq.add_msg.call_count == 0
+            assert 'Unknown IOLinc flags input' in caplog.text
 
     @pytest.mark.parametrize("mode,expected", [
         ("latching", [0x07, 0x13, 0x15]),


### PR DESCRIPTION
Exceptions only show up in the LOG.  UI, Error, and Warning are sent out to the user UI.  I will add some suggestions on logging to the developer instructions.

There was no need to raise an exception here, plus without a LOG message, the user doesn't get very helpful instructions.

Previous:
```
Commanding dimmer device 12.29.84 (lamp2) cmd=set_flags                                                                 
ERROR: Error running command set_flags on device 12.29.84 (lamp2) 
```

Now:
```
Commanding dimmer device 12.29.84 (lamp2) cmd=set_flags                                                                 
ERROR: Unknown Dimmer flags input: {'on-level'}.                                                                         
Valid flags are: {'ramp_rate', 'on_level', 'backlight'}                                                                
Dimmer set_flags complete
```

This also highlights the need to abstract more of the code.  Rather than have to go around to multiple places to fix this, it should only be in one place.