### PR TITLE
Refactor MQTT Part 2, State and Manual Topics

### DIFF
--- a/insteon_mqtt/Scenes.py
+++ b/insteon_mqtt/Scenes.py
@@ -716,7 +716,7 @@ class SceneDevice:
                        "device that is neither defined in the config file nor "
                        "defined in the scenes file as an address: %s" %
                        self.label)
-                raise Exception(msg)
+                LOG.exception(msg)
 
         # Remove values from yaml_data if they are default values and make
         # pretty. Easiest way to do this is just to set things to themselves

--- a/insteon_mqtt/device/BatterySensor.py
+++ b/insteon_mqtt/device/BatterySensor.py
@@ -37,7 +37,7 @@ class BatterySensor(Base):
     connect to these signals to perform an action when a change is made to
     the device (like sending MQTT messages).  Supported signals are:
 
-    - signal_on_off( Device, bool is_on ): Sent when the sensor is tripped
+    - signal_state( Device, bool is_on ): Sent when the sensor is tripped
       (is_on=True) or resets (is_on=False).
 
     - signal_low_battery( Device, bool is_low ): Sent to indicate the current
@@ -62,7 +62,7 @@ class BatterySensor(Base):
         super().__init__(protocol, modem, address, name)
 
         # Sensor on/off signal.  API: func( Device, bool is_on )
-        self.signal_on_off = Signal()
+        self.signal_state = Signal()
         # Sensor low battery signal.  API: func( Device, bool is_low )
         self.signal_low_battery = Signal()
         # Sensor heartbeat signal.  API: func( Device, True )
@@ -286,7 +286,7 @@ class BatterySensor(Base):
         """
         LOG.info("Setting device %s on:%s", self.label, is_on)
         self._is_on = is_on
-        self.signal_on_off.emit(self, self._is_on)
+        self.signal_state.emit(self, self._is_on)
 
     #-----------------------------------------------------------------------
     def _pop_send_queue(self):

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -28,7 +28,7 @@ class Dimmer(functions.Scene, Base):
     connect to these signals to perform an action when a change is made to
     the device (like sending MQTT messages).  Supported signals are:
 
-    - signal_level_changed( Device, int level, on_off.Mode mode, str reason ):
+    - signal_state( Device, int level, on_off.Mode mode, str reason ):
       Sent whenever the dimmer is turned on or off or changes level.  The
       level field will be in the range 0-255.
 
@@ -63,7 +63,7 @@ class Dimmer(functions.Scene, Base):
 
         # Support dimmer style signals and motion on/off style signals.
         # API:  func(Device, int level, on_off.Mode mode, str reason)
-        self.signal_level_changed = Signal()
+        self.signal_state = Signal()
 
         # Manual mode start up, down, off
         # API: func(Device, on_off.Manual mode, str reason)
@@ -876,6 +876,6 @@ class Dimmer(functions.Scene, Base):
                  reason)
         self._level = level
 
-        self.signal_level_changed.emit(self, level, mode, reason)
+        self.signal_state.emit(self, level=level, mode=mode, reason=reason)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -713,7 +713,7 @@ class Dimmer(functions.Scene, Base):
             manual = on_off.Manual.decode(msg.cmd1, msg.cmd2)
             LOG.info("Dimmer %s manual change %s", self.addr, manual)
 
-            self.signal_manual.emit(self, manual, reason)
+            self.signal_manual.emit(self, manual=manual, reason=reason)
 
             # Refresh to get the new level after the button is released.
             if manual == on_off.Manual.STOP:
@@ -846,7 +846,7 @@ class Dimmer(functions.Scene, Base):
         # Starting or stopping manual mode.
         elif on_off.Manual.is_valid(msg.cmd1):
             manual = on_off.Manual.decode(msg.cmd1, msg.cmd2)
-            self.signal_manual.emit(self, manual, reason=reason)
+            self.signal_manual.emit(self, manual=manual, reason=reason)
 
             # If the button is released, refresh to get the final level.
             if manual == on_off.Manual.STOP:

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -68,7 +68,7 @@ class EZIO4O(Base):
     connect to these signals to perform an action when a change is made to
     the device (like sending MQTT messages).  Supported signals are:
 
-    - signal_on_off( Device, int group, bool is_on, on_off.Mode mode, str
+    - signal_state( Device, int group, bool is_on, on_off.Mode mode, str
                      reason ): Sent whenever an output is turned on or off.
                      Group will be 1 to 4 matching the corresponding device
                      output.
@@ -92,7 +92,7 @@ class EZIO4O(Base):
         # Support on/off style signals.
         # API: func(Device, int group, bool is_on, on_off.Mode mode,
         #           str reason)
-        self.signal_on_off = Signal()
+        self.signal_state = Signal()
 
         # Remote (mqtt) commands mapped to methods calls.  Add to the
         # base class defined commands.
@@ -675,6 +675,7 @@ class EZIO4O(Base):
         self._is_on[group - 1] = is_on
 
         # Notify others that the output state has changed.
-        self.signal_on_off.emit(self, group, is_on, mode, reason)
+        self.signal_state.emit(self, button=group, is_on=is_on, mode=mode,
+                               reason=reason)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -32,10 +32,6 @@ class FanLinc(Dimmer):
     - signal_fan_speed( Device, bool is_on, on_off.Mode mode, str reason ):
       Sent whenever the switch is turned on or off.
 
-    - signal_manual( Device, on_off.Manual mode, str reason ): Sent when the
-      device starts or stops manual mode (when a button is held down or
-      released).
-
     """
     type_name = "fan_linc"
 

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -28,7 +28,7 @@ class Motion(BatterySensor):
     database is current or what the current motion state is - we can really
     only respond to the sensor when it sends out a message.
 
-    Motion sensors send a Motion.signal_on_off signal (from BatterySensor)
+    Motion sensors send a Motion.signal_state signal (from BatterySensor)
     when motion is detected.  Some motion sensors also support a dusk/dawn
     light sensor.  In that case, the Motion.signal_dawn signal is emitted
     when the light sensor changes state.
@@ -47,7 +47,7 @@ class Motion(BatterySensor):
     connect to these signals to perform an action when a change is made to
     the device (like sending MQTT messages).  Supported signals are:
 
-    - signal_on_off( Device, bool is_on ): Sent when the sensor is tripped
+    - signal_state( Device, bool is_on ): Sent when the sensor is tripped
       (is_on=True) or resets (is_on=False).
 
     - signal_low_battery( Device, bool is_low ): Sent to indicate the current

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -27,7 +27,7 @@ class Outlet(Base):
     connect to these signals to perform an action when a change is made to
     the device (like sending MQTT messages).  Supported signals are:
 
-    - signal_on_off( Device, int group, bool is_on, on_off.Mode mode, str
+    - signal_state( Device, int group, bool is_on, on_off.Mode mode, str
                      reason ): Sent whenever the switch is turned on or off.
                      Group will be 1 for the top outlet and 2 for the bottom
                      outlet.
@@ -51,7 +51,7 @@ class Outlet(Base):
         # Support on/off style signals.
         # API: func(Device, int group, bool is_on, on_off.Mode mode,
         #           str reason)
-        self.signal_on_off = Signal()
+        self.signal_state = Signal()
 
         # Remote (mqtt) commands mapped to methods calls.  Add to the
         # base class defined commands.
@@ -493,6 +493,7 @@ class Outlet(Base):
         self._is_on[group - 1] = is_on
 
         # Notify others that the outlet state has changed.
-        self.signal_on_off.emit(self, group, is_on, mode, reason)
+        self.signal_state.emit(self, button=group, is_on=is_on, mode=mode,
+                               reason=reason)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/Remote.py
+++ b/insteon_mqtt/device/Remote.py
@@ -32,7 +32,7 @@ class Remote(BatterySensor):
     connect to these signals to perform an action when a change is made to
     the device (like sending MQTT messages).  Supported signals are:
 
-    - signal_pressed( Device, int group, bool is_on, on_off.Mode mode ):
+    - signal_state( Device, int group, bool is_on, on_off.Mode mode ):
       Sent whenever a button is pressed.  The remote will toggle on and off
       with each button press.
 
@@ -78,7 +78,7 @@ class Remote(BatterySensor):
 
         # Button pressed signal.
         # API: func(Device, int group, bool on, on_off.Mode mode)
-        self.signal_pressed = Signal()
+        self.signal_state = Signal()
 
         # Manual mode start up, down, off
         # API: func(Device, int group, on_off.Manual mode)
@@ -158,7 +158,8 @@ class Remote(BatterySensor):
                          self.addr, msg.group, is_on, mode)
 
                 # Notify others that the button was pressed.
-                self.signal_pressed.emit(self, msg.group, is_on, mode)
+                self.signal_state.emit(self, button=msg.group, is_on=is_on,
+                                       mode=mode)
                 self.update_linked_devices(msg)
 
             # Starting or stopping manual increment (cmd2 0x00=up, 0x01=down)
@@ -167,7 +168,7 @@ class Remote(BatterySensor):
                 LOG.info("Remote %s manual change group: %s %s", self.addr,
                          msg.group, manual)
 
-                self.signal_manual.emit(self, msg.group, manual)
+                self.signal_manual.emit(self, button=msg.group, manual=manual)
                 self.update_linked_devices(msg)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -321,7 +321,7 @@ class Switch(functions.Scene, Base):
             manual = on_off.Manual.decode(msg.cmd1, msg.cmd2)
             LOG.info("Switch %s manual change %s", self.addr, manual)
 
-            self.signal_manual.emit(self, manual)
+            self.signal_manual.emit(self, manual=manual)
 
             # Switches change state when the switch is held (not all devices
             # do this).

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -28,7 +28,7 @@ class Switch(functions.Scene, Base):
     connect to these signals to perform an action when a change is made to
     the device (like sending MQTT messages).  Supported signals are:
 
-    - signal_on_off( Device, bool is_on, on_off.Mode mode, str reason ):
+    - signal_state( Device, bool is_on, on_off.Mode mode, str reason ):
       Sent whenever the switch is turned on or off.
 
     - signal_manual( Device, on_off.Manual mode ): Sent when the device
@@ -51,7 +51,7 @@ class Switch(functions.Scene, Base):
 
         # Support on/off style signals.
         # API: func(Device, bool is_on, on_off.Mode mode, str reason)
-        self.signal_on_off = Signal()
+        self.signal_state = Signal()
 
         # Manual mode start up, down, off
         # API: func(Device, on_off.Manual mode)
@@ -438,6 +438,7 @@ class Switch(functions.Scene, Base):
                  mode, reason)
         self._is_on = bool(is_on)
 
-        self.signal_on_off.emit(self, self._is_on, mode, reason)
+        self.signal_state.emit(self, is_on=self._is_on, mode=mode,
+                               reason=reason)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/BaseTopic.py
+++ b/insteon_mqtt/mqtt/BaseTopic.py
@@ -9,22 +9,24 @@ LOG = log.get_logger()
 
 
 class BaseTopic:
-    """MQTT interface to an Insteon on/off switch.
-
-    This class connects to a device.Switch object and converts it's
-    output state changes to MQTT messages.  It also subscribes to topics to
-    allow input MQTT messages to change the state of the Insteon device.
-
-    Switches will report their state and can be commanded to turn on and off.
+    """Abstract Class for MQTT Topics
     """
-
     def __init__(self, mqtt, device):
+        """Constructor
+
+        Args:
+          mqtt (mqtt.Mqtt):  The MQTT main interface.
+          device (device):  The Insteon object to link to.
+        """
         self.mqtt = mqtt
         self.device = device
 
     #-----------------------------------------------------------------------
     def base_template_data(self, **kwargs):
         """Create the Jinja templating data variables for use in topics.
+
+        As the base template, this provides the immutable values such as
+        address and name.
 
         Args:
           button (int):  The button (group) ID (1-8) of the Insteon button

--- a/insteon_mqtt/mqtt/BaseTopic.py
+++ b/insteon_mqtt/mqtt/BaseTopic.py
@@ -1,0 +1,42 @@
+#===========================================================================
+#
+# MQTT Base Topic
+#
+#===========================================================================
+from .. import log
+
+LOG = log.get_logger()
+
+
+class BaseTopic:
+    """MQTT interface to an Insteon on/off switch.
+
+    This class connects to a device.Switch object and converts it's
+    output state changes to MQTT messages.  It also subscribes to topics to
+    allow input MQTT messages to change the state of the Insteon device.
+
+    Switches will report their state and can be commanded to turn on and off.
+    """
+
+    def __init__(self, mqtt, device):
+        self.mqtt = mqtt
+        self.device = device
+
+    #-----------------------------------------------------------------------
+    def topic_template_data(self, button=None):
+        """Create the Jinja templating data variables for use in topics.
+
+        Args:
+          button (int):  The button (group) ID (1-8) of the Insteon button
+                 that was triggered.
+
+        Returns:
+          dict:  Returns a dict with the variables available for templating.
+        """
+        data = {"address" : self.device.addr.hex,
+                "name" : self.device.addr.hex,}
+        if self.device.name:
+            data['name'] = self.device.name
+        if button is not None:
+            data['button'] = button
+        return data

--- a/insteon_mqtt/mqtt/BaseTopic.py
+++ b/insteon_mqtt/mqtt/BaseTopic.py
@@ -23,7 +23,7 @@ class BaseTopic:
         self.device = device
 
     #-----------------------------------------------------------------------
-    def topic_template_data(self, button=None):
+    def base_template_data(self, button=None):
         """Create the Jinja templating data variables for use in topics.
 
         Args:

--- a/insteon_mqtt/mqtt/BaseTopic.py
+++ b/insteon_mqtt/mqtt/BaseTopic.py
@@ -23,7 +23,7 @@ class BaseTopic:
         self.device = device
 
     #-----------------------------------------------------------------------
-    def base_template_data(self, button=None):
+    def base_template_data(self, **kwargs):
         """Create the Jinja templating data variables for use in topics.
 
         Args:
@@ -37,6 +37,6 @@ class BaseTopic:
                 "name" : self.device.addr.hex,}
         if self.device.name:
             data['name'] = self.device.name
-        if button is not None:
-            data['button'] = button
+        if 'button' in kwargs and kwargs['button'] is not None:
+            data['button'] = kwargs['button']
         return data

--- a/insteon_mqtt/mqtt/BaseTopic.py
+++ b/insteon_mqtt/mqtt/BaseTopic.py
@@ -34,7 +34,7 @@ class BaseTopic:
           dict:  Returns a dict with the variables available for templating.
         """
         data = {"address" : self.device.addr.hex,
-                "name" : self.device.addr.hex,}
+                "name" : self.device.addr.hex}
         if self.device.name:
             data['name'] = self.device.name
         if 'button' in kwargs and kwargs['button'] is not None:

--- a/insteon_mqtt/mqtt/BatterySensor.py
+++ b/insteon_mqtt/mqtt/BatterySensor.py
@@ -103,11 +103,7 @@ class BatterySensor(StateTopic):
           dict:  Returns a dict with the variables available for templating.
         """
         # Set up the variables that can be used in the templates.
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            }
+        data = self.base_template_data()
 
         if is_on is not None:
             data["on"] = 1 if is_on else 0

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -30,8 +30,10 @@ class Dimmer(StateTopic, SceneTopic):
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.Dimmer):  The Insteon object to link to.
         """
-        self.mqtt = mqtt
-        self.device = device
+        # Setup the Topics
+        super().__init__(mqtt, device,
+                         state_payload='{ "state" : "{{on_str.lower()}}", '
+                                       '"brightness" : {{level_255}} }')
 
         # Output manual state change is off by default.
         self.msg_manual_state = MsgTemplate(None, None)
@@ -50,10 +52,6 @@ class Dimmer(StateTopic, SceneTopic):
         # Connect the signals from the insteon device so we get notified of
         # changes.
         device.signal_manual.connect(self._insteon_manual)
-
-        # Setup the Topics
-        super().__init__(state_payload='{ "state" : "{{on_str.lower()}}", '
-                                       '"brightness" : {{level_255}} }')
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
@@ -91,11 +89,11 @@ class Dimmer(StateTopic, SceneTopic):
           qos (int):  The quality of service to use.
         """
         # On/off command messages.
-        topic = self.msg_on_off.render_topic(self.template_data())
+        topic = self.msg_on_off.render_topic(self.topic_template_data())
         link.subscribe(topic, qos, self._input_on_off)
 
         # Level changing command messages.
-        topic = self.msg_level.render_topic(self.template_data())
+        topic = self.msg_level.render_topic(self.topic_template_data())
         link.subscribe(topic, qos, self._input_set_level)
 
         self.scene_subscribe(link, qos)
@@ -107,10 +105,10 @@ class Dimmer(StateTopic, SceneTopic):
         Args:
           link (network.Mqtt):  The MQTT network client to use.
         """
-        topic = self.msg_on_off.render_topic(self.template_data())
+        topic = self.msg_on_off.render_topic(self.topic_template_data())
         link.unsubscribe(topic)
 
-        topic = self.msg_level.render_topic(self.template_data())
+        topic = self.msg_level.render_topic(self.topic_template_data())
         link.unsubscribe(topic)
 
         self.scene_unsubscribe(link)

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -89,11 +89,11 @@ class Dimmer(StateTopic, SceneTopic):
           qos (int):  The quality of service to use.
         """
         # On/off command messages.
-        topic = self.msg_on_off.render_topic(self.topic_template_data())
+        topic = self.msg_on_off.render_topic(self.base_template_data())
         link.subscribe(topic, qos, self._input_on_off)
 
         # Level changing command messages.
-        topic = self.msg_level.render_topic(self.topic_template_data())
+        topic = self.msg_level.render_topic(self.base_template_data())
         link.subscribe(topic, qos, self._input_set_level)
 
         self.scene_subscribe(link, qos)
@@ -105,10 +105,10 @@ class Dimmer(StateTopic, SceneTopic):
         Args:
           link (network.Mqtt):  The MQTT network client to use.
         """
-        topic = self.msg_on_off.render_topic(self.topic_template_data())
+        topic = self.msg_on_off.render_topic(self.base_template_data())
         link.unsubscribe(topic)
 
-        topic = self.msg_level.render_topic(self.topic_template_data())
+        topic = self.msg_level.render_topic(self.base_template_data())
         link.unsubscribe(topic)
 
         self.scene_unsubscribe(link)

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -107,56 +107,6 @@ class Dimmer(StateTopic, SceneTopic, ManualTopic):
         self.scene_unsubscribe(link)
 
     #-----------------------------------------------------------------------
-    def template_data(self, **kwargs):
-        """Create the Jinja templating data variables for on/off messages.
-
-        Args:
-          level (int):  The dimmer level.  If None, on/off and levels
-                attributes are not added to the data.
-          mode (on_off.Mode):  The on/off mode state.
-          manual (on_off.Manual):  The manual mode state.  If None, manual
-                 attributes are not added to the data.
-          reason (str):  The reason the device was triggered.  This is an
-                 arbitrary string set into the template variables.
-
-        Returns:
-          dict:  Returns a dict with the variables available for templating.
-        """
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            }
-
-        if 'level' in kwargs and kwargs['level'] is not None:
-            data["on"] = 1 if kwargs['level'] else 0
-            data["on_str"] = "on" if kwargs['level'] else "off"
-            data["level_255"] = kwargs['level']
-            data["level_100"] = int(100.0 * kwargs['level'] / 255.0)
-            data["mode"] = str(on_off.Mode.NORMAL)
-            data["fast"] = 0
-            data["instant"] = 0
-            if 'mode' in kwargs:
-                data["mode"] = str(kwargs['mode'])
-                data["fast"] = 1 if kwargs['mode'] == on_off.Mode.FAST else 0
-                data["instant"] = 0
-                if kwargs['mode'] == on_off.Mode.INSTANT:
-                    data["instant"] = 1
-            data["reason"] = ""
-            if 'reason' in kwargs and kwargs['reason'] is not None:
-                data["reason"] = kwargs['reason']
-
-        if 'manual' in kwargs and kwargs['manual'] is not None:
-            data["manual_str"] = str(kwargs['manual'])
-            data["manual"] = kwargs['manual'].int_value()
-            data["manual_openhab"] = kwargs['manual'].openhab_value()
-            data["reason"] = ""
-            if 'reason' in kwargs and kwargs['reason'] is not None:
-                data["reason"] = kwargs['reason']
-
-        return data
-
-    #-----------------------------------------------------------------------
     def _input_on_off(self, client, data, message):
         """Handle an input on/off change MQTT message.
 

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -58,7 +58,7 @@ class Dimmer(SceneTopic):
         device.signal_manual.connect(self._insteon_manual)
 
         # Setup the Scene Topic
-        super().__init__(mqtt, device)
+        super().__init__()
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/FanLinc.py
+++ b/insteon_mqtt/mqtt/FanLinc.py
@@ -149,11 +149,8 @@ class FanLinc(Dimmer):
         Returns:
           dict:  Returns a dict with the variables available for templating.
         """
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            }
+        # Set up the variables that can be used in the templates.
+        data = self.base_template_data()
 
         if level is not None:
             assert isinstance(level, Dev.FanLinc.Speed)

--- a/insteon_mqtt/mqtt/FanLinc.py
+++ b/insteon_mqtt/mqtt/FanLinc.py
@@ -99,7 +99,7 @@ class FanLinc(Dimmer):
         super().subscribe(link, qos)
 
         # Subscribe to the FanLinc topics.
-        data = self.template_data()
+        data = self.base_template_data()
 
         topic = self.msg_fan_on_off.render_topic(data)
         if topic:

--- a/insteon_mqtt/mqtt/IOLinc.py
+++ b/insteon_mqtt/mqtt/IOLinc.py
@@ -6,11 +6,12 @@
 from .. import log
 from .MsgTemplate import MsgTemplate
 from . import util
+from .BaseTopic import BaseTopic
 
 LOG = log.get_logger()
 
 
-class IOLinc:
+class IOLinc(BaseTopic):
     """MQTT interface to an Insteon IOLinc device.
 
     This class connects to a device.IOLinc object and converts it's
@@ -24,8 +25,7 @@ class IOLinc:
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.IOLinc):  The Insteon object to link to.
         """
-        self.mqtt = mqtt
-        self.device = device
+        super().__init__(mqtt, device)
 
         # Output state change reporting template.
         self.msg_state = MsgTemplate(
@@ -108,11 +108,7 @@ class IOLinc:
           dict:  Returns a dict with the variables available for templating.
         """
         # Set up the variables that can be used in the templates.
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            }
+        data = self.base_template_data()
 
         if sensor_is_on is not None:
             data["sensor_on"] = 1 if sensor_is_on else 0

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -30,8 +30,8 @@ class KeypadLinc(SceneTopic):
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.KeypadLinc):  The Insteon object to link to.
         """
-        self.mqtt = mqtt
-        self.device = device
+        super().__init__(mqtt, device,
+                         scene_topic='insteon/{{address}}/scene/{{button}}')
 
         # Output on/off state change reporting template.
         self.msg_btn_state = MsgTemplate(
@@ -65,7 +65,6 @@ class KeypadLinc(SceneTopic):
         # changes.
         device.signal_level_changed.connect(self._insteon_level_changed)
         device.signal_manual.connect(self._insteon_manual)
-        super().__init__(scene_topic='insteon/{{address}}/scene/{{button}}')
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -65,8 +65,7 @@ class KeypadLinc(SceneTopic):
         # changes.
         device.signal_level_changed.connect(self._insteon_level_changed)
         device.signal_manual.connect(self._insteon_manual)
-        super().__init__(mqtt, device,
-                         scene_topic='insteon/{{address}}/scene/{{button}}')
+        super().__init__(scene_topic='insteon/{{address}}/scene/{{button}}')
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -5,7 +5,6 @@
 #===========================================================================
 import functools
 from .. import log
-# from .. import on_off
 from .MsgTemplate import MsgTemplate
 from . import util
 from .SceneTopic import SceneTopic

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -5,15 +5,17 @@
 #===========================================================================
 import functools
 from .. import log
-from .. import on_off
+# from .. import on_off
 from .MsgTemplate import MsgTemplate
 from . import util
 from .SceneTopic import SceneTopic
+from .StateTopic import StateTopic
+from .ManualTopic import ManualTopic
 
 LOG = log.get_logger()
 
 
-class KeypadLinc(SceneTopic):
+class KeypadLinc(SceneTopic, StateTopic, ManualTopic):
     """MQTT interface to an Insteon KeypadLinc dimmer or switch.
 
     This class connects to a device.KeypadLinc object and converts it's output
@@ -30,41 +32,28 @@ class KeypadLinc(SceneTopic):
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.KeypadLinc):  The Insteon object to link to.
         """
+        # Setup a special template for button one if this is a dimmer
+        state_payload_1 = None
+        if device.is_dimmer:
+            state_payload_1 = '{ "state" : "{{on_str.lower()}}", ' \
+                              '"brightness" : {{level_255}} }'
         super().__init__(mqtt, device,
-                         scene_topic='insteon/{{address}}/scene/{{button}}')
-
-        # Output on/off state change reporting template.
-        self.msg_btn_state = MsgTemplate(
-            topic='insteon/{{address}}/state/{{button}}',
-            payload='{{on_str.lower()}}')
-
-        # Output manual state change is off by default.
-        self.msg_manual_state = MsgTemplate(None, None)
+                         scene_topic='insteon/{{address}}/scene/{{button}}',
+                         state_topic='insteon/{{address}}/state/{{button}}',
+                         state_payload_1=state_payload_1,)
 
         # Input on/off command template.
         self.msg_btn_on_off = MsgTemplate(
             topic='insteon/{{address}}/set/{{button}}',
             payload='{ "cmd" : "{{value.lower()}}" }')
 
-        self.msg_dimmer_state = None
         self.msg_dimmer_level = None
         if self.device.is_dimmer:
-            # Output dimmer state change reporting template.
-            self.msg_dimmer_state = MsgTemplate(
-                topic='insteon/{{address}}/state/1',
-                payload='{ "state" : "{{on_str.lower()}}", '
-                        '"brightness" : {{level_255}} }')
-
             # Input dimmer level command template.
             self.msg_dimmer_level = MsgTemplate(
                 topic='insteon/{{address}}/level',
                 payload='{ "cmd" : "{{json.state.lower()}}", '
                         '"level" : {{json.brightness}} }')
-
-        # Connect the signals from the insteon device so we get notified of
-        # changes.
-        device.signal_level_changed.connect(self._insteon_level_changed)
-        device.signal_manual.connect(self._insteon_manual)
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
@@ -79,20 +68,19 @@ class KeypadLinc(SceneTopic):
         if not data:
             return
 
+        # Load the various topics
+        self.load_state_data(data, qos,
+                             topic='btn_state_topic',
+                             payload='btn_state_payload')
+        self.load_manual_data(data, qos)
         self.load_scene_data(data, qos,
                              topic='btn_scene_topic',
                              payload='btn_scene_payload')
 
-        self.msg_btn_state.load_config(data, 'btn_state_topic',
-                                       'btn_state_payload', qos)
-        self.msg_manual_state.load_config(data, 'manual_state_topic',
-                                          'manual_state_payload', qos)
         self.msg_btn_on_off.load_config(data, 'btn_on_off_topic',
                                         'btn_on_off_payload', qos)
 
         if self.device.is_dimmer:
-            self.msg_dimmer_state.load_config(data, 'dimmer_state_topic',
-                                              'dimmer_state_payload', qos)
             self.msg_dimmer_level.load_config(data, 'dimmer_level_topic',
                                               'dimmer_level_payload', qos)
 
@@ -115,7 +103,7 @@ class KeypadLinc(SceneTopic):
             start_group = 2
 
             # Create the topic names for button 1.
-            data = self.template_data(button=1)
+            data = self.base_template_data(button=1)
             topic_switch = self.msg_btn_on_off.render_topic(data)
             topic_dimmer = self.msg_dimmer_level.render_topic(data)
 
@@ -139,7 +127,7 @@ class KeypadLinc(SceneTopic):
         # which.
         for group in range(start_group, 9):
             handler = functools.partial(self._input_on_off, group=group)
-            data = self.template_data(button=group)
+            data = self.base_template_data(button=group)
 
             topic = self.msg_btn_on_off.render_topic(data)
             link.subscribe(topic, qos, handler)
@@ -155,7 +143,7 @@ class KeypadLinc(SceneTopic):
           link (network.Mqtt):  The MQTT network client to use.
         """
         for group in range(1, 9):
-            data = self.template_data(button=group)
+            data = self.base_template_data(button=group)
 
             topic = self.msg_btn_on_off.render_topic(data)
             link.unsubscribe(topic)
@@ -164,106 +152,9 @@ class KeypadLinc(SceneTopic):
             self.scene_unsubscribe(link, group=group)
 
         if self.device.is_dimmer:
-            data = self.template_data(button=1)
+            data = self.base_template_data(button=1)
             topic = self.msg_dimmer_level.render_topic(data)
             link.unsubscribe(topic)
-
-    #-----------------------------------------------------------------------
-    # pylint: disable=arguments-differ
-    def template_data(self, button=None, level=None, mode=on_off.Mode.NORMAL,
-                      manual=None, reason=None):
-        """Create the Jinja templating data variables for on/off messages.
-
-        Args:
-          button (int):  The button (group) ID (1-8) of the Insteon button
-                 that was triggered.
-          level (int):  The dimmer level.  If None, on/off, levels, and mode
-                attributes are not added to the data.
-          mode (on_off.Mode):  The on/off mode state.
-          manual (on_off.Manual):  The manual mode state.  If None, manual
-                 attributes are not added to the data.
-          reason (str):  The reason the device was triggered.  This is an
-                 arbitrary string set into the template variables.
-
-        Returns:
-          dict:  Returns a dict with the variables available for templating.
-        """
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            "button" : button,
-            }
-
-        if level is not None:
-            level = int(level)
-            data["on"] = 1 if level else 0
-            data["on_str"] = "on" if level else "off"
-            data["level_255"] = level
-            data["level_100"] = int(100.0 * level / 255.0)
-            data["mode"] = str(mode)
-            data["fast"] = 1 if mode == on_off.Mode.FAST else 0
-            data["instant"] = 1 if mode == on_off.Mode.INSTANT else 0
-            data["reason"] = reason if reason is not None else ""
-
-        if manual is not None:
-            data["manual_str"] = str(manual)
-            data["manual"] = manual.int_value()
-            data["manual_openhab"] = manual.openhab_value()
-            data["reason"] = reason if reason is not None else ""
-
-        return data
-
-    #-----------------------------------------------------------------------
-    def _insteon_level_changed(self, device, group, level,
-                               mode=on_off.Mode.NORMAL, reason=""):
-        """Device on/off and dimmer level changed callback.
-
-        This is triggered via signal when the Insteon device goes active or
-        inactive.  It will publish an MQTT message with the new state.
-
-        Args:
-          device (device.KeypadLinc):  The Insteon device that changed.
-          group (int):  The button (1-8) that was pressed.
-          level (int):  The dimmer level (0->255)
-          mode (on_off.Mode):  The on/off mode state.
-          reason (str):  The reason the device was triggered.  This is an
-                 arbitrary string set into the template variables.
-        """
-        LOG.info("MQTT received button press %s = btn %s at %s %s %s",
-                 device.label, group, level, mode, reason)
-
-        data = self.template_data(group, level, mode, reason=reason)
-
-        # For manual mode messages, don't retain them because they don't
-        # represent persistent state - they're momentary events.
-        retain = False if mode == on_off.Mode.MANUAL else None
-
-        if group == 1 and self.device.is_dimmer:
-            self.msg_dimmer_state.publish(self.mqtt, data, retain=retain)
-        else:
-            self.msg_btn_state.publish(self.mqtt, data, retain=retain)
-
-    #-----------------------------------------------------------------------
-    def _insteon_manual(self, device, group, manual, reason=""):
-        """Device manual mode changed callback.
-
-        This is triggered via signal when the Insteon device starts or stops
-        manual mode (holding a button down).  It will publish an MQTT message
-        with the new state.
-
-        Args:
-          device (device.Dimmer):  The Insteon device that changed.
-          group (int):  The button (1-8) that was pressed.
-          manual (on_off.Manual):  The manual mode.
-        """
-        LOG.info("MQTT received manual button press %s = btn %s %s %s",
-                 device.label, group, manual, reason)
-
-        # For manual mode messages, don't retain them because they don't
-        # represent persistent state - they're momentary events.
-        data = self.template_data(group, manual=manual, reason=reason)
-        self.msg_manual_state.publish(self.mqtt, data, retain=False)
 
     #-----------------------------------------------------------------------
     def _input_on_off(self, client, data, message, group, raise_errors=False):

--- a/insteon_mqtt/mqtt/Leak.py
+++ b/insteon_mqtt/mqtt/Leak.py
@@ -73,11 +73,7 @@ class Leak(BatterySensor):
           dict:  Returns a dict with the variables available for templating.
         """
         # Set up the variables that can be used in the templates.
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            }
+        data = self.base_template_data()
 
         if is_wet is not None:
             data["is_wet"] = 1 if is_wet else 0

--- a/insteon_mqtt/mqtt/ManualTopic.py
+++ b/insteon_mqtt/mqtt/ManualTopic.py
@@ -5,7 +5,7 @@
 #===========================================================================
 # import functools
 from .. import log
-from .. import on_off
+# from .. import on_off
 from .MsgTemplate import MsgTemplate
 # from . import util
 from .BaseTopic import BaseTopic

--- a/insteon_mqtt/mqtt/ManualTopic.py
+++ b/insteon_mqtt/mqtt/ManualTopic.py
@@ -1,0 +1,93 @@
+#===========================================================================
+#
+# MQTT Manual Topic
+#
+#===========================================================================
+# import functools
+from .. import log
+from .. import on_off
+from .MsgTemplate import MsgTemplate
+# from . import util
+from .BaseTopic import BaseTopic
+
+LOG = log.get_logger()
+
+
+class ManualTopic(BaseTopic):
+    """MQTT interface to the Manual Topic
+
+    This is an abstract class that provides support for the manual topic.
+
+    Output manual state change is off by default.
+    """
+    @staticmethod
+    def manual_template_data(**kwargs):
+        data = {}
+        if 'manual' in kwargs and kwargs['manual'] is not None:
+            data["manual_str"] = str(kwargs['manual'])
+            data["manual"] = kwargs['manual'].int_value()
+            data["manual_openhab"] = kwargs['manual'].openhab_value()
+            data["reason"] = ""
+            if 'reason' in kwargs and kwargs['reason'] is not None:
+                data["reason"] = kwargs['reason']
+        return data
+
+    def __init__(self, mqtt, device, manual_topic=None, manual_payload=None,
+                 **kwargs):
+        """Constructor
+
+        """
+        super().__init__(mqtt, device, **kwargs)
+
+        LOG.debug("%s, %s", manual_topic, manual_payload)
+
+        # Output manual on/off command template.
+        self.msg_manual_state = MsgTemplate(topic=manual_topic,
+                                            payload=manual_payload)
+
+        # Receive notifications from the Insteon device when it changes.
+        self.device.signal_manual.connect(self.publish_manual)
+
+    #-----------------------------------------------------------------------
+    def load_manual_data(self, data, qos=None, topic=None, payload=None):
+        """Load values from a configuration data object.
+
+        Args:
+          data (dict):  The section of the config dict that applies to this
+                        class.
+          qos (int):  The default quality of service level to use.
+        """
+        if topic is None:
+            topic = 'manual_state_topic'
+        if payload is None:
+            payload = 'manual_state_payload'
+
+        # Update the MQTT topics and payloads from the config file.
+        self.msg_manual_state.load_config(data, topic, payload, qos)
+
+    #-----------------------------------------------------------------------
+    def template_data(self, **kwargs):
+        raise NotImplementedError  # pragma: no cover
+
+    #-----------------------------------------------------------------------
+    def publish_manual(self, device, manual, reason=""):
+        """Device on/off callback.
+
+        This is triggered via signal when the Insteon device is turned on or
+        off.  It will publish an MQTT message with the new manual.
+
+        Args:
+          device (device.Switch):   The Insteon device that changed.
+          is_on (bool):   True for on, False for off.
+          mode (on_off.Mode):  The on/off mode manual.
+          reason (str):  The reason the device was triggered.  This is an
+                 arbitrary string set into the template variables.
+        """
+        LOG.info("MQTT received manual change %s on: %s", device.label, manual)
+        data = ManualTopic.manual_template_data(manual=manual, reason=reason)
+        # update data with base data
+        base_data = self.base_template_data()
+        data.update(base_data)
+        self.msg_manual_state.publish(self.mqtt, data, retain=False)
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/ManualTopic.py
+++ b/insteon_mqtt/mqtt/ManualTopic.py
@@ -19,6 +19,12 @@ class ManualTopic(BaseTopic):
     """
     @staticmethod
     def manual_template_data(**kwargs):
+        """Generate the manual template data
+
+        This is used in StateTopic as well by devices that do not necessarily
+        have a ManualTopic.  Not sure if this is necessary, but to enable such
+        functionality, this is a static method.
+        """
         data = {}
         if 'manual' in kwargs and kwargs['manual'] is not None:
             data["manual_str"] = str(kwargs['manual'])
@@ -31,8 +37,15 @@ class ManualTopic(BaseTopic):
 
     def __init__(self, mqtt, device, manual_topic=None, manual_payload=None,
                  **kwargs):
-        """Constructor
+        """Manual Topic Constructor
 
+        Manual topics are off by default.
+
+        Args:
+          mqtt (mqtt.Mqtt):  The MQTT main interface.
+          device (device):  The Insteon object to link to.
+          manual_topic (str): The template for the topic
+          manual_payload (str): The tempalte for the payload
         """
         super().__init__(mqtt, device, **kwargs)
 
@@ -64,17 +77,14 @@ class ManualTopic(BaseTopic):
 
     #-----------------------------------------------------------------------
     def publish_manual(self, device, **kwargs):
-        """Device on/off callback.
+        """Device Manual Change Callback.
 
-        This is triggered via signal when the Insteon device is turned on or
-        off.  It will publish an MQTT message with the new manual.
+        This is triggered via signal when the Insteon device is manual change
+        is triggered.  It will publish an MQTT message with the new manual.
 
         Args:
-          device (device.Switch):   The Insteon device that changed.
-          is_on (bool):   True for on, False for off.
-          mode (on_off.Mode):  The on/off mode manual.
-          reason (str):  The reason the device was triggered.  This is an
-                 arbitrary string set into the template variables.
+          device (device):   The Insteon device that changed.
+          kwargs (dict):  The dictionary of values to pass to template.
         """
         LOG.info("MQTT received manual change %s on: %s", device.label, kwargs)
         data = ManualTopic.manual_template_data(**kwargs)

--- a/insteon_mqtt/mqtt/ManualTopic.py
+++ b/insteon_mqtt/mqtt/ManualTopic.py
@@ -66,10 +66,6 @@ class ManualTopic(BaseTopic):
         self.msg_manual_state.load_config(data, topic, payload, qos)
 
     #-----------------------------------------------------------------------
-    def template_data(self, **kwargs):
-        raise NotImplementedError  # pragma: no cover
-
-    #-----------------------------------------------------------------------
     def publish_manual(self, device, manual, reason=""):
         """Device on/off callback.
 

--- a/insteon_mqtt/mqtt/ManualTopic.py
+++ b/insteon_mqtt/mqtt/ManualTopic.py
@@ -66,7 +66,7 @@ class ManualTopic(BaseTopic):
         self.msg_manual_state.load_config(data, topic, payload, qos)
 
     #-----------------------------------------------------------------------
-    def publish_manual(self, device, manual, reason=""):
+    def publish_manual(self, device, **kwargs):
         """Device on/off callback.
 
         This is triggered via signal when the Insteon device is turned on or
@@ -79,10 +79,10 @@ class ManualTopic(BaseTopic):
           reason (str):  The reason the device was triggered.  This is an
                  arbitrary string set into the template variables.
         """
-        LOG.info("MQTT received manual change %s on: %s", device.label, manual)
-        data = ManualTopic.manual_template_data(manual=manual, reason=reason)
+        LOG.info("MQTT received manual change %s on: %s", device.label, kwargs)
+        data = ManualTopic.manual_template_data(**kwargs)
         # update data with base data
-        base_data = self.base_template_data()
+        base_data = self.base_template_data(**kwargs)
         data.update(base_data)
         self.msg_manual_state.publish(self.mqtt, data, retain=False)
 

--- a/insteon_mqtt/mqtt/ManualTopic.py
+++ b/insteon_mqtt/mqtt/ManualTopic.py
@@ -3,11 +3,8 @@
 # MQTT Manual Topic
 #
 #===========================================================================
-# import functools
 from .. import log
-# from .. import on_off
 from .MsgTemplate import MsgTemplate
-# from . import util
 from .BaseTopic import BaseTopic
 
 LOG = log.get_logger()

--- a/insteon_mqtt/mqtt/Motion.py
+++ b/insteon_mqtt/mqtt/Motion.py
@@ -76,11 +76,7 @@ class Motion(BatterySensor):
           dict:  Returns a dict with the variables available for templating.
         """
         # Set up the variables that can be used in the templates.
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            }
+        data = self.base_template_data()
 
         if is_dawn is not None:
             data["is_dawn"] = 1 if is_dawn else 0

--- a/insteon_mqtt/mqtt/Motion.py
+++ b/insteon_mqtt/mqtt/Motion.py
@@ -58,8 +58,8 @@ class Motion(BatterySensor):
         # In versions < 0.6, these were in motion sensor so try and
         # load them to insure old config files still work.
         if "state_topic" in data:
-            self.msg_state.load_config(data, 'state_topic', 'state_payload',
-                                       qos)
+            self.load_state_data(data, qos)
+
         if "low_battery_topic" in data:
             self.msg_battery.load_config(data, 'low_battery_topic',
                                          'low_battery_payload', qos)

--- a/insteon_mqtt/mqtt/Outlet.py
+++ b/insteon_mqtt/mqtt/Outlet.py
@@ -8,11 +8,12 @@ from .. import log
 from .. import on_off
 from .MsgTemplate import MsgTemplate
 from . import util
+from .StateTopic import StateTopic
 
 LOG = log.get_logger()
 
 
-class Outlet:
+class Outlet(StateTopic):
     """MQTT interface to an Insteon on/off outlet.
 
     This class connects to a device.Outlet object and converts it's
@@ -29,20 +30,14 @@ class Outlet:
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.Outlet):  The Insteon object to link to.
         """
-        self.mqtt = mqtt
-        self.device = device
-
-        # Output state change reporting template.
-        self.msg_state = MsgTemplate(
-            topic='insteon/{{address}}/state/{{button}}',
-            payload='{{on_str.lower()}}')
+        # Setup the Topics
+        super().__init__(mqtt, device,
+                         state_topic='insteon/{{address}}/state/{{button}}')
 
         # Input on/off command template.
         self.msg_on_off = MsgTemplate(
             topic='insteon/{{address}}/set/{{button}}',
             payload='{ "cmd" : "{{value.lower()}}" }')
-
-        device.signal_on_off.connect(self._insteon_on_off)
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
@@ -57,7 +52,9 @@ class Outlet:
         if not data:
             return
 
-        self.msg_state.load_config(data, 'state_topic', 'state_payload', qos)
+        # Load the various topics
+        self.load_state_data(data, qos)
+
         self.msg_on_off.load_config(data, 'on_off_topic', 'on_off_payload',
                                     qos)
 
@@ -77,7 +74,7 @@ class Outlet:
         # group number set for each socket.
         for group in [1, 2]:
             handler = functools.partial(self._input_on_off, group=group)
-            data = self.template_data(button=group)
+            data = self.base_template_data(button=group)
 
             topic = self.msg_on_off.render_topic(data)
             link.subscribe(topic, qos, handler)
@@ -90,69 +87,10 @@ class Outlet:
           link (network.Mqtt):  The MQTT network client to use.
         """
         for group in [1, 2]:
-            data = self.template_data(button=group)
+            data = self.base_template_data(button=group)
 
             topic = self.msg_on_off.render_topic(data)
             link.unsubscribe(topic)
-
-    #-----------------------------------------------------------------------
-    def template_data(self, is_on=None, button=None, mode=on_off.Mode.NORMAL,
-                      reason=None):
-        """Create the Jinja templating data variables for on/off messages.
-
-        Args:
-          button (int):  The button (group) ID (1-2) of the Insteon button
-                 that was triggered.
-          is_on (bool):  True for on, False for off.  If None, on/off and
-                mode attributes are not added to the data.
-          mode (on_off.Mode):  The on/off mode state.
-          reason (str):  The reason the device was triggered.  This is an
-                 arbitrary string set into the template variables.
-
-        Returns:
-          dict:  Returns a dict with the variables available for templating.
-        """
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            }
-
-        if button is not None:
-            data["button"] = button
-
-        if is_on is not None:
-            data["on"] = 1 if is_on else 0
-            data["on_str"] = "on" if is_on else "off"
-            data["mode"] = str(mode)
-            data["fast"] = 1 if mode == on_off.Mode.FAST else 0
-            data["instant"] = 1 if mode == on_off.Mode.INSTANT else 0
-            data["reason"] = reason if reason is not None else ""
-
-        return data
-
-    #-----------------------------------------------------------------------
-    def _insteon_on_off(self, device, group, is_on, mode=on_off.Mode.NORMAL,
-                        reason=""):
-        """Device active on/off callback.
-
-        This is triggered via signal when the Insteon device turns on or off.
-        It will publish an MQTT message with the new state.
-
-        Args:
-          device (device.Outlet):  The Insteon device that changed.
-          group (int):  The socket number (1 or 2) that was changed.
-          is_on (bool):  True for on, False for off.  If None, on/off and
-                mode attributes are not added to the data.
-          mode (on_off.Mode):  The on/off mode state.
-          reason (str):  The reason the device was triggered.  This is an
-                 arbitrary string set into the template variables.
-        """
-        LOG.info("MQTT received on/off %s grp: %s on: %s %s '%s'",
-                 device.label, group, is_on, mode, reason)
-
-        data = self.template_data(is_on, group, mode, reason=reason)
-        self.msg_state.publish(self.mqtt, data)
 
     #-----------------------------------------------------------------------
     def _input_on_off(self, client, data, message, group):

--- a/insteon_mqtt/mqtt/Remote.py
+++ b/insteon_mqtt/mqtt/Remote.py
@@ -4,9 +4,7 @@
 #
 #===========================================================================
 from .. import log
-from .. import on_off
 from .BatterySensor import BatterySensor
-from .MsgTemplate import MsgTemplate
 from .ManualTopic import ManualTopic
 
 LOG = log.get_logger()

--- a/insteon_mqtt/mqtt/Remote.py
+++ b/insteon_mqtt/mqtt/Remote.py
@@ -7,11 +7,12 @@ from .. import log
 from .. import on_off
 from .BatterySensor import BatterySensor
 from .MsgTemplate import MsgTemplate
+from .ManualTopic import ManualTopic
 
 LOG = log.get_logger()
 
 
-class Remote(BatterySensor):
+class Remote(BatterySensor, ManualTopic):
     """MQTT interface to an Insteon mini-remote.
 
     This class connects to a device.Remote object and converts it's output
@@ -26,17 +27,20 @@ class Remote(BatterySensor):
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.Remote):  The Insteon object to link to.
         """
-        super().__init__(mqtt, device)
-
-        self.msg_state = MsgTemplate(
-            topic='insteon/{{address}}/state/{{button}}',
-            payload='{{on_str.lower()}}')
-
-        # Output manual state change is off by default.
-        self.msg_manual_state = MsgTemplate(None, None)
-
-        device.signal_pressed.connect(self._insteon_pressed)
-        device.signal_manual.connect(self._insteon_manual)
+        super().__init__(mqtt, device,
+                         state_topic='insteon/{{address}}/state/{{button}}',
+                         state_payload='{{on_str.lower()}}')
+        # For the remote control, there is no way to know it's state on start
+        # up so we don't want to retain those messages.  If we did, then a
+        # remote that got out of sync (because of the device changing state
+        # and the remote not knowing about it) would cause problems when HA
+        # is restarted because the remotes retain message would still be in
+        # the broker.
+        # I am not sure I understand the rational here, we retain messages
+        # from other battery devices such as motion sensors.  Isn't it up to
+        # the subscriber of the topic to determine if it should act on a
+        # retained message? - KRKeegan 2021-01-10
+        self.state_retain = False
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
@@ -53,99 +57,14 @@ class Remote(BatterySensor):
         if not data:
             return
 
-        self.msg_state.load_config(data, 'state_topic', 'state_payload', qos)
-        self.msg_manual_state.load_config(data, 'manual_state_topic',
-                                          'manual_state_payload', qos)
+        # Load the various topics
+        self.load_state_data(data, qos)
+        self.load_manual_data(data, qos)
 
         # Leak and Motion allow for overrides b/c of grandfathering.  But I
         # think is may be a helpful feature, so enabling here too.
         if "low_battery_topic" in data:
             self.msg_battery.load_config(data, 'low_battery_topic',
                                          'low_battery_payload', qos)
-
-    #-----------------------------------------------------------------------
-    def template_data_remote(self, button, is_on=None, mode=on_off.Mode.NORMAL,
-                             manual=None):
-        """Create the Jinja templating data variables for on/off messages.
-
-        Args:
-          button (int):  The button (group) ID (1-8) of the Insteon button
-                 that was triggered.
-          is_on (bool):  True for on, False for off.  If None, on/off and
-                mode attributes are not added to the data.
-          mode (on_off.Mode):  The on/off mode state.
-          manual (on_off.Manual):  The manual mode state.  If None, manual
-                 attributes are not added to the data.
-
-        Returns:
-          dict:  Returns a dict with the variables available for templating.
-        """
-        # Set up the variables that can be used in the templates.
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            "button" : button,
-            }
-
-        if is_on is not None:
-            data["on"] = 1 if is_on else 0
-            data["on_str"] = "on" if is_on else "off"
-            data["mode"] = str(mode)
-            data["fast"] = 1 if mode == on_off.Mode.FAST else 0
-            data["instant"] = 1 if mode == on_off.Mode.INSTANT else 0
-
-        if manual is not None:
-            data["manual_str"] = str(manual)
-            data["manual"] = manual.int_value()
-            data["manual_openhab"] = manual.openhab_value()
-
-        return data
-
-    #-----------------------------------------------------------------------
-    def _insteon_pressed(self, device, button, is_on, mode=on_off.Mode.NORMAL):
-        """Device active button pressed callback.
-
-        This is triggered via signal when the Insteon device button is
-        pressed.  It will publish an MQTT message with the button
-        number.
-
-        Args:
-          device (device.Remote):  The Insteon device that changed.
-          button (int):  The button number 1...n that was pressed.
-          is_on (bool):  True for on, False for off.  If None, on/off and
-                mode attributes are not added to the data.
-          mode (on_off.Mode):  The on/off mode state.
-        """
-        LOG.info("MQTT received button press %s = btn %s on %s %s",
-                 device.label, button, is_on, mode)
-
-        # For the remote control, there is no way to know it's state on start
-        # up so we don't want to retain those messages.  If we did, then a
-        # remote that got out of sync (because of the device changing state
-        # and the remote not knowing about it) would cause problems when HA
-        # is restarted because the remotes retain message would still be in
-        # the broker.
-        retain = False
-
-        data = self.template_data_remote(button, is_on, mode)
-        self.msg_state.publish(self.mqtt, data, retain=retain)
-
-    #-----------------------------------------------------------------------
-    def _insteon_manual(self, device, group, manual):
-        """Device manual mode callback.
-
-        This is triggered via signal when the Insteon device goes active or
-        inactive.  It will publish an MQTT message with the new state.
-
-        Args:
-          device:   (device.Base) The Insteon device that changed.
-          manual:   (on_off.Manual) The manual mode.
-        """
-        LOG.info("MQTT received manual button press %s = btn %s %s",
-                 device.label, group, manual)
-
-        data = self.template_data_remote(group, manual=manual)
-        self.msg_manual_state.publish(self.mqtt, data, retain=False)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/SceneTopic.py
+++ b/insteon_mqtt/mqtt/SceneTopic.py
@@ -19,8 +19,13 @@ class SceneTopic(BaseTopic):
     """
     def __init__(self, mqtt, device, scene_topic=None, scene_payload=None,
                  **kwargs):
-        """Constructor
+        """Scene Topic Constructor
 
+        Args:
+          mqtt (mqtt.Mqtt):  The MQTT main interface.
+          device (device):  The Insteon object to link to.
+          scene_topic (str): The template for the topic
+          scene_payload (str): The template for the payload
         """
         super().__init__(mqtt, device, **kwargs)
         # It looks cleaner setting these long strings here rather than in the

--- a/insteon_mqtt/mqtt/SceneTopic.py
+++ b/insteon_mqtt/mqtt/SceneTopic.py
@@ -17,12 +17,9 @@ class SceneTopic:
 
     This is an abstract class that provides support for the Scene topic.
     """
-    def __init__(self, mqtt, device, scene_topic=None, scene_payload=None):
+    def __init__(self, scene_topic=None, scene_payload=None, **kwargs):
         """Constructor
 
-        Args:
-          mqtt (mqtt.Mqtt):  The MQTT main interface.
-          device (device):  The Insteon object to link to.
         """
         # It looks cleaner setting these long strings here rather than in the
         # function declaration
@@ -38,6 +35,8 @@ class SceneTopic:
         self.msg_scene = MsgTemplate(
             topic=scene_topic,
             payload=scene_payload)
+
+        super().__init__(**kwargs)
 
     #-----------------------------------------------------------------------
     def load_scene_data(self, data, qos=None, topic=None, payload=None):

--- a/insteon_mqtt/mqtt/SceneTopic.py
+++ b/insteon_mqtt/mqtt/SceneTopic.py
@@ -70,11 +70,11 @@ class SceneTopic(BaseTopic):
         if group is not None:
             handler = functools.partial(self._input_scene, group=group)
             topic = self.msg_scene.render_topic(
-                self.topic_template_data(button=group)
+                self.base_template_data(button=group)
             )
         else:
             handler = self._input_scene
-            topic = self.msg_scene.render_topic(self.topic_template_data())
+            topic = self.msg_scene.render_topic(self.base_template_data())
         link.subscribe(topic, qos, handler)
 
     #-----------------------------------------------------------------------
@@ -85,10 +85,10 @@ class SceneTopic(BaseTopic):
           link (network.Mqtt):  The MQTT network client to use.
         """
         if group is not None:
-            data = self.topic_template_data(button=group)
+            data = self.base_template_data(button=group)
             topic = self.msg_scene.render_topic(data)
         else:
-            topic = self.msg_scene.render_topic(self.topic_template_data())
+            topic = self.msg_scene.render_topic(self.base_template_data())
         link.unsubscribe(topic)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/SceneTopic.py
+++ b/insteon_mqtt/mqtt/SceneTopic.py
@@ -5,7 +5,6 @@
 #===========================================================================
 import functools
 from .. import log
-from .. import on_off
 from .MsgTemplate import MsgTemplate
 from . import util
 from .BaseTopic import BaseTopic

--- a/insteon_mqtt/mqtt/StateTopic.py
+++ b/insteon_mqtt/mqtt/StateTopic.py
@@ -3,11 +3,9 @@
 # MQTT State Topic
 #
 #===========================================================================
-# import functools
 from .. import log
 from .. import on_off
 from .MsgTemplate import MsgTemplate
-# from . import util
 from .BaseTopic import BaseTopic
 from .ManualTopic import ManualTopic
 
@@ -144,6 +142,7 @@ class StateTopic(BaseTopic):
         data.update(manual_data)
 
         return data
+
     #-----------------------------------------------------------------------
     def publish_state(self, device, **kwargs):
         """Device on/off callback.

--- a/insteon_mqtt/mqtt/StateTopic.py
+++ b/insteon_mqtt/mqtt/StateTopic.py
@@ -9,6 +9,7 @@ from .. import on_off
 from .MsgTemplate import MsgTemplate
 # from . import util
 from .BaseTopic import BaseTopic
+# from .ManualTopic import ManualTopic
 
 LOG = log.get_logger()
 

--- a/insteon_mqtt/mqtt/StateTopic.py
+++ b/insteon_mqtt/mqtt/StateTopic.py
@@ -1,0 +1,88 @@
+#===========================================================================
+#
+# MQTT State Topic
+#
+#===========================================================================
+import functools
+from .. import log
+from .. import on_off
+from .MsgTemplate import MsgTemplate
+from . import util
+
+LOG = log.get_logger()
+
+
+class StateTopic:
+    """MQTT interface to the State Topic
+
+    This is an abstract class that provides support for the State topic.
+    """
+    def __init__(self, state_topic=None, state_payload=None, **kwargs):
+        """Constructor
+
+        """
+        # It looks cleaner setting these long strings here rather than in the
+        # function declaration
+        if state_topic is None:
+            state_topic = 'insteon/{{address}}/state'
+        if state_payload is None:
+            state_payload = '{{on_str.lower()}}'
+
+        LOG.debug("%s, %s", state_topic, state_payload)
+
+        # Output state on/off command template.
+        self.msg_state = MsgTemplate(
+            topic=state_topic,
+            payload=state_payload)
+
+        # Receive notifications from the Insteon device when it changes.
+        self.device.signal_on_off.connect(self._insteon_on_off)
+
+        super().__init__(**kwargs)
+
+    #-----------------------------------------------------------------------
+    def load_state_data(self, data, qos=None, topic=None, payload=None):
+        """Load values from a configuration data object.
+
+        Args:
+          data (dict):  The section of the config dict that applies to this
+                        class.
+          qos (int):  The default quality of service level to use.
+        """
+        if topic is None:
+            topic = 'state_topic'
+        if payload is None:
+            payload = 'state_payload'
+        # Update the MQTT topics and payloads from the config file.
+        self.msg_state.load_config(data, topic, payload, qos)
+
+    #-----------------------------------------------------------------------
+    def template_data(self, *args, **kwargs):
+        raise NotImplementedError  # pragma: no cover
+
+    #-----------------------------------------------------------------------
+    def _insteon_on_off(self, device, is_on, mode=on_off.Mode.NORMAL,
+                        reason=""):
+        """Device on/off callback.
+
+        This is triggered via signal when the Insteon device is turned on or
+        off.  It will publish an MQTT message with the new state.
+
+        Args:
+          device (device.Switch):   The Insteon device that changed.
+          is_on (bool):   True for on, False for off.
+          mode (on_off.Mode):  The on/off mode state.
+          reason (str):  The reason the device was triggered.  This is an
+                 arbitrary string set into the template variables.
+        """
+        LOG.info("MQTT received on/off %s on: %s %s '%s'", device.label, is_on,
+                 mode, reason)
+
+        # For manual mode messages, don't retain them because they don't
+        # represent persistent state - they're momentary events.
+        retain = False if mode == on_off.Mode.MANUAL else None
+
+        data = self.template_data(is_on, mode, reason=reason)
+        self.msg_state.publish(self.mqtt, data, retain=retain)
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/StateTopic.py
+++ b/insteon_mqtt/mqtt/StateTopic.py
@@ -19,9 +19,11 @@ class StateTopic(BaseTopic):
     """
     def __init__(self, mqtt, device, state_topic=None, state_payload=None,
                  state_topic_1=None, state_payload_1=None, **kwargs):
-        """Constructor
+        """State Topic Constructor
 
         Args:
+          device (device):  The Insteon object to link to.
+          mqtt (mqtt.Mqtt):  The MQTT main interface.
           state_topic (str): A string of the jinja template for the topic
           state_payload (str): A string of the jinja template for the payload
           state_topic_1 (str): A string of the jinja template for the topic of
@@ -31,7 +33,6 @@ class StateTopic(BaseTopic):
                                  of group 1 if it is distinct from other
                                  groups. Only the KPL Dimmer uses this.
           mqtt (mqtt.Mqtt):  The MQTT main interface.
-          device (device.KeypadLinc):  The Insteon object to link to.
         """
         super().__init__(mqtt, device, **kwargs)
         # It looks cleaner setting these long strings here rather than in the
@@ -95,7 +96,7 @@ class StateTopic(BaseTopic):
     def state_template_data(self, **kwargs):
         """Create the Jinja templating data variables for on/off messages.
 
-        Args:
+        kwargs includes:
           is_on (bool):  The on/off state of the switch.  If None, on/off and
                 mode attributes are not added to the data.
           mode (on_off.Mode):  The on/off mode state.
@@ -103,6 +104,8 @@ class StateTopic(BaseTopic):
                  attributes are not added to the data.
           reason (str):  The reason the device was triggered.  This is an
                  arbitrary string set into the template variables.
+          level (int):  A brightness level between 0-255
+          button (int): Passed to base_template_data, the group numer to use
 
         Returns:
           dict:  Returns a dict with the variables available for templating.
@@ -151,11 +154,8 @@ class StateTopic(BaseTopic):
         off.  It will publish an MQTT message with the new state.
 
         Args:
-          device (device.Switch):   The Insteon device that changed.
-          is_on (bool):   True for on, False for off.
-          mode (on_off.Mode):  The on/off mode state.
-          reason (str):  The reason the device was triggered.  This is an
-                 arbitrary string set into the template variables.
+          device (device):   The Insteon device that changed.
+          kwargs (dict): The arguments to pass to state_template_data
         """
         LOG.info("MQTT received state %s on: %s", device.label, kwargs)
 

--- a/insteon_mqtt/mqtt/StateTopic.py
+++ b/insteon_mqtt/mqtt/StateTopic.py
@@ -3,24 +3,27 @@
 # MQTT State Topic
 #
 #===========================================================================
-import functools
+# import functools
 from .. import log
 from .. import on_off
 from .MsgTemplate import MsgTemplate
-from . import util
+# from . import util
+from .BaseTopic import BaseTopic
 
 LOG = log.get_logger()
 
 
-class StateTopic:
+class StateTopic(BaseTopic):
     """MQTT interface to the State Topic
 
     This is an abstract class that provides support for the State topic.
     """
-    def __init__(self, state_topic=None, state_payload=None, **kwargs):
+    def __init__(self, mqtt, device, state_topic=None, state_payload=None,
+                 **kwargs):
         """Constructor
 
         """
+        super().__init__(mqtt, device, **kwargs)
         # It looks cleaner setting these long strings here rather than in the
         # function declaration
         if state_topic is None:
@@ -37,8 +40,6 @@ class StateTopic:
 
         # Receive notifications from the Insteon device when it changes.
         self.device.signal_state.connect(self.publish_state)
-
-        super().__init__(**kwargs)
 
     #-----------------------------------------------------------------------
     def load_state_data(self, data, qos=None, topic=None, payload=None):

--- a/insteon_mqtt/mqtt/Switch.py
+++ b/insteon_mqtt/mqtt/Switch.py
@@ -30,8 +30,8 @@ class Switch(StateTopic, SceneTopic):
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.Switch):  The Insteon object to link to.
         """
-        self.mqtt = mqtt
-        self.device = device
+        # Setup the Topics
+        super().__init__(mqtt, device)
 
         # Output manual state change is off by default.
         self.msg_manual_state = MsgTemplate(None, None)
@@ -43,9 +43,6 @@ class Switch(StateTopic, SceneTopic):
 
         # Receive notifications from the Insteon device when it changes.
         device.signal_manual.connect(self._insteon_manual)
-
-        # Setup the Topics
-        super().__init__()
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/Switch.py
+++ b/insteon_mqtt/mqtt/Switch.py
@@ -100,8 +100,7 @@ class Switch(StateTopic, SceneTopic):
         self.scene_unsubscribe(link)
 
     #-----------------------------------------------------------------------
-    def template_data(self, is_on=None, mode=on_off.Mode.NORMAL,
-                      manual=None, reason=None):
+    def template_data(self, **kwargs):
         """Create the Jinja templating data variables for on/off messages.
 
         Args:
@@ -123,19 +122,29 @@ class Switch(StateTopic, SceneTopic):
                      else self.device.addr.hex,
             }
 
-        if is_on is not None:
-            data["on"] = 1 if is_on else 0
-            data["on_str"] = "on" if is_on else "off"
-            data["mode"] = str(mode)
-            data["fast"] = 1 if mode == on_off.Mode.FAST else 0
-            data["instant"] = 1 if mode == on_off.Mode.INSTANT else 0
-            data["reason"] = reason if reason is not None else ""
+        if 'is_on' in kwargs and kwargs['is_on'] is not None:
+            data["on"] = 1 if kwargs['is_on'] else 0
+            data["on_str"] = "on" if kwargs['is_on'] else "off"
+            data["mode"] = str(on_off.Mode.NORMAL)
+            data["fast"] = 0
+            data["instant"] = 0
+            if 'mode' in kwargs:
+                data["mode"] = str(kwargs['mode'])
+                data["fast"] = 1 if kwargs['mode'] == on_off.Mode.FAST else 0
+                data["instant"] = 0
+                if kwargs['mode'] == on_off.Mode.INSTANT:
+                    data["instant"] = 1
+            data["reason"] = ""
+            if 'reason' in kwargs and kwargs['reason'] is not None:
+                data["reason"] = kwargs['reason']
 
-        if manual is not None:
-            data["manual_str"] = str(manual)
-            data["manual"] = manual.int_value()
-            data["manual_openhab"] = manual.openhab_value()
-            data["reason"] = reason if reason is not None else ""
+        if 'manual' in kwargs and kwargs['manual'] is not None:
+            data["manual_str"] = str(kwargs['manual'])
+            data["manual"] = kwargs['manual'].int_value()
+            data["manual_openhab"] = kwargs['manual'].openhab_value()
+            data["reason"] = ""
+            if 'reason' in kwargs and kwargs['reason'] is not None:
+                data["reason"] = kwargs['reason']
 
         return data
 

--- a/insteon_mqtt/mqtt/Switch.py
+++ b/insteon_mqtt/mqtt/Switch.py
@@ -90,55 +90,6 @@ class Switch(StateTopic, SceneTopic, ManualTopic):
         self.scene_unsubscribe(link)
 
     #-----------------------------------------------------------------------
-    def template_data(self, **kwargs):
-        """Create the Jinja templating data variables for on/off messages.
-
-        Args:
-          is_on (bool):  The on/off state of the switch.  If None, on/off and
-                mode attributes are not added to the data.
-          mode (on_off.Mode):  The on/off mode state.
-          manual (on_off.Manual):  The manual mode state.  If None, manual
-                 attributes are not added to the data.
-          reason (str):  The reason the device was triggered.  This is an
-                 arbitrary string set into the template variables.
-
-        Returns:
-          dict:  Returns a dict with the variables available for templating.
-        """
-        # Set up the variables that can be used in the templates.
-        data = {
-            "address" : self.device.addr.hex,
-            "name" : self.device.name if self.device.name
-                     else self.device.addr.hex,
-            }
-
-        if 'is_on' in kwargs and kwargs['is_on'] is not None:
-            data["on"] = 1 if kwargs['is_on'] else 0
-            data["on_str"] = "on" if kwargs['is_on'] else "off"
-            data["mode"] = str(on_off.Mode.NORMAL)
-            data["fast"] = 0
-            data["instant"] = 0
-            if 'mode' in kwargs:
-                data["mode"] = str(kwargs['mode'])
-                data["fast"] = 1 if kwargs['mode'] == on_off.Mode.FAST else 0
-                data["instant"] = 0
-                if kwargs['mode'] == on_off.Mode.INSTANT:
-                    data["instant"] = 1
-            data["reason"] = ""
-            if 'reason' in kwargs and kwargs['reason'] is not None:
-                data["reason"] = kwargs['reason']
-
-        if 'manual' in kwargs and kwargs['manual'] is not None:
-            data["manual_str"] = str(kwargs['manual'])
-            data["manual"] = kwargs['manual'].int_value()
-            data["manual_openhab"] = kwargs['manual'].openhab_value()
-            data["reason"] = ""
-            if 'reason' in kwargs and kwargs['reason'] is not None:
-                data["reason"] = kwargs['reason']
-
-        return data
-
-    #-----------------------------------------------------------------------
     def _input_on_off(self, client, data, message):
         """Handle an input on/off change MQTT message.
 

--- a/insteon_mqtt/on_off.py
+++ b/insteon_mqtt/on_off.py
@@ -33,7 +33,7 @@ class Mode(enum.Enum):
     RAMP = "ramp"
 
     def __str__(self):
-        return self.value
+        return str(self.value)
 
     @staticmethod
     def is_valid(cmd):
@@ -163,7 +163,7 @@ class Manual(enum.Enum):
     STOP = "stop"
 
     def __str__(self):
-        return self.value
+        return str(self.value)
 
     @staticmethod
     def is_valid(cmd):

--- a/insteon_mqtt/util.py
+++ b/insteon_mqtt/util.py
@@ -5,7 +5,9 @@
 #===========================================================================
 import binascii
 import io
+from . import log
 
+LOG = log.get_logger()
 
 def to_hex(data, num=None, space=' '):
     """Convert a byte array to a string of hex.
@@ -199,7 +201,7 @@ def input_bool(inputs, field):
         return bool(int(value))
     except ValueError:
         msg = "Invalid %s input.  Valid inputs are 1/0 or True/False" % input
-        raise ValueError(msg)
+        LOG.exception(msg)
 
 
 #===========================================================================
@@ -237,7 +239,7 @@ def input_integer(inputs, field):
             return int(value)
     except ValueError:
         msg = "Invalid %s input.  Valid inputs are integer values." % input
-        raise ValueError(msg)
+        LOG.exception(msg)
 
 
 #===========================================================================
@@ -279,7 +281,7 @@ def input_byte(inputs, field):
         return v
     except ValueError:
         msg = "Invalid %s input.  Valid inputs are 0-255" % input
-        raise ValueError(msg)
+        LOG.exception(msg)
 
 
 #===========================================================================
@@ -312,4 +314,4 @@ def input_float(inputs, field):
             return float(value)
     except ValueError:
         msg = "Invalid %s input.  Valid inputs are float values." % input
-        raise ValueError(msg)
+        LOG.exception(msg)

--- a/tests/device/test_DimmerDev.py
+++ b/tests/device/test_DimmerDev.py
@@ -38,16 +38,30 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 2
 
     @pytest.mark.parametrize("group,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,[255,IM.on_off.Mode.NORMAL, 'device']),
-        (0x01,Msg.CmdType.OFF, 0x00, [0,IM.on_off.Mode.NORMAL, 'device']),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,[255,IM.on_off.Mode.FAST, 'device']),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, [0,IM.on_off.Mode.FAST, 'device']),
-        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.DOWN, 'device']),
-        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x01, [IM.on_off.Manual.UP, 'device']),
-        (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.STOP, 'device']),
+        (0x01,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"level":0,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"level":255,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"level":0,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])
     def test_handle_on_off(self, test_device, group, cmd1, cmd2, expected):
+        with mock.patch.object(IM.Signal, 'emit') as mocked:
+            flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
+            group = IM.Address(0x00, 0x00, group)
+            addr = IM.Address(0x01, 0x02, 0x03)
+            msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
+            test_device.handle_broadcast(msg)
+            if expected is not None:
+                mocked.assert_called_once_with(test_device, **expected)
+            else:
+                mocked.assert_not_called()
+
+    @pytest.mark.parametrize("group,cmd1,cmd2,expected", [
+        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.DOWN, 'device']),
+        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x01, [IM.on_off.Manual.UP, 'device']),
+        (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.STOP, 'device']),
+    ])
+    def test_handle_on_off_manual(self, test_device, group, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:
             flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
             group = IM.Address(0x00, 0x00, group)
@@ -92,19 +106,19 @@ class Test_Base_Config():
         # default on-level then to full brightness, as expected.
         # Fast-on should always go to full brightness.
         params = [
-            (Msg.CmdType.ON, 0x00, [64, IM.on_off.Mode.NORMAL, 'device']),
-            (Msg.CmdType.ON, 0x00, [255, IM.on_off.Mode.NORMAL, 'device']),
-            (Msg.CmdType.ON, 0x00, [64, IM.on_off.Mode.NORMAL, 'device']),
-            (Msg.CmdType.OFF, 0x00, [0, IM.on_off.Mode.NORMAL, 'device']),
-            (Msg.CmdType.ON_FAST, 0x00, [255, IM.on_off.Mode.FAST, 'device']),
-            (Msg.CmdType.ON_FAST, 0x00, [255, IM.on_off.Mode.FAST, 'device']),
-            (Msg.CmdType.OFF_FAST, 0x00, [0, IM.on_off.Mode.FAST, 'device']),
+            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+            (Msg.CmdType.ON, 0x00, {"level":255, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+            (Msg.CmdType.OFF, 0x00, {"level":0, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "reason":'device'}),
+            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "reason":'device'}),
+            (Msg.CmdType.OFF_FAST, 0x00, {"level":0, "mode":IM.on_off.Mode.FAST, "reason":'device'}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                [64, IM.on_off.Mode.INSTANT, 'device']),
+                {"level":64, "mode":IM.on_off.Mode.INSTANT, "reason":'device'}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                [255, IM.on_off.Mode.INSTANT, 'device']),
+                {"level":255,"mode": IM.on_off.Mode.INSTANT, "reason":'device'}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                [64, IM.on_off.Mode.INSTANT, 'device'])]
+                {"level":64, "mode":IM.on_off.Mode.INSTANT, "reason":'device'})]
         for cmd1, cmd2, expected in params:
             with mock.patch.object(IM.Signal, 'emit') as mocked:
                 print("Trying:", "[%x, %x]" % (cmd1, cmd2))
@@ -115,7 +129,7 @@ class Test_Base_Config():
                 msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
                 test_device.handle_broadcast(msg)
                 if expected is not None:
-                    mocked.assert_called_once_with(test_device, *expected)
+                    mocked.assert_called_once_with(test_device, **expected)
                 else:
                     mocked.assert_not_called()
 

--- a/tests/device/test_DimmerDev.py
+++ b/tests/device/test_DimmerDev.py
@@ -57,9 +57,9 @@ class Test_Base_Config():
                 mocked.assert_not_called()
 
     @pytest.mark.parametrize("group,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.DOWN, 'device']),
-        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x01, [IM.on_off.Manual.UP, 'device']),
-        (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.STOP, 'device']),
+        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, {"manual":IM.on_off.Manual.DOWN, "reason":'device'}),
+        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x01, {"manual":IM.on_off.Manual.UP, "reason":'device'}),
+        (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, {"manual":IM.on_off.Manual.STOP, "reason":'device'}),
     ])
     def test_handle_on_off_manual(self, test_device, group, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:
@@ -69,7 +69,7 @@ class Test_Base_Config():
             msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
             test_device.handle_broadcast(msg)
             if expected is not None:
-                mocked.assert_called_once_with(test_device, *expected)
+                mocked.assert_called_once_with(test_device, **expected)
             else:
                 mocked.assert_not_called()
 

--- a/tests/device/test_KeypadLincDev.py
+++ b/tests/device/test_KeypadLincDev.py
@@ -278,19 +278,19 @@ class Test_KPL():
         # default on-level then to full brightness, as expected.
         # Fast-on should always go to full brightness.
         params = [
-            (Msg.CmdType.ON, 0x00, [64, IM.on_off.Mode.NORMAL, 'device']),
-            (Msg.CmdType.ON, 0x00, [255, IM.on_off.Mode.NORMAL, 'device']),
-            (Msg.CmdType.ON, 0x00, [64, IM.on_off.Mode.NORMAL, 'device']),
-            (Msg.CmdType.OFF, 0x00, [0, IM.on_off.Mode.NORMAL, 'device']),
-            (Msg.CmdType.ON_FAST, 0x00, [255, IM.on_off.Mode.FAST, 'device']),
-            (Msg.CmdType.ON_FAST, 0x00, [255, IM.on_off.Mode.FAST, 'device']),
-            (Msg.CmdType.OFF_FAST, 0x00, [0, IM.on_off.Mode.FAST, 'device']),
+            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
+            (Msg.CmdType.ON, 0x00, {"level":255, "mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
+            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
+            (Msg.CmdType.OFF, 0x00, {"level":0, "mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
+            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
+            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
+            (Msg.CmdType.OFF_FAST, 0x00, {"level":0, "mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                [64, IM.on_off.Mode.INSTANT, 'device']),
+                {"level":64, "mode":IM.on_off.Mode.INSTANT, "reason":'device', "button":1}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                [255, IM.on_off.Mode.INSTANT, 'device']),
+                {"level":255, "mode":IM.on_off.Mode.INSTANT, "reason":'device', "button":1}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                [64, IM.on_off.Mode.INSTANT, 'device'])]
+                {"level":64, "mode":IM.on_off.Mode.INSTANT, "reason":'device', "button":1})]
         for cmd1, cmd2, expected in params:
             with mock.patch.object(IM.Signal, 'emit') as mocked:
                 print("Trying:", "[%x, %x]" % (cmd1, cmd2))
@@ -301,8 +301,7 @@ class Test_KPL():
                 msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
                 test_device.handle_broadcast(msg)
                 if expected is not None:
-                    mocked.assert_called_once_with(test_device, group_num,
-                                                   *expected)
+                    mocked.assert_called_once_with(test_device, **expected)
                 else:
                     mocked.assert_not_called()
 
@@ -337,21 +336,21 @@ class Test_KPL():
 
 
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,[255,IM.on_off.Mode.NORMAL, 'device']),
-        (0x01,Msg.CmdType.OFF, 0x00, [0,IM.on_off.Mode.NORMAL, 'device']),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,[255,IM.on_off.Mode.FAST, 'device']),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, [0,IM.on_off.Mode.FAST, 'device']),
-        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.DOWN, 'device']),
-        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x01, [IM.on_off.Manual.UP, 'device']),
-        (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.STOP, 'device']),
+        (0x01,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"level":0,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"level":255,"mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"level":0,"mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, {"manual":IM.on_off.Manual.DOWN, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x01, {"manual":IM.on_off.Manual.UP, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, {"manual":IM.on_off.Manual.STOP, "reason":'device', "button":1}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
-        (0x02,Msg.CmdType.ON, 0x00,[255,IM.on_off.Mode.NORMAL, 'device']),
-        (0x03,Msg.CmdType.ON, 0x00,[255,IM.on_off.Mode.NORMAL, 'device']),
-        (0x04,Msg.CmdType.ON, 0x00,[255,IM.on_off.Mode.NORMAL, 'device']),
-        (0x05,Msg.CmdType.ON, 0x00,[255,IM.on_off.Mode.NORMAL, 'device']),
-        (0x06,Msg.CmdType.ON, 0x00,[255,IM.on_off.Mode.NORMAL, 'device']),
-        (0x07,Msg.CmdType.ON, 0x00,[255,IM.on_off.Mode.NORMAL, 'device']),
-        (0x08,Msg.CmdType.ON, 0x00,[255,IM.on_off.Mode.NORMAL, 'device']),
+        (0x02,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":2}),
+        (0x03,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":3}),
+        (0x04,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":4}),
+        (0x05,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":5}),
+        (0x06,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":6}),
+        (0x07,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":7}),
+        (0x08,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":8}),
     ])
     def test_handle_on_off(self, test_device, group_num, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:
@@ -361,7 +360,7 @@ class Test_KPL():
             msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
             test_device.handle_broadcast(msg)
             if expected is not None:
-                mocked.assert_called_once_with(test_device, group_num, *expected)
+                mocked.assert_called_once_with(test_device, **expected)
             else:
                 mocked.assert_not_called()
 

--- a/tests/device/test_OutletDev.py
+++ b/tests/device/test_OutletDev.py
@@ -40,13 +40,13 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 3
 
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL, 'device']),
-        (0x01,Msg.CmdType.OFF, 0x00, [0,IM.on_off.Mode.NORMAL, 'device']),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,[True,IM.on_off.Mode.FAST, 'device']),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, [0,IM.on_off.Mode.FAST, 'device']),
+        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL, "reason":'device',"button":1}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":0,"mode":IM.on_off.Mode.NORMAL, "reason":'device',"button":1}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"is_on":True,"mode":IM.on_off.Mode.FAST, "reason":'device',"button":1}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"is_on":0,"mode":IM.on_off.Mode.FAST, "reason":'device',"button":1}),
         (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, None),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
-        (0x02,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL, 'device']),
+        (0x02,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL, "reason":'device',"button":2}),
     ])
     def test_handle_on_off(self, test_device, group_num, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:
@@ -56,7 +56,7 @@ class Test_Base_Config():
             msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
             test_device.handle_broadcast(msg)
             if expected is not None:
-                mocked.assert_called_once_with(test_device, group_num, *expected)
+                mocked.assert_called_once_with(test_device, **expected)
             else:
                 mocked.assert_not_called()
 

--- a/tests/device/test_RemoteDev.py
+++ b/tests/device/test_RemoteDev.py
@@ -79,21 +79,21 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 9
 
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL]),
-        (0x01,Msg.CmdType.OFF, 0x00, [False,IM.on_off.Mode.NORMAL]),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,[True,IM.on_off.Mode.FAST]),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, [False,IM.on_off.Mode.FAST]),
-        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.DOWN]),
-        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x01, [IM.on_off.Manual.UP]),
-        (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.STOP]),
+        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL,"button":1}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False,"mode":IM.on_off.Mode.NORMAL,"button":1}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"is_on":True,"mode":IM.on_off.Mode.FAST,"button":1}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"is_on":False,"mode":IM.on_off.Mode.FAST,"button":1}),
+        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, {"manual":IM.on_off.Manual.DOWN,"button":1}),
+        (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x01, {"manual":IM.on_off.Manual.UP,"button":1}),
+        (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, {"manual":IM.on_off.Manual.STOP,"button":1}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
-        (0x02,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL]),
-        (0x03,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL]),
-        (0x04,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL]),
-        (0x05,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL]),
-        (0x06,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL]),
-        (0x07,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL]),
-        (0x08,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL]),
+        (0x02,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL,"button":2}),
+        (0x03,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL,"button":3}),
+        (0x04,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL,"button":4}),
+        (0x05,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL,"button":5}),
+        (0x06,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL,"button":6}),
+        (0x07,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL,"button":7}),
+        (0x08,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL,"button":8}),
     ])
     def test_handle_on_off(self, test_device8, group_num, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:
@@ -103,6 +103,6 @@ class Test_Base_Config():
             msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
             test_device8.handle_broadcast(msg)
             if expected is not None:
-                mocked.assert_called_once_with(test_device8, group_num, *expected)
+                mocked.assert_called_once_with(test_device8, **expected)
             else:
                 mocked.assert_not_called()

--- a/tests/device/test_SwitchDev.py
+++ b/tests/device/test_SwitchDev.py
@@ -64,7 +64,7 @@ class Test_Base_Config():
             msg = Msg.InpStandard(addr, group, flags, Msg.CmdType.START_MANUAL_CHANGE, 0x00)
             test_device.handle_broadcast(msg)
             assert mocked.call_count == 2
-            calls = [call(test_device, IM.on_off.Manual.DOWN),
+            calls = [call(test_device, manual=IM.on_off.Manual.DOWN),
                      call(test_device, is_on=False, mode=IM.on_off.Mode.MANUAL, reason='device')]
             mocked.assert_has_calls(calls)
         with mock.patch.object(IM.Signal, 'emit') as mocked:
@@ -74,7 +74,7 @@ class Test_Base_Config():
             msg = Msg.InpStandard(addr, group, flags, Msg.CmdType.START_MANUAL_CHANGE, 0x01)
             test_device.handle_broadcast(msg)
             assert mocked.call_count == 2
-            calls = [call(test_device, IM.on_off.Manual.UP),
+            calls = [call(test_device, manual=IM.on_off.Manual.UP),
                      call(test_device, is_on=True, mode=IM.on_off.Mode.MANUAL, reason='device')]
             mocked.assert_has_calls(calls)
 

--- a/tests/device/test_SwitchDev.py
+++ b/tests/device/test_SwitchDev.py
@@ -38,12 +38,11 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 2
 
     @pytest.mark.parametrize("group,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,[True,IM.on_off.Mode.NORMAL, 'device']),
-        (0x01,Msg.CmdType.OFF, 0x00, [False,IM.on_off.Mode.NORMAL, 'device']),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,[True,IM.on_off.Mode.FAST, 'device']),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, [False,IM.on_off.Mode.FAST, 'device']),
+        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"is_on":True,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"is_on":False,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
-        (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, [IM.on_off.Manual.STOP]),
     ])
     def test_handle_on_off(self, test_device, group, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:
@@ -53,7 +52,7 @@ class Test_Base_Config():
             msg = Msg.InpStandard(addr, group, flags, cmd1, cmd2)
             test_device.handle_broadcast(msg)
             if expected is not None:
-                mocked.assert_called_once_with(test_device, *expected)
+                mocked.assert_called_once_with(test_device, **expected)
             else:
                 mocked.assert_not_called()
 
@@ -66,7 +65,7 @@ class Test_Base_Config():
             test_device.handle_broadcast(msg)
             assert mocked.call_count == 2
             calls = [call(test_device, IM.on_off.Manual.DOWN),
-                     call(test_device, False, IM.on_off.Mode.MANUAL, 'device')]
+                     call(test_device, is_on=False, mode=IM.on_off.Mode.MANUAL, reason='device')]
             mocked.assert_has_calls(calls)
         with mock.patch.object(IM.Signal, 'emit') as mocked:
             flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
@@ -76,7 +75,7 @@ class Test_Base_Config():
             test_device.handle_broadcast(msg)
             assert mocked.call_count == 2
             calls = [call(test_device, IM.on_off.Manual.UP),
-                     call(test_device, True, IM.on_off.Mode.MANUAL, 'device')]
+                     call(test_device, is_on=True, mode=IM.on_off.Mode.MANUAL, reason='device')]
             mocked.assert_has_calls(calls)
 
     def test_set_backlight(self, test_device):

--- a/tests/mqtt/test_BatterySensor.py
+++ b/tests/mqtt/test_BatterySensor.py
@@ -74,8 +74,8 @@ class Test_BatterySensor:
         mdev.load_config({})
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, True)
-        dev.signal_on_off.emit(dev, False)
+        dev.signal_state.emit(dev, is_on=True)
+        dev.signal_state.emit(dev, is_on=False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic='%s/state' % topic, payload='on', qos=0, retain=True)
@@ -109,8 +109,8 @@ class Test_BatterySensor:
         btopic = "bar/%s" % setup.addr.hex
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, True)
-        dev.signal_on_off.emit(dev, False)
+        dev.signal_state.emit(dev, is_on=True)
+        dev.signal_state.emit(dev, is_on=False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic=stopic, payload='1 ON', qos=qos, retain=True)

--- a/tests/mqtt/test_Dimmer.py
+++ b/tests/mqtt/test_Dimmer.py
@@ -101,8 +101,8 @@ class Test_Dimmer:
         mdev.load_config({})
 
         # Send a level signal
-        dev.signal_level_changed.emit(dev, 0x12)
-        dev.signal_level_changed.emit(dev, 0x00)
+        dev.signal_state.emit(dev, level=0x12)
+        dev.signal_state.emit(dev, level=0x00)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic='%s/state' % topic,
@@ -135,8 +135,8 @@ class Test_Dimmer:
         mtopic = "bar/%s" % setup.addr.hex
 
         # Send a level signal
-        dev.signal_level_changed.emit(dev, 0xff)
-        dev.signal_level_changed.emit(dev, 0x00)
+        dev.signal_state.emit(dev, level=0xff)
+        dev.signal_state.emit(dev, level=0x00)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic=ltopic, payload='1 255', qos=qos, retain=True)

--- a/tests/mqtt/test_Dimmer.py
+++ b/tests/mqtt/test_Dimmer.py
@@ -66,13 +66,13 @@ class Test_Dimmer:
     def test_template(self, setup):
         mdev, addr, name = setup.getAll(['mdev', 'addr', 'name'])
 
-        data = mdev.template_data()
+        data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
         assert data == right
 
-        data = mdev.template_data(level=0x55, mode=IM.on_off.Mode.FAST,
-                                  manual=IM.on_off.Manual.STOP,
-                                  reason="something")
+        data = mdev.state_template_data(level=0x55, mode=IM.on_off.Mode.FAST,
+                                        manual=IM.on_off.Manual.STOP,
+                                        reason="something")
         right = {"address" : addr.hex, "name" : name,
                  "on" : 1, "on_str" : "on", "reason" : "something",
                  "level_255" : 85, "level_100" : 33,
@@ -80,14 +80,15 @@ class Test_Dimmer:
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
         assert data == right
 
-        data = mdev.template_data(level=0x00)
+        data = mdev.state_template_data(level=0x00)
         right = {"address" : addr.hex, "name" : name,
                  "on" : 0, "on_str" : "off", "reason" : "",
                  "level_255" : 0, "level_100" : 0,
                  "mode" : "normal", "fast" : 0, "instant" : 0}
         assert data == right
 
-        data = mdev.template_data(manual=IM.on_off.Manual.UP, reason="foo")
+        data = mdev.state_template_data(manual=IM.on_off.Manual.UP,
+                                        reason="foo")
         right = {"address" : addr.hex, "name" : name, "reason" : "foo",
                  "manual_str" : "up", "manual" : 1, "manual_openhab" : 2}
         assert data == right

--- a/tests/mqtt/test_Dimmer.py
+++ b/tests/mqtt/test_Dimmer.py
@@ -116,8 +116,8 @@ class Test_Dimmer:
         link.client.clear()
 
         # Send a manual mode signal - should do nothing w/ the default config.
-        dev.signal_manual.emit(dev, IM.on_off.Manual.DOWN)
-        dev.signal_manual.emit(dev, IM.on_off.Manual.STOP)
+        dev.signal_manual.emit(dev, manual=IM.on_off.Manual.DOWN)
+        dev.signal_manual.emit(dev, manual=IM.on_off.Manual.STOP)
         assert len(link.client.pub) == 0
 
     #-----------------------------------------------------------------------
@@ -146,8 +146,8 @@ class Test_Dimmer:
         link.client.clear()
 
         # Send a manual signal
-        dev.signal_manual.emit(dev, IM.on_off.Manual.DOWN)
-        dev.signal_manual.emit(dev, IM.on_off.Manual.STOP)
+        dev.signal_manual.emit(dev, manual=IM.on_off.Manual.DOWN)
+        dev.signal_manual.emit(dev, manual=IM.on_off.Manual.STOP)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic=mtopic, payload='-1 DOWN', qos=qos, retain=False)

--- a/tests/mqtt/test_EZIO4O.py
+++ b/tests/mqtt/test_EZIO4O.py
@@ -79,11 +79,11 @@ class Test_EZIO4O:
     def test_template(self, setup):
         mdev, addr, name = setup.getAll(["mdev", "addr", "name"])
 
-        data = mdev.template_data()
+        data = mdev.base_template_data()
         right = {"address": addr.hex, "name": name}
         assert data == right
 
-        data = mdev.template_data(
+        data = mdev.state_template_data(
             is_on=True, button=1, reason="something", mode=IM.on_off.Mode.FAST
         )
         right = {
@@ -99,7 +99,7 @@ class Test_EZIO4O:
         }
         assert data == right
 
-        data = mdev.template_data(is_on=False, button=2)
+        data = mdev.state_template_data(is_on=False, button=2)
         right = {
             "address": addr.hex,
             "name": name,
@@ -113,7 +113,7 @@ class Test_EZIO4O:
         }
         assert data == right
 
-        data = mdev.template_data(is_on=False, button=3)
+        data = mdev.state_template_data(is_on=False, button=3)
         right = {
             "address": addr.hex,
             "name": name,
@@ -127,7 +127,7 @@ class Test_EZIO4O:
         }
         assert data == right
 
-        data = mdev.template_data(is_on=False, button=4)
+        data = mdev.state_template_data(is_on=False, button=4)
         right = {
             "address": addr.hex,
             "name": name,
@@ -150,10 +150,10 @@ class Test_EZIO4O:
         mdev.load_config({})
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, 1, True)
-        dev.signal_on_off.emit(dev, 2, False)
-        dev.signal_on_off.emit(dev, 3, True)
-        dev.signal_on_off.emit(dev, 4, False)
+        dev.signal_state.emit(dev, button=1, is_on=True)
+        dev.signal_state.emit(dev, button=2, is_on=False)
+        dev.signal_state.emit(dev, button=3, is_on=True)
+        dev.signal_state.emit(dev, button=4, is_on=False)
         assert len(link.client.pub) == 4
         assert link.client.pub[0] == dict(
             topic="%s/state/1" % topic, payload="on", qos=0, retain=True
@@ -185,10 +185,10 @@ class Test_EZIO4O:
         stopic = "foo/%s" % setup.addr.hex
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, 1, True)
-        dev.signal_on_off.emit(dev, 2, False)
-        dev.signal_on_off.emit(dev, 3, True)
-        dev.signal_on_off.emit(dev, 4, False)
+        dev.signal_state.emit(dev, button=1, is_on=True)
+        dev.signal_state.emit(dev, button=2, is_on=False)
+        dev.signal_state.emit(dev, button=3, is_on=True)
+        dev.signal_state.emit(dev, button=4, is_on=False)
         assert len(link.client.pub) == 4
         assert link.client.pub[0] == dict(
             topic=stopic + "/1", payload="1 1 ON", qos=qos, retain=True

--- a/tests/mqtt/test_FanLinc.py
+++ b/tests/mqtt/test_FanLinc.py
@@ -137,8 +137,8 @@ class Test_FanLinc:
         mdev.load_config({})
 
         # Send a level signal
-        dev.signal_level_changed.emit(dev, 0x12)
-        dev.signal_level_changed.emit(dev, 0x00)
+        dev.signal_state.emit(dev, level=0x12)
+        dev.signal_state.emit(dev, level=0x00)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic='%s/state' % topic,
@@ -185,8 +185,8 @@ class Test_FanLinc:
         stopic = "fan/speed/%s" % setup.addr.hex
 
         # Send a level signal
-        dev.signal_level_changed.emit(dev, 0xff)
-        dev.signal_level_changed.emit(dev, 0x00)
+        dev.signal_state.emit(dev, level=0xff)
+        dev.signal_state.emit(dev, level=0x00)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic=ltopic, payload='1 255', qos=qos, retain=True)

--- a/tests/mqtt/test_FanLinc.py
+++ b/tests/mqtt/test_FanLinc.py
@@ -70,13 +70,13 @@ class Test_FanLinc:
     def test_template(self, setup):
         mdev, addr, name = setup.getAll(['mdev', 'addr', 'name'])
 
-        data = mdev.template_data()
+        data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
         assert data == right
 
-        data = mdev.template_data(level=0x55, mode=IM.on_off.Mode.FAST,
-                                  manual=IM.on_off.Manual.STOP,
-                                  reason="something")
+        data = mdev.state_template_data(level=0x55, mode=IM.on_off.Mode.FAST,
+                                        manual=IM.on_off.Manual.STOP,
+                                        reason="something")
         right = {"address" : addr.hex, "name" : name,
                  "on" : 1, "on_str" : "on", "reason" : "something",
                  "level_255" : 85, "level_100" : 33,
@@ -84,14 +84,14 @@ class Test_FanLinc:
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
         assert data == right
 
-        data = mdev.template_data(level=0x00)
+        data = mdev.state_template_data(level=0x00)
         right = {"address" : addr.hex, "name" : name,
                  "on" : 0, "on_str" : "off", "reason" : "",
                  "level_255" : 0, "level_100" : 0,
                  "mode" : "normal", "fast" : 0, "instant" : 0}
         assert data == right
 
-        data = mdev.template_data(manual=IM.on_off.Manual.UP)
+        data = mdev.state_template_data(manual=IM.on_off.Manual.UP)
         right = {"address" : addr.hex, "name" : name, "reason" : "",
                  "manual_str" : "up", "manual" : 1, "manual_openhab" : 2}
         assert data == right

--- a/tests/mqtt/test_KeypadLinc_sw.py
+++ b/tests/mqtt/test_KeypadLinc_sw.py
@@ -67,13 +67,13 @@ class Test_KeypadLinc_sw:
     def test_template(self, setup):
         mdev, addr, name = setup.getAll(['mdev', 'addr', 'name'])
 
-        data = mdev.template_data(button=5)
+        data = mdev.base_template_data(button=5)
         right = {"address" : addr.hex, "name" : name, "button" : 5}
         assert data == right
 
-        data = mdev.template_data(button=3, level=1,
-                                  mode=IM.on_off.Mode.FAST,
-                                  manual=IM.on_off.Manual.STOP)
+        data = mdev.state_template_data(button=3, level=1,
+                                        mode=IM.on_off.Mode.FAST,
+                                        manual=IM.on_off.Manual.STOP)
         right = {"address" : addr.hex, "name" : name, "button" : 3,
                  "on" : 1, "on_str" : "on", "reason" : "",
                  "level_255" : 1, "level_100" : 0,
@@ -81,14 +81,14 @@ class Test_KeypadLinc_sw:
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
         assert data == right
 
-        data = mdev.template_data(button=1, level=0)
+        data = mdev.state_template_data(button=1, level=0)
         right = {"address" : addr.hex, "name" : name, "button" : 1,
                  "on" : 0, "on_str" : "off", "reason" : "",
                  "level_255" : 0, "level_100" : 0,
                  "mode" : "normal", "fast" : 0, "instant" : 0}
         assert data == right
 
-        data = mdev.template_data(button=2, manual=IM.on_off.Manual.UP)
+        data = mdev.state_template_data(button=2, manual=IM.on_off.Manual.UP)
         right = {"address" : addr.hex, "name" : name, "button" : 2,
                  "reason" : "", "manual_str" : "up", "manual" : 1,
                  "manual_openhab" : 2}
@@ -103,8 +103,8 @@ class Test_KeypadLinc_sw:
         mdev.load_config({})
 
         # Send an on/off signal
-        dev.signal_level_changed.emit(dev, 1, 255)
-        dev.signal_level_changed.emit(dev, 2, 0)
+        dev.signal_state.emit(dev, button=1, level=255)
+        dev.signal_state.emit(dev, button=2, level=0)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic='%s/state/1' % topic, payload='on', qos=0, retain=True)
@@ -113,8 +113,8 @@ class Test_KeypadLinc_sw:
         link.client.clear()
 
         # Send a manual mode signal - should do nothing w/ the default config.
-        dev.signal_manual.emit(dev, 3, IM.on_off.Manual.DOWN)
-        dev.signal_manual.emit(dev, 4, IM.on_off.Manual.STOP)
+        dev.signal_manual.emit(dev, button=3, manual=IM.on_off.Manual.DOWN)
+        dev.signal_manual.emit(dev, button=4, manual=IM.on_off.Manual.STOP)
         assert len(link.client.pub) == 0
 
     #-----------------------------------------------------------------------
@@ -130,8 +130,8 @@ class Test_KeypadLinc_sw:
         mdev.load_config(config, qos)
 
         # Send an on/off signal
-        dev.signal_level_changed.emit(dev, 3, 128)
-        dev.signal_level_changed.emit(dev, 2, 0)
+        dev.signal_state.emit(dev, button=3, level=128)
+        dev.signal_state.emit(dev, button=2, level=0)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic="foo/%s/3" % setup.addr.hex, payload='1 ON', qos=qos,
@@ -142,8 +142,8 @@ class Test_KeypadLinc_sw:
         link.client.clear()
 
         # Send a manual signal
-        dev.signal_manual.emit(dev, 5, IM.on_off.Manual.DOWN)
-        dev.signal_manual.emit(dev, 4, IM.on_off.Manual.STOP)
+        dev.signal_manual.emit(dev, button=5, manual=IM.on_off.Manual.DOWN)
+        dev.signal_manual.emit(dev, button=4, manual=IM.on_off.Manual.STOP)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic="bar/%s/5" % setup.addr.hex, payload='-1 DOWN', qos=qos,

--- a/tests/mqtt/test_Motion.py
+++ b/tests/mqtt/test_Motion.py
@@ -92,8 +92,8 @@ class Test_Motion:
         mdev.load_config({})
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, True)
-        dev.signal_on_off.emit(dev, False)
+        dev.signal_state.emit(dev, is_on=True)
+        dev.signal_state.emit(dev, is_on=False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic='%s/state' % topic, payload='on', qos=0, retain=True)
@@ -135,8 +135,8 @@ class Test_Motion:
         dtopic = "baz/%s" % setup.addr.hex
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, True)
-        dev.signal_on_off.emit(dev, False)
+        dev.signal_state.emit(dev, is_on=True)
+        dev.signal_state.emit(dev, is_on=False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic=stopic, payload='1 ON', qos=qos, retain=True)
@@ -186,8 +186,8 @@ class Test_Motion:
         dtopic = "baz/%s" % setup.addr.hex
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, True)
-        dev.signal_on_off.emit(dev, False)
+        dev.signal_state.emit(dev, is_on=True)
+        dev.signal_state.emit(dev, is_on=False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic=stopic, payload='1 ON', qos=qos, retain=True)

--- a/tests/mqtt/test_Outlet.py
+++ b/tests/mqtt/test_Outlet.py
@@ -62,18 +62,18 @@ class Test_Outlet:
     def test_template(self, setup):
         mdev, addr, name = setup.getAll(['mdev', 'addr', 'name'])
 
-        data = mdev.template_data()
+        data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
         assert data == right
 
-        data = mdev.template_data(is_on=True, button=1, reason="something",
-                                  mode=IM.on_off.Mode.FAST)
+        data = mdev.state_template_data(is_on=True, button=1, reason="something",
+                                        mode=IM.on_off.Mode.FAST)
         right = {"address" : addr.hex, "name" : name, "button" : 1,
                  "on" : 1, "on_str" : "on", "reason" : "something",
                  "mode" : "fast", "fast" : 1, "instant" : 0}
         assert data == right
 
-        data = mdev.template_data(is_on=False, button=2)
+        data = mdev.state_template_data(is_on=False, button=2)
         right = {"address" : addr.hex, "name" : name, "button" : 2,
                  "on" : 0, "on_str" : "off", "reason" : "",
                  "mode" : "normal", "fast" : 0, "instant" : 0}
@@ -88,8 +88,8 @@ class Test_Outlet:
         mdev.load_config({})
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, 1, True)
-        dev.signal_on_off.emit(dev, 2, False)
+        dev.signal_state.emit(dev, button=1, is_on=True)
+        dev.signal_state.emit(dev, button=2, is_on=False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic='%s/state/1' % topic, payload='on', qos=0, retain=True)
@@ -110,8 +110,8 @@ class Test_Outlet:
         stopic = "foo/%s" % setup.addr.hex
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, 1, True)
-        dev.signal_on_off.emit(dev, 2, False)
+        dev.signal_state.emit(dev, button=1, is_on=True)
+        dev.signal_state.emit(dev, button=2, is_on=False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic=stopic + "/1", payload='1 1 ON', qos=qos, retain=True)

--- a/tests/mqtt/test_Switch.py
+++ b/tests/mqtt/test_Switch.py
@@ -62,26 +62,27 @@ class Test_Switch:
     def test_template(self, setup):
         mdev, addr, name = setup.getAll(['mdev', 'addr', 'name'])
 
-        data = mdev.template_data()
+        data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
         assert data == right
 
-        data = mdev.template_data(is_on=True, mode=IM.on_off.Mode.FAST,
-                                  manual=IM.on_off.Manual.STOP,
-                                  reason="something")
+        data = mdev.state_template_data(is_on=True, mode=IM.on_off.Mode.FAST,
+                                        manual=IM.on_off.Manual.STOP,
+                                        reason="something")
         right = {"address" : addr.hex, "name" : name,
                  "on" : 1, "on_str" : "on", "reason" : "something",
                  "mode" : "fast", "fast" : 1, "instant" : 0,
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
         assert data == right
 
-        data = mdev.template_data(is_on=False)
+        data = mdev.state_template_data(is_on=False)
         right = {"address" : addr.hex, "name" : name, "reason" : "",
                  "on" : 0, "on_str" : "off",
                  "mode" : "normal", "fast" : 0, "instant" : 0}
         assert data == right
 
-        data = mdev.template_data(manual=IM.on_off.Manual.UP, reason="foo")
+        data = mdev.state_template_data(manual=IM.on_off.Manual.UP,
+                                        reason="foo")
         right = {"address" : addr.hex, "name" : name, "reason" : "foo",
                  "manual_str" : "up", "manual" : 1, "manual_openhab" : 2}
         assert data == right

--- a/tests/mqtt/test_Switch.py
+++ b/tests/mqtt/test_Switch.py
@@ -106,8 +106,8 @@ class Test_Switch:
         link.client.clear()
 
         # Send a manual mode signal - should do nothing w/ the default config.
-        dev.signal_manual.emit(dev, IM.on_off.Manual.DOWN)
-        dev.signal_manual.emit(dev, IM.on_off.Manual.STOP)
+        dev.signal_manual.emit(dev, manual=IM.on_off.Manual.DOWN)
+        dev.signal_manual.emit(dev, manual=IM.on_off.Manual.STOP)
         assert len(link.client.pub) == 0
 
     #-----------------------------------------------------------------------
@@ -136,8 +136,8 @@ class Test_Switch:
         link.client.clear()
 
         # Send a manual signal
-        dev.signal_manual.emit(dev, IM.on_off.Manual.DOWN)
-        dev.signal_manual.emit(dev, IM.on_off.Manual.STOP)
+        dev.signal_manual.emit(dev, manual=IM.on_off.Manual.DOWN)
+        dev.signal_manual.emit(dev, manual=IM.on_off.Manual.STOP)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic=mtopic, payload='-1 DOWN', qos=qos, retain=False)

--- a/tests/mqtt/test_Switch.py
+++ b/tests/mqtt/test_Switch.py
@@ -95,8 +95,8 @@ class Test_Switch:
         mdev.load_config({})
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, True)
-        dev.signal_on_off.emit(dev, False)
+        dev.signal_state.emit(dev, is_on=True)
+        dev.signal_state.emit(dev, is_on=False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic='%s/state' % topic, payload='on', qos=0, retain=True)
@@ -125,8 +125,8 @@ class Test_Switch:
         mtopic = "bar/%s" % setup.addr.hex
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, True)
-        dev.signal_on_off.emit(dev, False)
+        dev.signal_state.emit(dev, is_on=True)
+        dev.signal_state.emit(dev, is_on=False)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
             topic=stopic, payload='1 ON', qos=qos, retain=True)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -106,7 +106,7 @@ class Test_util:
             v = IM.util.input_choice(inputs, 'key2', ['foo', 'bar'])
 
     #-----------------------------------------------------------------------
-    def test_input_bool(self):
+    def test_input_bool(self, caplog):
         inputs = {'key1' : 'TRUE', 'key2' : 'FALSE',
                   'key3' : 1, 'key4': 0,
                   'key5' : 'On', 'key6' : 'Off',
@@ -140,11 +140,11 @@ class Test_util:
         v = IM.util.input_bool(inputs, 'invalid')
         assert v is None
 
-        with pytest.raises(ValueError):
-            v = IM.util.input_bool(inputs, 'key9')
+        v = IM.util.input_bool(inputs, 'key9')
+        assert 'Valid inputs are 1/0' in caplog.text
 
     #-----------------------------------------------------------------------
-    def test_input_integer(self):
+    def test_input_integer(self,caplog):
         inputs = {'key1' : '1', 'key2' : 2,
                   'key3' : '0x03', 'key4' : 0x04,
                   'key5' : None, 'key6' : 'None',
@@ -174,11 +174,11 @@ class Test_util:
         v = IM.util.input_integer(inputs, 'invalid')
         assert v is None
 
-        with pytest.raises(ValueError):
-            v = IM.util.input_integer(inputs, 'key8')
+        v = IM.util.input_integer(inputs, 'key8')
+        assert 'Valid inputs are integer values' in caplog.text
 
     #-----------------------------------------------------------------------
-    def test_input_byte(self):
+    def test_input_byte(self, caplog):
         inputs = {'key1' : 0, 'key2' : '10',
                   'key3' : '0x2f', 'key4' : '0b11',
                   'key5' : 256, 'key6' : '257',
@@ -199,14 +199,14 @@ class Test_util:
         v = IM.util.input_byte(inputs, 'key4')
         assert v == 0x03
 
-        with pytest.raises(ValueError):
-            v = IM.util.input_byte(inputs, 'key5')
+        v = IM.util.input_byte(inputs, 'key5')
+        assert 'Valid inputs are 0-255' in caplog.text
 
-        with pytest.raises(ValueError):
-            v = IM.util.input_byte(inputs, 'key6')
+        v = IM.util.input_byte(inputs, 'key6')
+        assert 'Valid inputs are 0-255' in caplog.text
 
-        with pytest.raises(ValueError):
-            v = IM.util.input_byte(inputs, 'key7')
+        v = IM.util.input_byte(inputs, 'key7')
+        assert 'Valid inputs are 0-255' in caplog.text
 
 
 #===========================================================================


### PR DESCRIPTION
This rearranges a lot of the MQTT code.  The State and Manual Topics are now contained in a single code base.  There is one location for calculating the state_template_data.  This might have even added Reason support to some devices that didn't have it before.

There is no sexy feature or bug fix here.

This is all a means to eliminate the repetitive code as much as possible.  This should make adding new devices, fixing bugs, adding features, and unit testing the code significantly easier.  

I still need to condense the set and level topics.  A few other topics could probably use cleanup, but if they are not used more than once, they are going to stay in their device files.

Then, the harder part is to continue condensing the device code eliminating repetitive code their as well.