### PR TITLE
Refactor MQTT Part 3; Set Topic

### DIFF
--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -1038,7 +1038,7 @@ class Modem:
         return [data_1, data_2, data_3]
 
     #-----------------------------------------------------------------------
-    def scene(self, is_on, group=None, name=None, num_retry=3, reason="",
+    def scene(self, is_on, group=0x01, name=None, reason=None, level=None,
               on_done=None):
         """Trigger a virtual modem scene.
 
@@ -1050,7 +1050,7 @@ class Modem:
                 False to send an off (0x13) command for the scene.
           group (int):  The modem group (scene) number to send.
           name (str):  The name of the scene as defined in a scenes.yaml file
-          num_retry (int):  The number of retries to use if the message fails.
+          level (None): Not used by Modem, should be None.
           reason (str):  This is optional and is used to identify why the
                  command was sent. It is passed through to the output signal
                  when the state changes - nothing else is done with it.
@@ -1060,11 +1060,13 @@ class Modem:
         """
         # TODO: figure out how to pass reason around
         on_done = util.make_callback(on_done)
+        if level is not None:
+            LOG.error("Modem scenes do not use level command")
         if name is not None:
             try:
                 group = self.scene_map[name]
             except KeyError:
-                LOG.error("Unable to find modem scene %s", name)
+                LOG.error("Unable to find modem scene named %s", name)
                 on_done(False, "Scene command failed", None)
                 return
         else:

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -112,7 +112,7 @@ class Dimmer(functions.Scene, functions.Set, Base):
         """
         LOG.info("Dimmer %s cmd: on %s", self.addr, level)
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
         if level is None:
             # Not specified - choose brightness as pressing the button would do
             if mode == on_off.Mode.FAST:

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -168,7 +168,7 @@ class Dimmer(functions.Scene, functions.Set, Base):
         """
         LOG.info("Dimmer %s cmd: off", self.addr)
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
         assert group == 0x01
         assert isinstance(mode, on_off.Mode)
 

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -111,8 +111,9 @@ class Dimmer(functions.Scene, functions.Set, Base):
                    completed.  Signature is: on_done(success, msg, data)
         """
         LOG.info("Dimmer %s cmd: on %s", self.addr, level)
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
         if level is None:
             # Not specified - choose brightness as pressing the button would do
             if mode == on_off.Mode.FAST:
@@ -167,8 +168,9 @@ class Dimmer(functions.Scene, functions.Set, Base):
                    completed.  Signature is: on_done(success, msg, data)
         """
         LOG.info("Dimmer %s cmd: off", self.addr)
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
         assert group == 0x01
         assert isinstance(mode, on_off.Mode)
 

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -188,8 +188,9 @@ class EZIO4O(functions.Set, Base):
         assert 1 <= group <= 4
         assert isinstance(mode, on_off.Mode)
 
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else modeddr)
 
         # Use a standard message to send "output on" (0x45) command for the
         # output
@@ -229,8 +230,9 @@ class EZIO4O(functions.Set, Base):
         assert 1 <= group <= 4
         assert isinstance(mode, on_off.Mode)
 
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
 
         # Use a standard message to send "output off" (0x46) command for the
         # output

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -189,7 +189,7 @@ class EZIO4O(functions.Set, Base):
         assert isinstance(mode, on_off.Mode)
 
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
 
         # Use a standard message to send "output on" (0x45) command for the
         # output
@@ -230,7 +230,7 @@ class EZIO4O(functions.Set, Base):
         assert isinstance(mode, on_off.Mode)
 
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
 
         # Use a standard message to send "output off" (0x46) command for the
         # output

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -190,7 +190,7 @@ class EZIO4O(functions.Set, Base):
 
         if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
-            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else modeddr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
 
         # Use a standard message to send "output on" (0x45) command for the
         # output

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -5,6 +5,7 @@
 #===========================================================================
 import functools
 from .Base import Base
+from . import functions
 from ..CommandSeq import CommandSeq
 from .. import handler
 from .. import log
@@ -57,7 +58,7 @@ EZIO4xx_flags = {
 }
 
 
-class EZIO4O(Base):
+class EZIO4O(functions.Set, Base):
     """Smartenit EZIO4O - 4 relay output device.
 
     This class can be used to model the EZIO4O device which has 4 outputs.
@@ -101,7 +102,6 @@ class EZIO4O(Base):
                 "on": self.on,
                 "off": self.off,
                 "set_flags": self.set_flags,
-                "set": self.set,
             }
         )
 
@@ -164,7 +164,7 @@ class EZIO4O(Base):
 
     #-----------------------------------------------------------------------
     def on(self, group=0x01, level=None, mode=on_off.Mode.NORMAL, reason="",
-           on_done=None):
+           transition=None, on_done=None):
         """Turn the device on.
 
         This will send the command to the device to update it's state.  When
@@ -186,8 +186,10 @@ class EZIO4O(Base):
         """
         LOG.info("EZIO4O %s grp: %s cmd: on", self.label, group)
         assert 1 <= group <= 4
-        assert level >= 0 and level <= 0xFF
         assert isinstance(mode, on_off.Mode)
+
+        if transition:
+            LOG.error("Device %s does not suppor transition.", self.addr)
 
         # Use a standard message to send "output on" (0x45) command for the
         # output
@@ -206,7 +208,7 @@ class EZIO4O(Base):
 
     #-----------------------------------------------------------------------
     def off(self, group=0x01, mode=on_off.Mode.NORMAL, reason="",
-            on_done=None):
+            transition=None, on_done=None):
         """Turn the device off.
 
         This will send the command to the device to update it's state.  When
@@ -227,6 +229,9 @@ class EZIO4O(Base):
         assert 1 <= group <= 4
         assert isinstance(mode, on_off.Mode)
 
+        if transition:
+            LOG.error("Device %s does not suppor transition.", self.addr)
+
         # Use a standard message to send "output off" (0x46) command for the
         # output
         msg = Msg.OutStandard.direct(self.addr, 0x46, group - 1)
@@ -241,30 +246,6 @@ class EZIO4O(Base):
 
         # Send the message to the PLM modem for protocol.
         self.send(msg, msg_handler)
-
-    #-----------------------------------------------------------------------
-    def set(self, level, group=0x01, mode=on_off.Mode.NORMAL, reason="",
-            on_done=None):
-        """Turn the device on or off.  Level zero will be off.
-
-        This will send the command to the device to update it's state.  When
-        we get an ACK of the result, we'll change our internal state and emit
-        the state changed signals.
-
-        Args:
-          level (int):  If non zero, turn the device on.  Should be in the
-                range 0 to 255.  Only dimmers use the intermediate values, all
-                other devices look at level=0 or level>0.
-          group (int):  The group to send the command to.  Group 1 to 4
-                        matching output 1 to 4.
-          mode (on_off.Mode): The type of command to send (normal, fast, etc).
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-        """
-        if level:
-            self.on(group, level, mode, reason, on_done)
-        else:
-            self.off(group, mode, reason, on_done)
 
     #-----------------------------------------------------------------------
     def link_data(self, is_controller, group, data=None):

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -518,7 +518,7 @@ class IOLinc(functions.Set, Base):
         assert group == 0x01
 
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
 
         # Send an on command.  Use the standard command handler which will
         # notify us when the command is ACK'ed.
@@ -556,7 +556,7 @@ class IOLinc(functions.Set, Base):
         assert group == 0x01
 
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
 
         # Send an off command.  Use the standard command handler which will
         # notify us when the command is ACK'ed.

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -6,6 +6,7 @@
 import enum
 import time
 from .Base import Base
+from . import functions
 from ..CommandSeq import CommandSeq
 from .. import handler
 from .. import log
@@ -17,7 +18,7 @@ from .. import util
 LOG = log.get_logger()
 
 
-class IOLinc(Base):
+class IOLinc(functions.Set, Base):
     """Insteon IOLinc relay/sensor device.
 
     This class can be used to model the IOLinc device which has a sensor and
@@ -143,7 +144,6 @@ class IOLinc(Base):
         self.cmd_map.update({
             'on' : self.on,
             'off' : self.off,
-            'set' : self.set,
             'set_flags' : self.set_flags,
             })
 
@@ -489,7 +489,7 @@ class IOLinc(Base):
 
     #-----------------------------------------------------------------------
     def on(self, group=0x01, level=None, mode=on_off.Mode.NORMAL, reason="",
-           on_done=None):
+           transition=None, on_done=None):
         """Turn the relay on.
 
         This turns the relay on no matter what.  It ignores the momentary
@@ -517,6 +517,9 @@ class IOLinc(Base):
         LOG.info("IOLinc %s cmd: on", self.addr)
         assert group == 0x01
 
+        if transition:
+            LOG.error("Device %s does not suppor transition.", self.addr)
+
         # Send an on command.  Use the standard command handler which will
         # notify us when the command is ACK'ed.
         msg = Msg.OutStandard.direct(self.addr, 0x11, 0xff)
@@ -527,7 +530,7 @@ class IOLinc(Base):
 
     #-----------------------------------------------------------------------
     def off(self, group=0x01, mode=on_off.Mode.NORMAL, reason="",
-            on_done=None):
+            transition=None, on_done=None):
         """Turn the relay off.
 
         This turns the relay off no matter what.  It ignores the momentary
@@ -552,6 +555,9 @@ class IOLinc(Base):
         LOG.info("IOLinc %s cmd: off", self.addr)
         assert group == 0x01
 
+        if transition:
+            LOG.error("Device %s does not suppor transition.", self.addr)
+
         # Send an off command.  Use the standard command handler which will
         # notify us when the command is ACK'ed.
         msg = Msg.OutStandard.direct(self.addr, 0x13, 0x00)
@@ -559,37 +565,6 @@ class IOLinc(Base):
 
         # Send the message to the PLM modem.
         self.send(msg, msg_handler)
-
-    #-----------------------------------------------------------------------
-    def set(self, level, group=0x01, instant=False, on_done=None):
-        """Turn the relay on or off.  Level zero will be off.
-
-        This turns the relay on or off no matter what.  It ignores the
-        momentary A/B/C settings and just turns the relay on. It will not
-        trigger any responders that are linked to this device.  If you want to
-        control the device where it respects the momentary settings and
-        properly updates responders, please define a scene for the device and
-        use that scene to control it.
-
-        This will send the command to the device to update it's state.
-        When we get an ACK of the result, we'll change our internal
-        state and emit the state changed signals.
-
-        Args:
-          level (int):  If non zero, turn the device on.  Should be in the
-                range 0 to 255.  Only dimmers use the intermediate values, all
-                other devices look at level=0 or level>0.
-          group (int):  The group to send the command to.  For this device,
-                this must be 1.  Allowing a group here gives us a consistent
-                API to the on command across devices.
-          mode (on_off.Mode): The type of command to send (normal, fast, etc).
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-        """
-        if level:
-            self.on(group, level, instant, on_done)
-        else:
-            self.off(group, instant, on_done)
 
     #-----------------------------------------------------------------------
     def handle_on_off(self, msg):

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -517,8 +517,9 @@ class IOLinc(functions.Set, Base):
         LOG.info("IOLinc %s cmd: on", self.addr)
         assert group == 0x01
 
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
 
         # Send an on command.  Use the standard command handler which will
         # notify us when the command is ACK'ed.
@@ -555,8 +556,9 @@ class IOLinc(functions.Set, Base):
         LOG.info("IOLinc %s cmd: off", self.addr)
         assert group == 0x01
 
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
 
         # Send an off command.  Use the standard command handler which will
         # notify us when the command is ACK'ed.

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -19,7 +19,7 @@ LOG = log.get_logger()
 
 
 #===========================================================================
-class KeypadLinc(functions.Scene, Base):
+class KeypadLinc(functions.Set, functions.Scene, Base):
     """Insteon KeypadLinc dimmer/switch device.
 
     This class can be used to model a 6 or 8 button KeypadLinc with dimming
@@ -82,7 +82,6 @@ class KeypadLinc(functions.Scene, Base):
         self.cmd_map.update({
             'on' : self.on,
             'off' : self.off,
-            'set' : self.set,
             'set_flags' : self.set_flags,
             'set_button_led' : self.set_button_led,
             'set_load_attached' : self.set_load_attached,
@@ -399,48 +398,6 @@ class KeypadLinc(functions.Scene, Base):
             callback = functools.partial(self.handle_set_load, reason=reason)
             msg_handler = handler.StandardCmd(msg, callback, on_done)
             self.send(msg, msg_handler)
-
-    #-----------------------------------------------------------------------
-    def set(self, level, group=0, mode=on_off.Mode.NORMAL, reason="",
-            transition=None, on_done=None):
-        """Turn the device on or off.  Level zero will be off.
-
-        NOTE: This does NOT simulate a button press on the device - it just
-        changes the state of the device.  It will not trigger any responders
-        that are linked to this device.  To simulate a button press, call the
-        scene() method.   If the input button is controlling the load (group 1
-        for an attached load, group 0 for attached or detached), then the
-        load will change.  Otherwise this command just changes the LED of
-        the button.
-
-        This will send the command to the device to update it's state.  When
-        we get an ACK of the result, we'll change our internal state and emit
-        the state changed signals.
-
-        Args:
-          level (int):  If non zero, turn the device on.  Should be in the
-                range 0 to 255.  For non-dimmer groups, it will only look at
-                level=0 or level>0.  If None, use default on-level.
-          group (int): The group to send the command to.  If the group is 0,
-                it will always be the load (whether it's attached or not).
-                Otherwise it must be in the range [1,8] and controls the
-                specific button.
-          mode (on_off.Mode): The type of command to send (normal, fast, etc).
-          reason (str):  This is optional and is used to identify why the
-                 command was sent. It is passed through to the output signal
-                 when the state changes - nothing else is done with it.
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-        """
-        if (level is None) or level:
-            # None/True == use default on-level.  Since true is integer 1,
-            # do an explicit check here to catch that input.
-            if level is True:
-                level = None
-
-            self.on(group, level, mode, reason, transition, on_done)
-        else:
-            self.off(group, mode, reason, transition, on_done)
 
     #-----------------------------------------------------------------------
     def increment_up(self, reason="", on_done=None):

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -5,6 +5,7 @@
 #===========================================================================
 import functools
 from .Base import Base
+from . import functions
 from ..CommandSeq import CommandSeq
 from .. import handler
 from .. import log
@@ -16,7 +17,7 @@ from .. import util
 LOG = log.get_logger()
 
 
-class Outlet(Base):
+class Outlet(functions.Set, Base):
     """Insteon on/off outlet device.
 
     This is used for in-wall on/off outlets.  Each outlet (top and bottom) is
@@ -58,7 +59,6 @@ class Outlet(Base):
         self.cmd_map.update({
             'on' : self.on,
             'off' : self.off,
-            'set' : self.set,
             'set_flags' : self.set_flags,
             })
 
@@ -116,7 +116,7 @@ class Outlet(Base):
 
     #-----------------------------------------------------------------------
     def on(self, group=0x01, level=None, mode=on_off.Mode.NORMAL,
-           reason="", on_done=None):
+           reason="", transition=None, on_done=None):
         """Turn the device on.
 
         This will send the command to the device to update it's state.  When
@@ -138,8 +138,10 @@ class Outlet(Base):
         """
         LOG.info("Outlet %s grp: %s cmd: on", group, self.addr)
         assert 1 <= group <= 2
-        assert level >= 0 and level <= 0xff
         assert isinstance(mode, on_off.Mode)
+
+        if transition:
+            LOG.error("Device %s does not suppor transition.", self.addr)
 
         # Send the requested on code value.
         cmd1 = on_off.Mode.encode(True, mode)
@@ -166,7 +168,7 @@ class Outlet(Base):
 
     #-----------------------------------------------------------------------
     def off(self, group=0x01, mode=on_off.Mode.NORMAL, reason="",
-            on_done=None):
+            transition=None, on_done=None):
         """Turn the device off.
 
         This will send the command to the device to update it's state.  When
@@ -186,6 +188,9 @@ class Outlet(Base):
         LOG.info("Outlet %s cmd: off", self.addr)
         assert 1 <= group <= 2
         assert isinstance(mode, on_off.Mode)
+
+        if transition:
+            LOG.error("Device %s does not suppor transition.", self.addr)
 
         # Send the correct off code.
         cmd1 = on_off.Mode.encode(False, mode)
@@ -209,30 +214,6 @@ class Outlet(Base):
 
         # Send the message to the PLM modem for protocol.
         self.send(msg, msg_handler)
-
-    #-----------------------------------------------------------------------
-    def set(self, level, group=0x01, mode=on_off.Mode.NORMAL, reason="",
-            on_done=None):
-        """Turn the device on or off.  Level zero will be off.
-
-        This will send the command to the device to update it's state.  When
-        we get an ACK of the result, we'll change our internal state and emit
-        the state changed signals.
-
-        Args:
-          level (int):  If non zero, turn the device on.  Should be in the
-                range 0 to 255.  Only dimmers use the intermediate values, all
-                other devices look at level=0 or level>0.
-          group (int):  The group to send the command to.  The top outlet is
-                group 1, the bottom outlet is group 2.
-          mode (on_off.Mode): The type of command to send (normal, fast, etc).
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-        """
-        if level:
-            self.on(group, level, mode, reason, on_done)
-        else:
-            self.off(group, mode, reason, on_done)
 
     #-----------------------------------------------------------------------
     def set_backlight(self, level, on_done=None):

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -141,7 +141,7 @@ class Outlet(functions.Set, Base):
         assert isinstance(mode, on_off.Mode)
 
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
 
         # Send the requested on code value.
         cmd1 = on_off.Mode.encode(True, mode)
@@ -190,7 +190,7 @@ class Outlet(functions.Set, Base):
         assert isinstance(mode, on_off.Mode)
 
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
 
         # Send the correct off code.
         cmd1 = on_off.Mode.encode(False, mode)

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -140,8 +140,9 @@ class Outlet(functions.Set, Base):
         assert 1 <= group <= 2
         assert isinstance(mode, on_off.Mode)
 
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
 
         # Send the requested on code value.
         cmd1 = on_off.Mode.encode(True, mode)
@@ -189,8 +190,9 @@ class Outlet(functions.Set, Base):
         assert 1 <= group <= 2
         assert isinstance(mode, on_off.Mode)
 
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
 
         # Send the correct off code.
         cmd1 = on_off.Mode.encode(False, mode)

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -101,7 +101,7 @@ class Switch(functions.Set, functions.Scene, Base):
         assert isinstance(mode, on_off.Mode)
 
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
 
         # Send the requested on code value.
         cmd1 = on_off.Mode.encode(True, mode)
@@ -144,7 +144,7 @@ class Switch(functions.Set, functions.Scene, Base):
         assert isinstance(mode, on_off.Mode)
 
         if transition:
-            LOG.error("Device %s does not suppor transition.", self.addr)
+            LOG.error("Device %s does not support transition.", self.addr)
 
         # Send an off or instant off command.
         cmd1 = on_off.Mode.encode(False, mode)

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -100,8 +100,9 @@ class Switch(functions.Set, functions.Scene, Base):
         assert group == 0x01
         assert isinstance(mode, on_off.Mode)
 
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
 
         # Send the requested on code value.
         cmd1 = on_off.Mode.encode(True, mode)
@@ -143,8 +144,9 @@ class Switch(functions.Set, functions.Scene, Base):
         assert group == 0x01
         assert isinstance(mode, on_off.Mode)
 
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
 
         # Send an off or instant off command.
         cmd1 = on_off.Mode.encode(False, mode)

--- a/insteon_mqtt/device/functions/Scene.py
+++ b/insteon_mqtt/device/functions/Scene.py
@@ -46,7 +46,8 @@ class Scene(Base):
         # in the self.group_map.  Only these groups will be valid scene
         # targets
 
-    def scene(self, is_on, group=0x01, reason=None, level=None, on_done=None):
+    def scene(self, is_on, group=0x01, name=None, reason=None, level=None,
+              on_done=None):
         """Trigger a scene on the device.
 
         Triggering a scene is the same as simulating a button press on the
@@ -64,6 +65,7 @@ class Scene(Base):
           is_on (bool): True for an on command, False for an off command.
           group (int): The group on the device to simulate.  For this device,
                 this must be 1.
+          name (None): Not used, only here for modem compatibility.
           reason (str):  This is optional and is used to identify why the
                  command was sent. It is passed through to the output signal
                  when the state changes - nothing else is done with it.
@@ -74,7 +76,13 @@ class Scene(Base):
                    completed.  Signature is: on_done(success, msg, data)
         """
         LOG.info("Device %s scene %s", self.addr, "on" if is_on else "off")
+        if group is None:
+            group = 0x01
         assert group in self.group_map
+
+        if name is not None:
+            LOG.error("Device %s scenes cannot use names, groups only.",
+                      self.addr)
 
         on_done = util.make_callback(on_done)
 

--- a/insteon_mqtt/device/functions/Set.py
+++ b/insteon_mqtt/device/functions/Set.py
@@ -1,0 +1,81 @@
+#===========================================================================
+#
+# Set Functions.
+#
+#===========================================================================
+from ..Base import Base
+from ... import log
+from ... import on_off
+
+LOG = log.get_logger()
+
+
+class Set(Base):
+    """Scene Trait Abstract Class
+
+    This is an abstract class that provides support for the Scene topic.
+    """
+    def __init__(self, protocol, modem, address, name=None):
+        """Constructor
+
+        Args:
+          protocol (Protocol): The Protocol object used to communicate
+                   with the Insteon network.  This is needed to allow the
+                   device to send messages to the PLM modem.
+          modem (Modem): The Insteon modem used to find other devices.
+          address (Address): The address of the device.
+          name (str): Nice alias name to use for the device.
+        """
+        super().__init__(protocol, modem, address, name)
+
+        self.cmd_map.update({
+            'set' : self.set,
+            })
+
+    #-----------------------------------------------------------------------
+    def set(self, is_on=None, level=None, group=0x01, mode=on_off.Mode.NORMAL,
+            reason="", transition=None, on_done=None):
+        """Turn the device on or off.  Level zero will be off.
+
+        NOTE: This does NOT simulate a button press on the device - it just
+        changes the state of the device.  It will not trigger any responders
+        that are linked to this device.  To simulate a button press, call the
+        scene() method.
+
+        This will send the command to the device to update it's state.  When
+        we get an ACK of the result, we'll change our internal state and emit
+        the state changed signals.
+
+        Args:
+          is_on (bool): True to turn on, False for off
+          level (int): If non zero, turn the device on.  Should be in the
+                range 0 to 255.  If None, use default on-level.
+          group (int): The group to send the command to.  For this device,
+                this must be 1.  Allowing a group here gives us a consistent
+                API to the on command across devices.
+          mode (on_off.Mode): The type of command to send (normal, fast, etc).
+          reason (str):  This is optional and is used to identify why the
+                 command was sent. It is passed through to the output signal
+                 when the state changes - nothing else is done with it.
+          transition (int): The transition ramp_rate if supported.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        if is_on or level:
+            self.on(group=group, level=level, mode=mode, reason=reason,
+                    transition=transition, on_done=on_done)
+        else:
+            self.off(group=group, mode=mode, reason=reason,
+                     transition=transition, on_done=on_done)
+
+    #-----------------------------------------------------------------------
+    def on(self, group, level, mode, reason, transition, on_done):
+        # TODO Might be able to move these functions in here too
+        # Probably put switch functions here and dimmer in a seperate
+        # level file.  Need to move handle_ack and all subsequent functions
+        # too.  KPL, IO devices would remain their own thing
+        raise NotImplementedError()
+
+    #-----------------------------------------------------------------------
+    def off(self, group, mode, reason, transition, on_done):
+        raise NotImplementedError()

--- a/insteon_mqtt/device/functions/__init__.py
+++ b/insteon_mqtt/device/functions/__init__.py
@@ -19,3 +19,4 @@ the list of available functions to inherit from.
 
 from ..Base import Base
 from .Scene import Scene
+from .Set import Set

--- a/insteon_mqtt/mqtt/BatterySensor.py
+++ b/insteon_mqtt/mqtt/BatterySensor.py
@@ -33,7 +33,7 @@ class BatterySensor(StateTopic):
 
         # Default values for the topics.
         self.msg_battery = MsgTemplate(
-            topic='insteon/{{address}}/low_battery',
+            topic='insteon/{{address}}/battery',
             payload='{{is_low_str.lower()}}')
         self.msg_heartbeat = MsgTemplate(
             topic='insteon/{{address}}/heartbeat',

--- a/insteon_mqtt/mqtt/BatterySensor.py
+++ b/insteon_mqtt/mqtt/BatterySensor.py
@@ -6,12 +6,12 @@
 import time
 from .. import log
 from .MsgTemplate import MsgTemplate
-from .StateTopic import StateTopic
+from . import topic
 
 LOG = log.get_logger()
 
 
-class BatterySensor(StateTopic):
+class BatterySensor(topic.StateTopic):
     """MQTT interface to an Insteon general battery powered sensor.
 
     This class connects to a device.BatterySensor object and converts it's

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -10,11 +10,12 @@ from . import util
 from .SceneTopic import SceneTopic
 from .StateTopic import StateTopic
 from .ManualTopic import ManualTopic
+from .SetTopic import SetTopic
 
 LOG = log.get_logger()
 
 
-class Dimmer(StateTopic, SceneTopic, ManualTopic):
+class Dimmer(StateTopic, SceneTopic, ManualTopic, SetTopic):
     """MQTT interface to an Insteon dimmer switch.
 
     This class connects to a device.Dimmer object and converts it's output
@@ -35,11 +36,6 @@ class Dimmer(StateTopic, SceneTopic, ManualTopic):
         super().__init__(mqtt, device,
                          state_payload='{ "state" : "{{on_str.lower()}}", '
                                        '"brightness" : {{level_255}} }')
-
-        # Input on/off command template.
-        self.msg_on_off = MsgTemplate(
-            topic='insteon/{{address}}/set',
-            payload='{ "cmd" : "{{value.lower()}}" }')
 
         # Input level command template.
         self.msg_level = MsgTemplate(
@@ -64,10 +60,9 @@ class Dimmer(StateTopic, SceneTopic, ManualTopic):
         self.load_scene_data(data, qos)
         self.load_state_data(data, qos)
         self.load_manual_data(data, qos)
+        self.load_set_data(data, qos)
 
         # Update the MQTT topics and payloads from the config file.
-        self.msg_on_off.load_config(data, 'on_off_topic', 'on_off_payload',
-                                    qos)
         self.msg_level.load_config(data, 'level_topic', 'level_payload', qos)
 
     #-----------------------------------------------------------------------
@@ -81,9 +76,7 @@ class Dimmer(StateTopic, SceneTopic, ManualTopic):
           link (network.Mqtt):  The MQTT network client to use.
           qos (int):  The quality of service to use.
         """
-        # On/off command messages.
-        topic = self.msg_on_off.render_topic(self.base_template_data())
-        link.subscribe(topic, qos, self._input_on_off)
+        self.set_subscribe(link, qos)
 
         # Level changing command messages.
         topic = self.msg_level.render_topic(self.base_template_data())
@@ -98,45 +91,12 @@ class Dimmer(StateTopic, SceneTopic, ManualTopic):
         Args:
           link (network.Mqtt):  The MQTT network client to use.
         """
-        topic = self.msg_on_off.render_topic(self.base_template_data())
-        link.unsubscribe(topic)
+        self.set_unsubscribe(link)
 
         topic = self.msg_level.render_topic(self.base_template_data())
         link.unsubscribe(topic)
 
         self.scene_unsubscribe(link)
-
-    #-----------------------------------------------------------------------
-    def _input_on_off(self, client, data, message):
-        """Handle an input on/off change MQTT message.
-
-        This is called when we receive a message on the on/off MQTT topic
-        subscription.  Parse the message and pass the command to the Insteon
-        device.
-
-        Args:
-          client (paho.Client):  The paho mqtt client (self.link).
-          data:  Optional user data (unused).
-          message:  MQTT message - has attrs: topic, payload, qos, retain.
-        """
-        LOG.debug("Dimmer message %s %s", message.topic, message.payload)
-
-        # Parse the input MQTT message.
-        data = self.msg_on_off.to_json(message.payload)
-        LOG.info("Dimmer input command: %s", data)
-        try:
-            # Tell the device to update its state.
-            is_on, mode, transition = util.parse_on_off(data)
-            if mode == on_off.Mode.RAMP or transition is not None:
-                LOG.error("Light ON/OFF at Ramp Rate not supported with "
-                          "dimmers - ignoring ramp rate.")
-            if mode == on_off.Mode.RAMP:  # Not supported
-                mode = on_off.Mode.NORMAL
-            level = 0 if not is_on else None
-            reason = data.get("reason", "")
-            self.device.set(level=level, mode=mode, reason=reason)
-        except:
-            LOG.error("Invalid switch on/off command: %s", data)
 
     #-----------------------------------------------------------------------
     def _input_set_level(self, client, data, message):

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -7,15 +7,13 @@ from .. import log
 from .. import on_off
 from .MsgTemplate import MsgTemplate
 from . import util
-from .SceneTopic import SceneTopic
-from .StateTopic import StateTopic
-from .ManualTopic import ManualTopic
-from .SetTopic import SetTopic
+from . import topic
 
 LOG = log.get_logger()
 
 
-class Dimmer(StateTopic, SceneTopic, ManualTopic, SetTopic):
+class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
+             topic.SetTopic):
     """MQTT interface to an Insteon dimmer switch.
 
     This class connects to a device.Dimmer object and converts it's output
@@ -79,8 +77,8 @@ class Dimmer(StateTopic, SceneTopic, ManualTopic, SetTopic):
         self.set_subscribe(link, qos)
 
         # Level changing command messages.
-        topic = self.msg_level.render_topic(self.base_template_data())
-        link.subscribe(topic, qos, self._input_set_level)
+        topic_str = self.msg_level.render_topic(self.base_template_data())
+        link.subscribe(topic_str, qos, self._input_set_level)
 
         self.scene_subscribe(link, qos)
 
@@ -93,8 +91,8 @@ class Dimmer(StateTopic, SceneTopic, ManualTopic, SetTopic):
         """
         self.set_unsubscribe(link)
 
-        topic = self.msg_level.render_topic(self.base_template_data())
-        link.unsubscribe(topic)
+        topic_str = self.msg_level.render_topic(self.base_template_data())
+        link.unsubscribe(topic_str)
 
         self.scene_unsubscribe(link)
 

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -122,13 +122,13 @@ class Dimmer(StateTopic, SceneTopic, ManualTopic, SetTopic):
                           "dimmers - ignoring ramp rate.")
             if mode == on_off.Mode.RAMP:  # Not supported
                 mode = on_off.Mode.NORMAL
-            level = '0' if not is_on else data.get('level')
+            level = '0' if not is_on else data.get('level', None)
             if level is not None:
                 level = int(level)
             reason = data.get("reason", "")
 
             # Tell the device to change its level.
-            self.device.set(level=level, mode=mode, reason=reason)
+            self.device.set(is_on=is_on, level=level, mode=mode, reason=reason)
         except:
             LOG.error("Invalid dimmer command: %s", data)
 

--- a/insteon_mqtt/mqtt/EZIO4O.py
+++ b/insteon_mqtt/mqtt/EZIO4O.py
@@ -4,13 +4,12 @@
 #
 #===========================================================================
 from .. import log
-from .StateTopic import StateTopic
-from .SetTopic import SetTopic
+from . import topic
 
 LOG = log.get_logger()
 
 
-class EZIO4O(StateTopic, SetTopic):
+class EZIO4O(topic.StateTopic, topic.SetTopic):
     """MQTT interface to Smartenit EZIO4O 4 relay output device.
 
     This class connects to a device.EZIO4O object and converts it's

--- a/insteon_mqtt/mqtt/EZIO4O.py
+++ b/insteon_mqtt/mqtt/EZIO4O.py
@@ -3,11 +3,7 @@
 # EZIO4O 4 relay output device
 #
 #===========================================================================
-import functools
 from .. import log
-from .. import on_off
-from .MsgTemplate import MsgTemplate
-from . import util
 from .StateTopic import StateTopic
 from .SetTopic import SetTopic
 

--- a/insteon_mqtt/mqtt/IOLinc.py
+++ b/insteon_mqtt/mqtt/IOLinc.py
@@ -5,13 +5,13 @@
 #===========================================================================
 from .. import log
 from .MsgTemplate import MsgTemplate
-from . import util
 from .BaseTopic import BaseTopic
+from .SetTopic import SetTopic
 
 LOG = log.get_logger()
 
 
-class IOLinc(BaseTopic):
+class IOLinc(SetTopic, BaseTopic):
     """MQTT interface to an Insteon IOLinc device.
 
     This class connects to a device.IOLinc object and converts it's
@@ -43,11 +43,6 @@ class IOLinc(BaseTopic):
             topic='insteon/{{address}}/sensor',
             payload='{{sensor_on_str.lower()}}')
 
-        # Input on/off command template.
-        self.msg_on_off = MsgTemplate(
-            topic='insteon/{{address}}/set',
-            payload='{ "cmd" : "{{value.lower()}}" }')
-
         device.signal_on_off.connect(self._insteon_on_off)
 
     #-----------------------------------------------------------------------
@@ -68,8 +63,7 @@ class IOLinc(BaseTopic):
                                          'relay_state_payload', qos)
         self.msg_sensor_state.load_config(data, 'sensor_state_topic',
                                           'sensor_state_payload', qos)
-        self.msg_on_off.load_config(data, 'on_off_topic', 'on_off_payload',
-                                    qos)
+        self.load_set_data(data, qos)
 
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
@@ -83,8 +77,7 @@ class IOLinc(BaseTopic):
           qos (int):  The quality of service to use.
         """
         # On/off command messages.
-        topic = self.msg_on_off.render_topic(self.template_data())
-        link.subscribe(topic, qos, self._input_on_off)
+        self.set_subscribe(link, qos)
 
     #-----------------------------------------------------------------------
     def unsubscribe(self, link):
@@ -93,8 +86,7 @@ class IOLinc(BaseTopic):
         Args:
           link (network.Mqtt):  The MQTT network client to use.
         """
-        topic = self.msg_on_off.render_topic(self.template_data())
-        link.unsubscribe(topic)
+        self.set_unsubscribe(link)
 
     #-----------------------------------------------------------------------
     def template_data(self, sensor_is_on=None, relay_is_on=None):
@@ -137,31 +129,5 @@ class IOLinc(BaseTopic):
         self.msg_state.publish(self.mqtt, data)
         self.msg_relay_state.publish(self.mqtt, data)
         self.msg_sensor_state.publish(self.mqtt, data)
-
-    #-----------------------------------------------------------------------
-    def _input_on_off(self, client, data, message):
-        """Handle an input on/off change MQTT message.
-
-        This is called when we receive a message on the on/off MQTT topic
-        subscription.  Parse the message and pass the command to the Insteon
-        device.
-
-        Args:
-          client (paho.Client):  The paho mqtt client (self.link).
-          data:  Optional user data (unused).
-          message:  MQTT message - has attrs: topic, payload, qos, retain.
-        """
-        LOG.debug("IOLinc message %s %s", message.topic, message.payload)
-
-        # Parse the input MQTT message.
-        data = self.msg_on_off.to_json(message.payload)
-        LOG.info("IOLinc input command: %s", data)
-
-        try:
-            # IOLinc doesn't support modes so don't parse that element.
-            is_on = util.parse_on_off(data, have_mode=False)
-            self.device.set(is_on=is_on)
-        except:
-            LOG.error("Invalid IOLinc on/off command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/IOLinc.py
+++ b/insteon_mqtt/mqtt/IOLinc.py
@@ -5,13 +5,12 @@
 #===========================================================================
 from .. import log
 from .MsgTemplate import MsgTemplate
-from .BaseTopic import BaseTopic
-from .SetTopic import SetTopic
+from . import topic
 
 LOG = log.get_logger()
 
 
-class IOLinc(SetTopic, BaseTopic):
+class IOLinc(topic.SetTopic):
     """MQTT interface to an Insteon IOLinc device.
 
     This class connects to a device.IOLinc object and converts it's

--- a/insteon_mqtt/mqtt/IOLinc.py
+++ b/insteon_mqtt/mqtt/IOLinc.py
@@ -160,7 +160,7 @@ class IOLinc(BaseTopic):
         try:
             # IOLinc doesn't support modes so don't parse that element.
             is_on = util.parse_on_off(data, have_mode=False)
-            self.device.set(is_on)
+            self.device.set(is_on=is_on)
         except:
             LOG.error("Invalid IOLinc on/off command: %s", data)
 

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -172,7 +172,7 @@ class KeypadLinc(topic.SetTopic, topic.SceneTopic, topic.StateTopic,
                 if level is not None:
                     level = int(level)
                 reason = data.get("reason", "")
-                self.device.set(is_on=is_on, level=level, mode=mode, reason=reason,
-                                transition=transition)
+                self.device.set(is_on=is_on, level=level, mode=mode, 
+                                reason=reason, transition=transition)
             except:
                 LOG.error("Invalid KeypadLinc level command: %s", data)

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -6,15 +6,13 @@
 from .. import log
 from .MsgTemplate import MsgTemplate
 from . import util
-from .SceneTopic import SceneTopic
-from .StateTopic import StateTopic
-from .ManualTopic import ManualTopic
-from .SetTopic import SetTopic
+from . import topic
 
 LOG = log.get_logger()
 
 
-class KeypadLinc(SetTopic, SceneTopic, StateTopic, ManualTopic):
+class KeypadLinc(topic.SetTopic, topic.SceneTopic, topic.StateTopic,
+                 topic.ManualTopic):
     """MQTT interface to an Insteon KeypadLinc dimmer or switch.
 
     This class connects to a device.KeypadLinc object and converts it's output
@@ -136,8 +134,8 @@ class KeypadLinc(SetTopic, SceneTopic, StateTopic, ManualTopic):
 
         if self.device.is_dimmer:
             data = self.base_template_data(button=1)
-            topic = self.msg_dimmer_level.render_topic(data)
-            link.unsubscribe(topic)
+            topic_str = self.msg_dimmer_level.render_topic(data)
+            link.unsubscribe(topic_str)
 
     #-----------------------------------------------------------------------
     def _input_set_level(self, client, data, message, raise_errors=False):

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -182,8 +182,8 @@ class KeypadLinc(SceneTopic, StateTopic, ManualTopic):
             is_on, mode, transition = util.parse_on_off(data)
             level = None if is_on else 0x00
             reason = data.get("reason", "")
-            self.device.set(level, group, mode, reason=reason,
-                            transition=transition)
+            self.device.set(is_on=is_on, level=level, group=group, mode=mode,
+                            reason=reason, transition=transition)
         except:
             LOG.error("Invalid KeypadLinc on/off command: %s", data)
             if raise_errors:
@@ -218,7 +218,7 @@ class KeypadLinc(SceneTopic, StateTopic, ManualTopic):
             if level is not None:
                 level = int(level)
             reason = data.get("reason", "")
-            self.device.set(level, mode=mode, reason=reason,
+            self.device.set(is_on=is_on, level=level, mode=mode, reason=reason,
                             transition=transition)
         except:
             LOG.error("Invalid KeypadLinc level command: %s", data)

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -172,7 +172,7 @@ class KeypadLinc(topic.SetTopic, topic.SceneTopic, topic.StateTopic,
                 if level is not None:
                     level = int(level)
                 reason = data.get("reason", "")
-                self.device.set(is_on=is_on, level=level, mode=mode, 
+                self.device.set(is_on=is_on, level=level, mode=mode,
                                 reason=reason, transition=transition)
             except:
                 LOG.error("Invalid KeypadLinc level command: %s", data)

--- a/insteon_mqtt/mqtt/Modem.py
+++ b/insteon_mqtt/mqtt/Modem.py
@@ -4,11 +4,11 @@
 #
 #===========================================================================
 from .. import log
-from .SceneTopic import SceneTopic
+from . import topic
 LOG = log.get_logger()
 
 
-class Modem(SceneTopic):
+class Modem(topic.SceneTopic):
     """MQTT interface to an Insteon power line modem (PLM).
 
     This class connects to an insteon_mqtt.Modem object and allows input MQTT

--- a/insteon_mqtt/mqtt/MsgTemplate.py
+++ b/insteon_mqtt/mqtt/MsgTemplate.py
@@ -195,7 +195,7 @@ class MsgTemplate:
             return json.loads(value)
         except:
             LOG.error("Invalid JSON message %s from template %s", value,
-                          self.payload_str)
+                      self.payload_str)
             return None
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Outlet.py
+++ b/insteon_mqtt/mqtt/Outlet.py
@@ -3,17 +3,14 @@
 # MQTT On/Off outlet device
 #
 #===========================================================================
-import functools
 from .. import log
-from .. import on_off
-from .MsgTemplate import MsgTemplate
-from . import util
 from .StateTopic import StateTopic
+from .SetTopic import SetTopic
 
 LOG = log.get_logger()
 
 
-class Outlet(StateTopic):
+class Outlet(SetTopic, StateTopic):
     """MQTT interface to an Insteon on/off outlet.
 
     This class connects to a device.Outlet object and converts it's
@@ -32,12 +29,8 @@ class Outlet(StateTopic):
         """
         # Setup the Topics
         super().__init__(mqtt, device,
-                         state_topic='insteon/{{address}}/state/{{button}}')
-
-        # Input on/off command template.
-        self.msg_on_off = MsgTemplate(
-            topic='insteon/{{address}}/set/{{button}}',
-            payload='{ "cmd" : "{{value.lower()}}" }')
+                         state_topic='insteon/{{address}}/state/{{button}}',
+                         set_topic='insteon/{{address}}/set/{{button}}')
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
@@ -54,9 +47,7 @@ class Outlet(StateTopic):
 
         # Load the various topics
         self.load_state_data(data, qos)
-
-        self.msg_on_off.load_config(data, 'on_off_topic', 'on_off_payload',
-                                    qos)
+        self.load_set_data(data, qos)
 
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
@@ -73,11 +64,7 @@ class Outlet(StateTopic):
         # Create a function that will call the input callback with the right
         # group number set for each socket.
         for group in [1, 2]:
-            handler = functools.partial(self._input_on_off, group=group)
-            data = self.base_template_data(button=group)
-
-            topic = self.msg_on_off.render_topic(data)
-            link.subscribe(topic, qos, handler)
+            self.set_subscribe(link, qos, group=group)
 
     #-----------------------------------------------------------------------
     def unsubscribe(self, link):
@@ -87,44 +74,6 @@ class Outlet(StateTopic):
           link (network.Mqtt):  The MQTT network client to use.
         """
         for group in [1, 2]:
-            data = self.base_template_data(button=group)
-
-            topic = self.msg_on_off.render_topic(data)
-            link.unsubscribe(topic)
-
-    #-----------------------------------------------------------------------
-    def _input_on_off(self, client, data, message, group):
-        """Handle an input on/off change MQTT message.
-
-        This is called when we receive a message on the on/off MQTT topic
-        subscription.  Parse the message and pass the command to the Insteon
-        device.
-
-        Args:
-          client (paho.Client):  The paho mqtt client (self.link).
-          data:  Optional user data (unused).
-          message:  MQTT message - has attrs: topic, payload, qos, retain.
-        """
-        LOG.debug("Outlet btn %s message %s %s", group, message.topic,
-                  message.payload)
-
-        # Parse the input MQTT message.
-        data = self.msg_on_off.to_json(message.payload)
-        LOG.info("Outlet input command: %s", data)
-
-        try:
-            # Tell the device to update it's state.
-            is_on, mode, transition = util.parse_on_off(data)
-            if mode == on_off.Mode.RAMP or transition is not None:
-                LOG.error("Light ON/OFF at Ramp Rate not supported with "
-                          "outlets - ignoring ramp rate.")
-            if mode == on_off.Mode.RAMP:  # Not supported
-                mode = on_off.Mode.NORMAL
-            reason = data.get("reason", "")
-            level = data.get("level", None)
-            self.device.set(is_on=is_on, level=level, group=group, mode=mode,
-                            reason=reason)
-        except:
-            LOG.exception("Invalid Outlet on/off command: %s", data)
+            self.set_unsubscribe(link, group=group)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Outlet.py
+++ b/insteon_mqtt/mqtt/Outlet.py
@@ -121,8 +121,10 @@ class Outlet(StateTopic):
             if mode == on_off.Mode.RAMP:  # Not supported
                 mode = on_off.Mode.NORMAL
             reason = data.get("reason", "")
-            self.device.set(level=is_on, group=group, mode=mode, reason=reason)
+            level = data.get("level", None)
+            self.device.set(is_on=is_on, level=level, group=group, mode=mode,
+                            reason=reason)
         except:
-            LOG.error("Invalid Outlet on/off command: %s", data)
+            LOG.exception("Invalid Outlet on/off command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Outlet.py
+++ b/insteon_mqtt/mqtt/Outlet.py
@@ -4,13 +4,12 @@
 #
 #===========================================================================
 from .. import log
-from .StateTopic import StateTopic
-from .SetTopic import SetTopic
+from . import topic
 
 LOG = log.get_logger()
 
 
-class Outlet(SetTopic, StateTopic):
+class Outlet(topic.SetTopic, topic.StateTopic):
     """MQTT interface to an Insteon on/off outlet.
 
     This class connects to a device.Outlet object and converts it's

--- a/insteon_mqtt/mqtt/Remote.py
+++ b/insteon_mqtt/mqtt/Remote.py
@@ -5,12 +5,12 @@
 #===========================================================================
 from .. import log
 from .BatterySensor import BatterySensor
-from .ManualTopic import ManualTopic
+from . import topic
 
 LOG = log.get_logger()
 
 
-class Remote(BatterySensor, ManualTopic):
+class Remote(BatterySensor, topic.ManualTopic):
     """MQTT interface to an Insteon mini-remote.
 
     This class connects to a device.Remote object and converts it's output

--- a/insteon_mqtt/mqtt/SceneTopic.py
+++ b/insteon_mqtt/mqtt/SceneTopic.py
@@ -96,7 +96,7 @@ class SceneTopic(BaseTopic):
         link.unsubscribe(topic)
 
     #-----------------------------------------------------------------------
-    def _input_scene(self, client, data, message, group=0x01):
+    def _input_scene(self, client, data, message, group=None):
         """Handle an input scene MQTT message.
 
         This is called when we receive a message on the scene trigger MQTT
@@ -116,12 +116,15 @@ class SceneTopic(BaseTopic):
         try:
             # Scenes don't support modes so don't parse that element.
             is_on = util.parse_on_off(data, have_mode=False)
-            group = int(data.get('group', group))
+            if 'group' in data:
+                group = int(data.get('group'))
+            name = data.get("name", None)
             reason = data.get("reason", None)
             level = data.get("level", None)
 
             # Tell the device to trigger the scene command.
-            self.device.scene(is_on, group, reason, level)
+            self.device.scene(is_on, level=level, group=group, name=name,
+                              reason=reason)
         except:
             LOG.error("Invalid SceneTopic command: %s", data)
 

--- a/insteon_mqtt/mqtt/SetTopic.py
+++ b/insteon_mqtt/mqtt/SetTopic.py
@@ -121,7 +121,8 @@ class SetTopic(BaseTopic):
                 mode = on_off.Mode.NORMAL
             level = 0 if not is_on else None
             reason = data.get("reason", "")
-            self.device.set(level=level, group=group, mode=mode, reason=reason)
+            self.device.set(is_on=is_on, level=level, group=group, mode=mode,
+                            reason=reason)
         except:
             LOG.error("Invalid SetTopic command: %s", data)
 

--- a/insteon_mqtt/mqtt/SetTopic.py
+++ b/insteon_mqtt/mqtt/SetTopic.py
@@ -70,12 +70,11 @@ class SetTopic(BaseTopic):
         # set triggering messages.
         if group is not None:
             handler = functools.partial(self._input_set, group=group)
-            topic = self.msg_set.render_topic(
-                self.base_template_data(button=group)
-            )
         else:
             handler = self._input_set
-            topic = self.msg_set.render_topic(self.base_template_data())
+        topic = self.msg_set.render_topic(
+            self.base_template_data(button=group)
+        )
         link.subscribe(topic, qos, handler)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/SetTopic.py
+++ b/insteon_mqtt/mqtt/SetTopic.py
@@ -1,0 +1,128 @@
+#===========================================================================
+#
+# MQTT Set Topic
+#
+#===========================================================================
+import functools
+from .. import log
+from .MsgTemplate import MsgTemplate
+from . import util
+from .. import on_off
+from .BaseTopic import BaseTopic
+
+LOG = log.get_logger()
+
+
+class SetTopic(BaseTopic):
+    """MQTT interface to the Set Topic
+
+    This is an abstract class that provides support for the set topic.
+    """
+    def __init__(self, mqtt, device, set_topic=None, set_payload=None,
+                 **kwargs):
+        """Set Topic Constructor
+
+        Args:
+          mqtt (mqtt.Mqtt):  The MQTT main interface.
+          device (device):  The Insteon object to link to.
+          set_topic (str): The template for the topic
+          set_payload (str): The template for the payload
+        """
+        super().__init__(mqtt, device, **kwargs)
+        # It looks cleaner setting these long strings here rather than in the
+        # function declaration
+        if set_topic is None:
+            set_topic = 'insteon/{{address}}/set'
+        if set_payload is None:
+            set_payload = '{ "cmd" : "{{value.lower()}}" }'
+        # Input set on/off command template.
+        self.msg_set = MsgTemplate(
+            topic=set_topic,
+            payload=set_payload)
+
+    #-----------------------------------------------------------------------
+    def load_set_data(self, data, qos=None, topic=None, payload=None):
+        """Load values from a configuration data object.
+
+        Args:
+          data (dict):  The section of the config dict that applies to this
+                        class.
+          qos (int):  The default quality of service level to use.
+        """
+        if topic is None:
+            topic = 'on_off_topic'
+        if payload is None:
+            payload = 'on_off_payload'
+        # Update the MQTT topics and payloads from the config file.
+        self.msg_set.load_config(data, topic, payload, qos)
+
+    #-----------------------------------------------------------------------
+    def set_subscribe(self, link, qos, group=None):
+        """Subscribe to any MQTT topics the object needs.
+
+        Subscriptions are used when the object has things that can be
+        commanded to change.
+
+        Args:
+          link (network.Mqtt):  The MQTT network client to use.
+          qos (int):  The quality of service to use.
+        """
+        # set triggering messages.
+        if group is not None:
+            handler = functools.partial(self._input_set, group=group)
+            topic = self.msg_set.render_topic(
+                self.base_template_data(button=group)
+            )
+        else:
+            handler = self._input_set
+            topic = self.msg_set.render_topic(self.base_template_data())
+        link.subscribe(topic, qos, handler)
+
+    #-----------------------------------------------------------------------
+    def set_unsubscribe(self, link, group=None):
+        """Unsubscribe to any MQTT topics the object was subscribed to.
+
+        Args:
+          link (network.Mqtt):  The MQTT network client to use.
+        """
+        if group is not None:
+            data = self.base_template_data(button=group)
+            topic = self.msg_set.render_topic(data)
+        else:
+            topic = self.msg_set.render_topic(self.base_template_data())
+        link.unsubscribe(topic)
+
+    #-----------------------------------------------------------------------
+    def _input_set(self, client, data, message, group=0x01):
+        """Handle an input set MQTT message.
+
+        This is called when we receive a message on the set trigger MQTT
+        topic subscription.  Parse the message and pass the command to the
+        Insteon device.
+
+        Args:
+          client (paho.Client):  The paho mqtt client (self.link).
+          data:  Optional user data (unused).
+          message:  MQTT message - has attrs: topic, payload, qos, retain.
+        """
+        LOG.debug("SetTopic message %s %s", message.topic, message.payload)
+
+        # Parse the input MQTT message.
+        data = self.msg_set.to_json(message.payload)
+        LOG.info("SetTopic input command: %s", data)
+        try:
+            # Tell the device to update its state.
+            is_on, mode, transition = util.parse_on_off(data)
+            if mode == on_off.Mode.RAMP or transition is not None:
+                # This doesn't belong here!!!! Will fix
+                LOG.error("Light ON/OFF at Ramp Rate not supported with "
+                          "dimmers - ignoring ramp rate.")
+            if mode == on_off.Mode.RAMP:  # Not supported
+                mode = on_off.Mode.NORMAL
+            level = 0 if not is_on else None
+            reason = data.get("reason", "")
+            self.device.set(level=level, mode=mode, reason=reason)
+        except:
+            LOG.error("Invalid SetTopic command: %s", data)
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/SetTopic.py
+++ b/insteon_mqtt/mqtt/SetTopic.py
@@ -121,7 +121,7 @@ class SetTopic(BaseTopic):
                 mode = on_off.Mode.NORMAL
             level = 0 if not is_on else None
             reason = data.get("reason", "")
-            self.device.set(level=level, mode=mode, reason=reason)
+            self.device.set(level=level, group=group, mode=mode, reason=reason)
         except:
             LOG.error("Invalid SetTopic command: %s", data)
 

--- a/insteon_mqtt/mqtt/SetTopic.py
+++ b/insteon_mqtt/mqtt/SetTopic.py
@@ -7,7 +7,7 @@ import functools
 from .. import log
 from .MsgTemplate import MsgTemplate
 from . import util
-from .. import on_off
+# from .. import on_off
 from .BaseTopic import BaseTopic
 
 LOG = log.get_logger()
@@ -113,16 +113,10 @@ class SetTopic(BaseTopic):
         try:
             # Tell the device to update its state.
             is_on, mode, transition = util.parse_on_off(data)
-            if mode == on_off.Mode.RAMP or transition is not None:
-                # This doesn't belong here!!!! Will fix
-                LOG.error("Light ON/OFF at Ramp Rate not supported with "
-                          "dimmers - ignoring ramp rate.")
-            if mode == on_off.Mode.RAMP:  # Not supported
-                mode = on_off.Mode.NORMAL
-            level = 0 if not is_on else None
+            level = data.get("level", None)
             reason = data.get("reason", "")
             self.device.set(is_on=is_on, level=level, group=group, mode=mode,
-                            reason=reason)
+                            transition=transition, reason=reason)
         except:
             LOG.error("Invalid SetTopic command: %s", data)
 

--- a/insteon_mqtt/mqtt/Switch.py
+++ b/insteon_mqtt/mqtt/Switch.py
@@ -4,9 +4,6 @@
 #
 #===========================================================================
 from .. import log
-from .. import on_off
-from .MsgTemplate import MsgTemplate
-from . import util
 from .SceneTopic import SceneTopic
 from .StateTopic import StateTopic
 from .ManualTopic import ManualTopic

--- a/insteon_mqtt/mqtt/Switch.py
+++ b/insteon_mqtt/mqtt/Switch.py
@@ -4,15 +4,13 @@
 #
 #===========================================================================
 from .. import log
-from .SceneTopic import SceneTopic
-from .StateTopic import StateTopic
-from .ManualTopic import ManualTopic
-from .SetTopic import SetTopic
+from . import topic
 
 LOG = log.get_logger()
 
 
-class Switch(SetTopic, StateTopic, SceneTopic, ManualTopic):
+class Switch(topic.SetTopic, topic.StateTopic, topic.SceneTopic,
+             topic.ManualTopic):
     """MQTT interface to an Insteon on/off switch.
 
     This class connects to a device.Switch object and converts it's

--- a/insteon_mqtt/mqtt/Switch.py
+++ b/insteon_mqtt/mqtt/Switch.py
@@ -116,7 +116,7 @@ class Switch(StateTopic, SceneTopic, ManualTopic):
             if mode == on_off.Mode.RAMP:  # Not supported
                 mode = on_off.Mode.NORMAL
             reason = data.get("reason", "")
-            self.device.set(level=is_on, mode=mode, reason=reason)
+            self.device.set(is_on=is_on, mode=mode, reason=reason)
         except:
             LOG.error("Invalid switch on/off command: %s", data)
 

--- a/insteon_mqtt/mqtt/topic/BaseTopic.py
+++ b/insteon_mqtt/mqtt/topic/BaseTopic.py
@@ -3,7 +3,7 @@
 # MQTT Base Topic
 #
 #===========================================================================
-from .. import log
+from ... import log
 
 LOG = log.get_logger()
 

--- a/insteon_mqtt/mqtt/topic/ManualTopic.py
+++ b/insteon_mqtt/mqtt/topic/ManualTopic.py
@@ -3,8 +3,8 @@
 # MQTT Manual Topic
 #
 #===========================================================================
-from .. import log
-from .MsgTemplate import MsgTemplate
+from ... import log
+from ..MsgTemplate import MsgTemplate
 from .BaseTopic import BaseTopic
 
 LOG = log.get_logger()

--- a/insteon_mqtt/mqtt/topic/SceneTopic.py
+++ b/insteon_mqtt/mqtt/topic/SceneTopic.py
@@ -4,9 +4,9 @@
 #
 #===========================================================================
 import functools
-from .. import log
-from .MsgTemplate import MsgTemplate
-from . import util
+from ... import log
+from ..MsgTemplate import MsgTemplate
+from .. import util
 from .BaseTopic import BaseTopic
 
 LOG = log.get_logger()

--- a/insteon_mqtt/mqtt/topic/SetTopic.py
+++ b/insteon_mqtt/mqtt/topic/SetTopic.py
@@ -4,9 +4,9 @@
 #
 #===========================================================================
 import functools
-from .. import log
-from .MsgTemplate import MsgTemplate
-from . import util
+from ... import log
+from ..MsgTemplate import MsgTemplate
+from .. import util
 # from .. import on_off
 from .BaseTopic import BaseTopic
 

--- a/insteon_mqtt/mqtt/topic/StateTopic.py
+++ b/insteon_mqtt/mqtt/topic/StateTopic.py
@@ -3,9 +3,9 @@
 # MQTT State Topic
 #
 #===========================================================================
-from .. import log
-from .. import on_off
-from .MsgTemplate import MsgTemplate
+from ... import log
+from ... import on_off
+from ..MsgTemplate import MsgTemplate
 from .BaseTopic import BaseTopic
 from .ManualTopic import ManualTopic
 

--- a/insteon_mqtt/mqtt/topic/__init__.py
+++ b/insteon_mqtt/mqtt/topic/__init__.py
@@ -1,0 +1,18 @@
+#===========================================================================
+#
+# MQTT Topic Abstract classes
+#
+#===========================================================================
+# flake8: noqa
+
+__doc__ = """MQTT Topic Abstract classes.
+
+These are abstract "Topic" classes that provide support for commonly used
+topics.  They should be extended by an MQTT device object.
+"""
+
+from .BaseTopic import BaseTopic
+from .ManualTopic import ManualTopic
+from .SceneTopic import SceneTopic
+from .SetTopic import SetTopic
+from .StateTopic import StateTopic

--- a/insteon_mqtt/mqtt/util.py
+++ b/insteon_mqtt/mqtt/util.py
@@ -57,7 +57,6 @@ def parse_on_off(data, have_mode=True):
             mode = on_off.Mode.NORMAL
     else:
         mode = on_off.Mode.NORMAL
-        # These options seem to be undocumented, except for docstring above
         if data.get('fast', False):
             mode = on_off.Mode.FAST
         elif data.get('instant', False):

--- a/insteon_mqtt/mqtt/util.py
+++ b/insteon_mqtt/mqtt/util.py
@@ -9,6 +9,7 @@ from .. import log
 
 LOG = log.get_logger()
 
+
 def parse_on_off(data, have_mode=True):
     """Parse on/off JSON data from an input message payload.
 

--- a/insteon_mqtt/util.py
+++ b/insteon_mqtt/util.py
@@ -9,6 +9,7 @@ from . import log
 
 LOG = log.get_logger()
 
+
 def to_hex(data, num=None, space=' '):
     """Convert a byte array to a string of hex.
 

--- a/tests/mqtt/test_BatterySensor.py
+++ b/tests/mqtt/test_BatterySensor.py
@@ -88,9 +88,9 @@ class Test_BatterySensor:
         dev.signal_low_battery.emit(dev, True)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
-            topic='%s/low_battery' % topic, payload='off', qos=0, retain=True)
+            topic='%s/battery' % topic, payload='off', qos=0, retain=True)
         assert link.client.pub[1] == dict(
-            topic='%s/low_battery' % topic, payload='on', qos=0, retain=True)
+            topic='%s/battery' % topic, payload='on', qos=0, retain=True)
 
     #-----------------------------------------------------------------------
     def test_config(self, setup):

--- a/tests/mqtt/test_KeypadLinc.py
+++ b/tests/mqtt/test_KeypadLinc.py
@@ -88,7 +88,6 @@ class Test_KeypadLinc:
                 "insteon/%s/set/%d" % (addr.hex, i),
                 "insteon/%s/scene/%d" % (addr.hex, i),
                 ]
-
         assert len(link.client.sub) == len(topics)
         for i in range(len(topics)):
             assert link.client.sub[i] == dict(topic=topics[i], qos=2)

--- a/tests/mqtt/test_Modem.py
+++ b/tests/mqtt/test_Modem.py
@@ -56,7 +56,7 @@ class Test_Modem:
     def test_template(self, setup):
         mdev, addr, name = setup.getAll(['mdev', 'addr', 'name'])
 
-        data = mdev.template_data()
+        data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
         assert data == right
 

--- a/tests/mqtt/test_Motion.py
+++ b/tests/mqtt/test_Motion.py
@@ -107,9 +107,9 @@ class Test_Motion:
         dev.signal_low_battery.emit(dev, True)
         assert len(link.client.pub) == 2
         assert link.client.pub[0] == dict(
-            topic='%s/low_battery' % topic, payload='off', qos=0, retain=True)
+            topic='%s/battery' % topic, payload='off', qos=0, retain=True)
         assert link.client.pub[1] == dict(
-            topic='%s/low_battery' % topic, payload='on', qos=0, retain=True)
+            topic='%s/battery' % topic, payload='on', qos=0, retain=True)
 
     #-----------------------------------------------------------------------
     def test_config(self, setup):


### PR DESCRIPTION
This completes the rewrite of the MQTT code.  Things are about as condensed as they can be.  There are some oddities but not many.

Something like 600+ lines of duplicate code has now been eliminated.  The MQTT objects will all pass on the reason attribute now.  The device classes still need a good amount of work to condense them down and remove duplicate code.  When that is done, the reason command should be fully enabled.

There was a bit of yak shearing and I had to condense the device set command already.