### PR TITLE
Force Checking of Msg Sent and PLM Ack

### DIFF
--- a/insteon_mqtt/handler/Base.py
+++ b/insteon_mqtt/handler/Base.py
@@ -145,6 +145,8 @@ class Base:
         # the handler again so we don't lose the count.
         # This calls protocol rather then device so that the hops count is
         # correcly set, also since we don't have the Device object here
+        self._PLM_sent = False
+        self._PLM_ACK = False
         protocol.send(self._msg, self)
 
         # Tell the protocol that we're expired.  This will end this handler

--- a/insteon_mqtt/handler/Base.py
+++ b/insteon_mqtt/handler/Base.py
@@ -56,6 +56,10 @@ class Base:
         self._num_retry = num_retry
         self._msg = None
 
+        # Track if PLM sent and if PLM ACK has arrived.
+        self._PLM_sent = False
+        self._PLM_ACK = False
+
     #-----------------------------------------------------------------------
     def set_retry_num(self, retry_num):
         """Used to set the number of retrie
@@ -81,6 +85,9 @@ class Base:
         # Save the message for a later retry if requested.
         self._num_sent += 1
         self._msg = msg
+
+        # Update flag to note sent
+        self._PLM_sent = True
 
         # Update the expiration time.
         self.update_expire_time()

--- a/insteon_mqtt/handler/BroadcastCmdResponse.py
+++ b/insteon_mqtt/handler/BroadcastCmdResponse.py
@@ -54,6 +54,9 @@ class BroadcastCmdResponse(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         # Probably an echo back of our sent message.
         if isinstance(msg, Msg.OutStandard):
             # If the message is the echo back of our message, then continue

--- a/insteon_mqtt/handler/BroadcastCmdResponse.py
+++ b/insteon_mqtt/handler/BroadcastCmdResponse.py
@@ -66,6 +66,7 @@ class BroadcastCmdResponse(Base):
                     LOG.warning("%s PLM NAK response", self.addr)
                 else:
                     LOG.debug("%s got PLM ACK", self.addr)
+                    self._PLM_ACK = True
                 return Msg.CONTINUE
 
             # Message didn't match the expected addr/cmd.
@@ -74,7 +75,7 @@ class BroadcastCmdResponse(Base):
 
         # Probably an ACK/NAK from the device for our get command.
         elif (isinstance(msg, Msg.InpStandard) and
-              msg.flags.type != Msg.Flags.Type.BROADCAST):
+              msg.flags.type != Msg.Flags.Type.BROADCAST and self._PLM_ACK):
             # Filter by address and command.
             if msg.from_addr != self.addr or msg.cmd1 != self.cmd:
                 return Msg.UNKNOWN
@@ -103,7 +104,7 @@ class BroadcastCmdResponse(Base):
 
         # Process the payload reply.
         elif (isinstance(msg, Msg.InpStandard) and
-              msg.flags.type == Msg.Flags.Type.BROADCAST):
+              msg.flags.type == Msg.Flags.Type.BROADCAST and self._PLM_ACK):
             # Filter by address and command.
             if msg.from_addr == self.addr:
                 # Run the callback - it's up to the callback to check if this

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -76,6 +76,9 @@ class DeviceDbGet(Base):
         # ok in Python>=3.5 but not 3.4.
         from .. import db  # pylint: disable=import-outside-toplevel
 
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         # Probably an echo back of our sent message.  See if the message
         # matches the address we sent to and assume it's the ACK/NAK message.
         # These seem to be either extended or standard message so allow for

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -87,12 +87,14 @@ class DeviceDbGet(Base):
             if msg.to_addr == self.db.addr and msg.cmd1 == 0x2f:
                 if not msg.is_ack:
                     LOG.warning("%s PLM NAK response", self.db.addr)
+                else:
+                    self._PLM_ACK = True
                 return Msg.CONTINUE
 
             return Msg.UNKNOWN
 
         # Probably an ACK/NAK from the device for our get command.
-        elif isinstance(msg, Msg.InpStandard):
+        elif isinstance(msg, Msg.InpStandard) and self._PLM_ACK:
             # Filter by address and command.
             if msg.from_addr != self.db.addr or msg.cmd1 != 0x2f:
                 return Msg.UNKNOWN
@@ -125,7 +127,7 @@ class DeviceDbGet(Base):
                 return Msg.UNKNOWN
 
         # Process the real reply.  Database reply is an extended messages.
-        elif isinstance(msg, Msg.InpExtended):
+        elif isinstance(msg, Msg.InpExtended) and self._PLM_ACK:
             # Filter by address and command.
             if msg.from_addr != self.db.addr or msg.cmd1 != 0x2f:
                 return Msg.UNKNOWN

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -58,6 +58,7 @@ class DeviceDbModify(Base):
             if msg.to_addr == self.db.addr and msg.cmd1 == 0x2f:
                 # ACK - command is ok - wait for ACK from device.
                 if msg.is_ack:
+                    self._PLM_ACK = True
                     return Msg.CONTINUE
 
                 # NAK - device rejected command.
@@ -66,7 +67,7 @@ class DeviceDbModify(Base):
                     self.on_done(False, "Device database update failed", None)
                     return Msg.FINISHED
 
-        elif isinstance(msg, Msg.InpStandard):
+        elif isinstance(msg, Msg.InpStandard) and self._PLM_ACK:
             # See if the message address matches our expected reply.
             if msg.from_addr == self.db.addr and msg.cmd1 == 0x2f:
                 # ACK or NAK - either way this transaction is complete.

--- a/insteon_mqtt/handler/DeviceDbModify.py
+++ b/insteon_mqtt/handler/DeviceDbModify.py
@@ -50,6 +50,9 @@ class DeviceDbModify(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         if isinstance(msg, Msg.OutExtended):
             # See if the message address matches our expected reply.
             if msg.to_addr == self.db.addr and msg.cmd1 == 0x2f:

--- a/insteon_mqtt/handler/DeviceRefresh.py
+++ b/insteon_mqtt/handler/DeviceRefresh.py
@@ -73,13 +73,15 @@ class DeviceRefresh(Base):
         if isinstance(msg, Msg.OutStandard) and msg.to_addr == self.addr:
             if msg.is_ack:
                 LOG.debug("%s PLM ACK response", self.addr)
+                self._PLM_ACK = True
                 return Msg.CONTINUE
             else:
                 LOG.warning("%s PLM NAK response", self.addr)
                 return Msg.CONTINUE
 
         # See if this is the standard message ack/nak we're expecting.
-        elif isinstance(msg, Msg.InpStandard) and msg.from_addr == self.addr:
+        elif (isinstance(msg, Msg.InpStandard) and
+              msg.from_addr == self.addr and self._PLM_ACK):
             if msg.flags.type == Msg.Flags.Type.DIRECT_ACK:
                 # All link database delta is stored in cmd1 so we if we have
                 # the latest version.  If not, schedule an update.

--- a/insteon_mqtt/handler/DeviceRefresh.py
+++ b/insteon_mqtt/handler/DeviceRefresh.py
@@ -66,6 +66,9 @@ class DeviceRefresh(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         # Probably an echo back of our sent message.
         if isinstance(msg, Msg.OutStandard) and msg.to_addr == self.addr:
             if msg.is_ack:

--- a/insteon_mqtt/handler/ExtendedCmdResponse.py
+++ b/insteon_mqtt/handler/ExtendedCmdResponse.py
@@ -64,6 +64,9 @@ class ExtendedCmdResponse(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         # Probably an echo back of our sent message.  See if the message
         # matches the address we sent to and assume it's the ACK/NAK message.
         # These seem to be either extended or standard message so allow for

--- a/insteon_mqtt/handler/ExtendedCmdResponse.py
+++ b/insteon_mqtt/handler/ExtendedCmdResponse.py
@@ -75,12 +75,15 @@ class ExtendedCmdResponse(Base):
             if msg.to_addr == self.addr and msg.cmd1 == self.cmd:
                 if not msg.is_ack:
                     LOG.warning("%s PLM NAK response", self.addr)
+                else:
+                    LOG.debug("%s PLM ACK", self.addr)
+                    self._PLM_ACK = True
                 return Msg.CONTINUE
 
             return Msg.UNKNOWN
 
         # Probably an ACK/NAK from the device for our get command.
-        elif isinstance(msg, Msg.InpStandard):
+        elif isinstance(msg, Msg.InpStandard) and self._PLM_ACK:
             # Filter by address and command.
             if msg.from_addr != self.addr or msg.cmd1 != self.cmd:
                 return Msg.UNKNOWN
@@ -110,7 +113,7 @@ class ExtendedCmdResponse(Base):
                 return Msg.UNKNOWN
 
         # Process the payload reply.
-        elif isinstance(msg, Msg.InpExtended):
+        elif isinstance(msg, Msg.InpExtended) and self._PLM_ACK:
             # Filter by address and command.
             if msg.from_addr == self.addr and msg.cmd1 == self.cmd:
                 # Run the callback - it's up to the callback to check if this

--- a/insteon_mqtt/handler/ModemDbGet.py
+++ b/insteon_mqtt/handler/ModemDbGet.py
@@ -72,10 +72,11 @@ class ModemDbGet(Base):
                 return Msg.FINISHED
 
             # ACK - keep reading until we get the record we requested.
+            self._PLM_ACK = True
             return Msg.CONTINUE
 
         # Message is the record we requested.
-        if isinstance(msg, Msg.InpAllLinkRec):
+        if isinstance(msg, Msg.InpAllLinkRec) and self._PLM_ACK:
             LOG.info("Adding modem db record for %s grp: %s", msg.addr,
                      msg.group)
             if not msg.db_flags.in_use:

--- a/insteon_mqtt/handler/ModemDbGet.py
+++ b/insteon_mqtt/handler/ModemDbGet.py
@@ -93,6 +93,8 @@ class ModemDbGet(Base):
             # Request the next record in the PLM database.
             LOG.info("Modem requesting next db record")
             msg = Msg.OutAllLinkGetNext()
+            self._PLM_sent = False
+            self._PLM_ACK = False
             self.db.device.send(msg, self)
 
             # Return finished - this way the getnext message will go out.

--- a/insteon_mqtt/handler/ModemDbGet.py
+++ b/insteon_mqtt/handler/ModemDbGet.py
@@ -56,6 +56,9 @@ class ModemDbGet(Base):
         # ok in Python>=3.5 but not 3.4.
         from .. import db    # pylint: disable=import-outside-toplevel
 
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         # Message is an ACK/NAK of the record request.
         if isinstance(msg, (Msg.OutAllLinkGetFirst, Msg.OutAllLinkGetNext)):
             # If we get a NAK, then there are no more db records.

--- a/insteon_mqtt/handler/ModemDbModify.py
+++ b/insteon_mqtt/handler/ModemDbModify.py
@@ -123,6 +123,8 @@ class ModemDbModify(Base):
                 self.is_retry = True
 
                 # Send the message.
+                self._PLM_sent = False
+                self._PLM_ACK = False
                 self.db.device.send(msg, self)
 
             elif (msg.cmd == Msg.OutAllLinkUpdate.Cmd.ADD_RESPONDER or
@@ -151,6 +153,8 @@ class ModemDbModify(Base):
                 self.is_retry = True
 
                 # Send the message.
+                self._PLM_sent = False
+                self._PLM_ACK = False
                 self.db.device.send(msg, self)
 
             # No matter what, all these messages are finished.
@@ -189,6 +193,9 @@ class ModemDbModify(Base):
         if self.next:
             LOG.info("Sending next modem db update")
             msg, self.entry = self.next.pop(0)
+            # Reset the PLM Flags
+            self._PLM_ACK = False
+            self._PLM_sent = False
             self.db.device.send(msg, self)
 
         # Only run the callback if this is the last message in the chain.

--- a/insteon_mqtt/handler/ModemDbModify.py
+++ b/insteon_mqtt/handler/ModemDbModify.py
@@ -81,6 +81,10 @@ class ModemDbModify(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
+
         # Not a message for us.
         if not isinstance(msg, Msg.OutAllLinkUpdate):
             return Msg.UNKNOWN

--- a/insteon_mqtt/handler/ModemDbSearch.py
+++ b/insteon_mqtt/handler/ModemDbSearch.py
@@ -62,6 +62,9 @@ class ModemDbSearch(Base):
         # ok in Python>=3.5 but not 3.4.
         from .. import db    # pylint: disable=import-outside-toplevel
 
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         # Message is an ACK/NAK of the record request.
         if (isinstance(msg, (Msg.OutAllLinkUpdate)) and
                 msg.cmd in (Msg.OutAllLinkUpdate.Cmd.EXISTS,

--- a/insteon_mqtt/handler/ModemDbSearch.py
+++ b/insteon_mqtt/handler/ModemDbSearch.py
@@ -80,10 +80,11 @@ class ModemDbSearch(Base):
                 return Msg.FINISHED
 
             # ACK - keep reading until we get the record we requested.
+            self._PLM_ACK = True
             return Msg.CONTINUE
 
         # Message is the record we requested.
-        if isinstance(msg, Msg.InpAllLinkRec):
+        if isinstance(msg, Msg.InpAllLinkRec) and self._PLM_ACK:
             LOG.info("Adding modem db record for %s grp: %s", msg.addr,
                      msg.group)
             # Create a modem database entry from the message data

--- a/insteon_mqtt/handler/ModemDbSearch.py
+++ b/insteon_mqtt/handler/ModemDbSearch.py
@@ -104,6 +104,8 @@ class ModemDbSearch(Base):
             msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.SEARCH,
                                        db_flags, entry.group, entry.addr,
                                        bytes(3))
+            self._PLM_sent = False
+            self._PLM_ACK = False
             self.db.device.send(msg, self)
 
             # Return finished - this way the getnext message will go out.

--- a/insteon_mqtt/handler/ModemInfo.py
+++ b/insteon_mqtt/handler/ModemInfo.py
@@ -42,6 +42,9 @@ class ModemInfo(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         if isinstance(msg, (Msg.OutModemInfo)):
             if msg.is_ack:
                 self.on_done(True, "Modem get info success", msg)

--- a/insteon_mqtt/handler/ModemLinkStart.py
+++ b/insteon_mqtt/handler/ModemLinkStart.py
@@ -41,6 +41,9 @@ class ModemLinkStart(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         if not isinstance(msg, Msg.OutModemLinking):
             return Msg.UNKNOWN
 

--- a/insteon_mqtt/handler/ModemScene.py
+++ b/insteon_mqtt/handler/ModemScene.py
@@ -75,11 +75,16 @@ class ModemScene(Base):
         # We should get an initial ack of the scene message
         if isinstance(msg, Msg.OutModemScene):
             if msg.is_ack:
+                self._PLM_ACK = True
                 return Msg.CONTINUE
 
             # NAK - modem not connected?
             self.on_done(False, "Scene command failed", None)
             return Msg.FINISHED
+
+        # Make sure we have PLM ACK before proceeding
+        elif not self._PLM_ACK:
+            return Msg.UNKNOWN
 
         # Next we should get cleanup_acks from each device
         elif (isinstance(msg, Msg.InpStandard) and

--- a/insteon_mqtt/handler/ModemScene.py
+++ b/insteon_mqtt/handler/ModemScene.py
@@ -69,6 +69,9 @@ class ModemScene(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         # We should get an initial ack of the scene message
         if isinstance(msg, Msg.OutModemScene):
             if msg.is_ack:

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -78,6 +78,7 @@ class StandardCmd(Base):
                     LOG.warning("%s PLM NAK response", self.addr)
                 else:
                     LOG.debug("%s got PLM ACK", self.addr)
+                    self._PLM_ACK = True
                 return Msg.CONTINUE
 
             # Message didn't match the expected addr/cmd.
@@ -85,7 +86,7 @@ class StandardCmd(Base):
             return Msg.UNKNOWN
 
         # See if this is the standard message ack/nak we're expecting.
-        elif isinstance(msg, Msg.InpStandard):
+        elif isinstance(msg, Msg.InpStandard) and self._PLM_ACK:
             # If this message matches our address and command, it's probably
             # the ACK we're expecting.
             if msg.from_addr == self.addr and msg.cmd1 == self.cmd:

--- a/insteon_mqtt/handler/StandardCmd.py
+++ b/insteon_mqtt/handler/StandardCmd.py
@@ -66,6 +66,9 @@ class StandardCmd(Base):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         # Probably an echo back of our sent message.
         if isinstance(msg, Msg.OutStandard):
             # If the message is the echo back of our message, then continue

--- a/insteon_mqtt/handler/StandardCmdNAK.py
+++ b/insteon_mqtt/handler/StandardCmdNAK.py
@@ -49,6 +49,7 @@ class StandardCmdNAK(StandardCmd):
                     LOG.warning("%s PLM NAK response", self.addr)
                 else:
                     LOG.debug("%s got PLM ACK", self.addr)
+                    self._PLM_ACK = True
                 return Msg.CONTINUE
 
             # Message didn't match the expected addr/cmd.
@@ -56,7 +57,7 @@ class StandardCmdNAK(StandardCmd):
             return Msg.UNKNOWN
 
         # See if this is the standard message ack/nak we're expecting.
-        elif isinstance(msg, Msg.InpStandard):
+        elif isinstance(msg, Msg.InpStandard) and self._PLM_ACK:
             # If this message matches our address and command, it's probably
             # the ACK we're expecting.
             if msg.from_addr == self.addr and msg.cmd1 == self.cmd:

--- a/insteon_mqtt/handler/StandardCmdNAK.py
+++ b/insteon_mqtt/handler/StandardCmdNAK.py
@@ -37,6 +37,9 @@ class StandardCmdNAK(StandardCmd):
           Msg.CONTINUE if we handled the message and expect more.
           Msg.FINISHED if we handled the message and are done.
         """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
         # Probably an echo back of our sent message.
         if isinstance(msg, Msg.OutStandard):
             # If the message is the echo back of our message, then continue

--- a/tests/handler/test_BroadcastCmdResponse.py
+++ b/tests/handler/test_BroadcastCmdResponse.py
@@ -21,6 +21,8 @@ class Test_BroadcastCmdResponse:
         # sent message, match input command
         out = Msg.OutStandard.direct(addr, 0x10, 0x00)
         handler = IM.handler.BroadcastCmdResponse(out, callback)
+        handler._PLM_sent = True
+        handler._PLM_ACK = True
 
         r = handler.msg_received(proto, "dummy")
         assert r == Msg.UNKNOWN
@@ -98,6 +100,35 @@ class Test_BroadcastCmdResponse:
         r = handler.msg_received(proto, msg)
         assert r == Msg.UNKNOWN
 
+    def test_plm_sent_ack(self):
+        # Tests matching the command from the outbound message.
+        proto = MockProto()
+        calls = []
+
+        def callback(msg, on_done=None):
+            calls.append(msg)
+
+        addr = IM.Address('0a.12.34')
+
+        # sent message, match input command
+        out = Msg.OutStandard.direct(addr, 0x10, 0x00)
+        handler = IM.handler.BroadcastCmdResponse(out, callback)
+
+        # test not sent
+        out.is_ack = True
+        r = handler.msg_received(proto, out)
+        assert r == Msg.UNKNOWN
+        assert not handler._PLM_sent
+
+        # Signal Sent
+        handler.sending_message(out)
+        assert handler._PLM_sent
+
+        # test ack sent
+        out.is_ack = True
+        r = handler.msg_received(proto, out)
+        assert r == Msg.CONTINUE
+        assert handler._PLM_ACK
 
 #===========================================================================
 

--- a/tests/handler/test_StandardCmd.py
+++ b/tests/handler/test_StandardCmd.py
@@ -21,6 +21,8 @@ class Test_StandardCmd:
         # sent message, match input command
         out = Msg.OutStandard.direct(addr, 0x11, 0xff)
         handler = IM.handler.StandardCmd(out, callback)
+        handler._PLM_sent = True
+        handler._PLM_ACK = True
 
         r = handler.msg_received(proto, "dummy")
         assert r == Msg.UNKNOWN
@@ -83,6 +85,8 @@ class Test_StandardCmd:
         # sent message, match input command
         out = Msg.OutStandard.direct(addr, 0x11, 0xff)
         handler = IM.handler.StandardCmd(out, callback)
+        handler._PLM_sent = True
+        handler._PLM_ACK = True
 
         # right cmd
         r = handler.msg_received(proto, out)
@@ -117,6 +121,8 @@ class Test_StandardCmd:
         # sent message, match input command
         out = Msg.OutStandard.direct(addr, 0x11, 0x00)
         handler = IM.handler.StandardCmd(out, callback)
+        handler._PLM_sent = True
+        handler._PLM_ACK = True
 
         r = handler.msg_received(proto, out)
         assert r == Msg.CONTINUE
@@ -131,6 +137,41 @@ class Test_StandardCmd:
         assert r == Msg.FINISHED
         assert len(calls) == 1
         assert calls[0] == msg
+
+    #-----------------------------------------------------------------------
+    def test_plm_sent_ack(self, tmpdir):
+        proto = MockProto()
+        modem = MockModem(tmpdir)
+        calls = []
+        addr = IM.Address('0a.12.34')
+        device = IM.device.Base(proto, modem, addr)
+
+        def callback(success, msg, data):
+            calls.append(msg)
+
+        # test PLM_sent flag
+        out = Msg.OutStandard.direct(addr, 0x0D, 0x00)
+        handler = IM.handler.StandardCmd(out, device.handle_engine, callback)
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x0D, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+        assert not handler._PLM_sent
+
+        # Signal Sent
+        handler.sending_message(out)
+        assert handler._PLM_sent
+
+        # test PLM nak
+        r = handler.msg_received(proto, out)
+        assert r == Msg.CONTINUE
+        assert not handler._PLM_ACK
+
+        # test PLM ack
+        out.is_ack = True
+        r = handler.msg_received(proto, out)
+        assert r == Msg.CONTINUE
+        assert handler._PLM_ACK
 
     #-----------------------------------------------------------------------
     def test_engine_version(self, tmpdir):
@@ -149,6 +190,8 @@ class Test_StandardCmd:
         handler = IM.handler.StandardCmd(out, device.handle_engine, callback)
         flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
         msg = Msg.InpStandard(addr, addr, flags, 0x0D, 0x00)
+        handler._PLM_sent = True
+        handler._PLM_ACK = True
         r = handler.msg_received(proto, msg)
         assert r == Msg.FINISHED
         assert calls[0] == "Operation complete"


### PR DESCRIPTION
This fixes #260 

This adds two flags to all handlers
 - `_PLM_sent` is false by default and is marked true when `sending_message()` is called.
 - `_PLM_ACK` is initially false and is marked true whenever a matching PLM Ack is received after _PLM_sent is true.

All handlers were updated with logic that requires `_PLM_sent` to be true before handing any message, they return `Msg.UNKNOWN` otherwise.  Handlers that process messages beyond the simple PLM ACK message require receiving a PLM Ack before that further processing can occur.  Again, these messages will return `Msg.UNKNOWN` prior to that.

 - [x] Updated Unit Test
 - [x] Added new tests to check that this functions as expected in each handler.
 - [x] Will run locally for a few days and look for issues