### PR TITLE
Remove Modem Groups in Scenes File from Empty Group List

### DIFF
--- a/insteon_mqtt/Scenes.py
+++ b/insteon_mqtt/Scenes.py
@@ -381,6 +381,22 @@ class SceneManager:
         """
         # Get a list of the empty groups
         empty_groups = self.modem.db.empty_groups()
+
+        # Remove groups that are already defined in the scenes file but not
+        # synced to the modem
+        for scene in self.entries:
+            for controller in scene.controllers:
+                if (controller.device is not None and
+                        controller.device.type() == "Modem" and
+                        controller.group > 0x01):
+                    try:
+                        position = empty_groups.index(controller.group)
+                        del empty_groups[position]
+                    except ValueError:
+                        # The group was not present
+                        pass
+
+        # Now assign groups
         updated = False
         for scene in self.entries:
             for controller in scene.controllers:

--- a/tests/test_Scenes.py
+++ b/tests/test_Scenes.py
@@ -155,24 +155,30 @@ class Test_Scenes:
         # 20 is the current lowest allowed group number
         assert scenes.data[0]['controllers'][0]['modem'] == 20
 
-    def test_assign_modem_group_mulitple(self):
+    def test_assign_modem_group_multiple(self):
         modem = MockModem()
         scenes = Scenes.SceneManager(modem, None)
         scenes.data = [{'controllers': ['ff.ff.ff'],
                         'responders': ['cc.bb.22'],
                         'name': 'test'},
+                       # This entry has a group, but is not synced to modem
+                       # yet
+                       {'controllers':  [{'ff.ff.ff': {'group': 22}}],
+                        'responders': ['cc.bb.24'],
+                        'name': 'test3'},
                        {'controllers': ['ff.ff.ff'],
                         'responders': ['cc.bb.23'],
                         'name': 'test2'},
-                       {'controllers': ['ff.ff.ff'],
+                       {'controllers':  ['ff.ff.ff'],
                         'responders': ['cc.bb.24'],
                         'name': 'test3'}]
         scenes._init_scene_entries()
         scenes._assign_modem_group()
         # 20 is the current lowest allowed group number
         assert scenes.data[0]['controllers'][0]['modem'] == 20
-        assert scenes.data[1]['controllers'][0]['modem'] == 21
-        assert scenes.data[2]['controllers'][0]['modem'] == 22
+        assert scenes.data[1]['controllers'][0]['modem'] == 22
+        assert scenes.data[2]['controllers'][0]['modem'] == 21
+        assert scenes.data[3]['controllers'][0]['modem'] == 23
 
     def test_bad_config(self):
         modem = MockModem()

--- a/tests/test_Scenes.py
+++ b/tests/test_Scenes.py
@@ -12,6 +12,7 @@ import insteon_mqtt.CommandSeq as CommandSeq
 import insteon_mqtt.db.Device as Device
 import insteon_mqtt.db.DeviceEntry as DeviceEntry
 import insteon_mqtt.db.Modem as ModemDB
+import insteon_mqtt.db.ModemEntry as ModemEntry
 import insteon_mqtt.device.Base as Base
 import insteon_mqtt.device.Dimmer as Dimmer
 import insteon_mqtt.device.FanLinc as FanLinc
@@ -157,6 +158,14 @@ class Test_Scenes:
 
     def test_assign_modem_group_multiple(self):
         modem = MockModem()
+
+        # Add an existing entry to the modem
+        entry1 = ModemEntry.from_json({"addr": "cc.bb.44",
+                                       "group": 44,
+                                       "is_controller": True,
+                                       "data": [0, 0, 0]})
+        modem.db.add_entry(entry1)
+
         scenes = Scenes.SceneManager(modem, None)
         scenes.data = [{'controllers': ['ff.ff.ff'],
                         'responders': ['cc.bb.22'],
@@ -164,7 +173,12 @@ class Test_Scenes:
                        # This entry has a group, but is not synced to modem
                        # yet
                        {'controllers':  [{'ff.ff.ff': {'group': 22}}],
-                        'responders': ['cc.bb.24'],
+                        'responders': ['cc.bb.22'],
+                        'name': 'test3'},
+                       # This entry has a group, and is already synced to the
+                       # modem
+                       {'controllers':  [{'ff.ff.ff': {'group': 44}}],
+                        'responders': ['cc.bb.44'],
                         'name': 'test3'},
                        {'controllers': ['ff.ff.ff'],
                         'responders': ['cc.bb.23'],
@@ -177,8 +191,9 @@ class Test_Scenes:
         # 20 is the current lowest allowed group number
         assert scenes.data[0]['controllers'][0]['modem'] == 20
         assert scenes.data[1]['controllers'][0]['modem'] == 22
-        assert scenes.data[2]['controllers'][0]['modem'] == 21
-        assert scenes.data[3]['controllers'][0]['modem'] == 23
+        assert scenes.data[2]['controllers'][0]['modem'] == 44
+        assert scenes.data[3]['controllers'][0]['modem'] == 21
+        assert scenes.data[4]['controllers'][0]['modem'] == 23
 
     def test_bad_config(self):
         modem = MockModem()


### PR DESCRIPTION
Related to #321

A further latent bug in the functionality that I had not thought of.

- [x] Added Unit tests to verify it.