### PR TITLE
MQTT Subscribe Only After MQTT Connect Callback

### DIFF
--- a/insteon_mqtt/mqtt/Mqtt.py
+++ b/insteon_mqtt/mqtt/Mqtt.py
@@ -146,7 +146,7 @@ class Mqtt:
           link (network.Mqtt):  The MQTT network link.
           connected (bool):  True if connected, False if disconnected.
         """
-        if connected:
+        if self.link.connected:
             self._subscribe()
 
     #-----------------------------------------------------------------------
@@ -180,7 +180,8 @@ class Mqtt:
         self.devices[device.addr.id] = obj
 
         # If we are already connected we need to subscribe this device
-        obj.subscribe(self.link, self.qos)
+        if self.link.connected:
+            obj.subscribe(self.link, self.qos)
 
     #-----------------------------------------------------------------------
     def handle_cmd(self, client, userdata, message):

--- a/insteon_mqtt/mqtt/Mqtt.py
+++ b/insteon_mqtt/mqtt/Mqtt.py
@@ -142,6 +142,11 @@ class Mqtt:
         This is called when the low level MQTT client connects to the broker.
         After the connection, we'll subscribe to our topics.
 
+        The connected arg doesn't actually tell us if the MQTT link is
+        connected.  It just tells us that the connect() call has returned
+        without error.  The link.connected attribute will be set to True
+        when the link is actually connected.
+
         Args:
           link (network.Mqtt):  The MQTT network link.
           connected (bool):  True if connected, False if disconnected.

--- a/insteon_mqtt/network/Mqtt.py
+++ b/insteon_mqtt/network/Mqtt.py
@@ -290,6 +290,7 @@ class Mqtt(Link):
         """
         if result == 0:
             self.connected = True
+            self.signal_connected.emit(self, True)
         else:
             LOG.error("MQTT connection refused %s %s %s", self.host, self.port,
                       result)

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -82,6 +82,7 @@ class Patch_Stack():
             IM.cmd_line.main()
             # Signal the mqtt link as connected
             # Ths causes the device mqtt objects to subscribe to topics
+            self.mqtt_obj.link.connected = True
             self.mqtt_obj.link.signal_connected.emit(self.mqtt_obj.link, True)
 
         start()


### PR DESCRIPTION
The return from network/mqtt.connect() does not describe whether the MQTT connection has been established.  This uses the on_connect callback instead.  The subscribe calls will only be made after on_connect signals a valid connection.

This Closes #312

This was a much easier fix than I expected.