### PR TITLE
Refactor Device Classes - Set, On, Off, Set_State, Handle_Ack Functions

### DIFF
--- a/insteon_mqtt/device/BatterySensor.py
+++ b/insteon_mqtt/device/BatterySensor.py
@@ -176,7 +176,7 @@ class BatterySensor(functions.State, Base):
         else:
             LOG.info("BatterySensor %s on_off broadcast cmd: %s", self.addr,
                      msg.cmd1)
-            self._set_state(is_on=msg.cmd1 == Msg.CmdType.ON)
+            self._set_state(is_on=(msg.cmd1 == Msg.CmdType.ON))
             self.update_linked_devices(msg)
 
     #-----------------------------------------------------------------------
@@ -239,7 +239,7 @@ class BatterySensor(functions.State, Base):
 
         # Current on/off level is stored in cmd2 so update our state
         # to match.
-        self._set_state(is_on=msg.cmd2 != 0x00)
+        self._set_state(is_on=(msg.cmd2 != 0x00))
 
     #-----------------------------------------------------------------------
     def awake(self, on_done):

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -75,7 +75,7 @@ class Dimmer(functions.Scene, functions.SetAndState, Base):
         self.group_map.update({0x01: self.handle_on_off})
 
     #-----------------------------------------------------------------------
-    def cmd_on_values(self, mode, level, transition):
+    def cmd_on_values(self, mode, level, transition, group):
         """Calculate Cmd Values for On
 
         Args:

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -85,8 +85,9 @@ class Dimmer(functions.Scene, functions.SetAndState, Base):
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
         if level is None:
             # Not specified - choose brightness as pressing the button would do
             if mode == on_off.Mode.FAST:

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -18,7 +18,7 @@ from .. import util
 LOG = log.get_logger()
 
 
-class Dimmer(functions.State, functions.Scene, functions.Set, Base):
+class Dimmer(functions.Scene, functions.SetAndState, Base):
     """Insteon dimmer device.
 
     This class can be used to model any device that acts like a dimmer

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -218,8 +218,9 @@ class EZIO4O(functions.SetAndState, Base):
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
         if level:
             LOG.error("Device %s does not support level.", self.addr)
         cmd1 = 0x45
@@ -236,8 +237,9 @@ class EZIO4O(functions.SetAndState, Base):
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
         cmd1 = 0x46
         cmd2 = group - 1
         return (cmd1, cmd2)

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -615,15 +615,16 @@ class EZIO4O(functions.SetAndState, Base):
                         msg.cmd1)
 
     #-----------------------------------------------------------------------
-    def _cache_state(self, group, is_on, level):
+    def _cache_state(self, group, is_on, level, reason):
         """Cache the State of the Device
 
-        Used to help with the KPL unique functions.
+        Used to help with the EZIO unique functions.
 
         Args:
           group (int): The group which this applies
           is_on (bool): Whether the device is on.
           level (int): The new device level in the range [0,255].  0 is off.
+          reason (str): Reason string to pass around.
         """
         self._is_on[group - 1] = is_on
 

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -58,7 +58,7 @@ EZIO4xx_flags = {
 }
 
 
-class EZIO4O(functions.Set, Base):
+class EZIO4O(functions.SetAndState, Base):
     """Smartenit EZIO4O - 4 relay output device.
 
     This class can be used to model the EZIO4O device which has 4 outputs.

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -215,6 +215,8 @@ class EZIO4O(functions.SetAndState, Base):
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           level (int): On level between 0-255.
           transition (int): Ramp rate for the transition in seconds.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """
@@ -234,6 +236,8 @@ class EZIO4O(functions.SetAndState, Base):
         Args:
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           transition (int): Ramp rate for the transition in seconds.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -545,8 +545,11 @@ class EZIO4O(functions.SetAndState, Base):
           is_on (bool): Is the device on.
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           level (int): On level between 0-255.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
         """
         # Default Returns
+        group = None
         is_on = None
         level = None
         mode = on_off.Mode.NORMAL
@@ -572,7 +575,7 @@ class EZIO4O(functions.SetAndState, Base):
             # Update the requested group as part of normal set process
             is_on = bool(util.bit_get(cmd2, group))
 
-        return (is_on, level, mode)
+        return (is_on, level, mode, group)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, msg):

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -180,26 +180,6 @@ class EZIO4O(functions.SetAndState, Base):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-<<<<<<< HEAD
-        LOG.info("EZIO4O %s grp: %s cmd: on", self.label, group)
-        assert 1 <= group <= 4
-        assert isinstance(mode, on_off.Mode)
-
-        if transition or mode == on_off.Mode.RAMP:
-            LOG.error("Device %s does not support transition.", self.addr)
-            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
-
-        # Use a standard message to send "output on" (0x45) command for the
-        # output
-        msg = Msg.OutStandard.direct(self.addr, 0x45, group - 1)
-
-        # Use the standard command handler which will notify us when
-        # the command is ACK'ed.
-        callback = functools.partial(self.handle_ack, reason=reason)
-        msg_handler = handler.StandardCmd(msg, callback, on_done)
-
-=======
->>>>>>> Move EZIO4O to SetAndState; Remove Weird Functions Wrap Instead
         # See __init__ code comments for what this is for.
         self._which_output.append(group)
         super().on(group=group, level=level, mode=mode, reason=reason,
@@ -222,20 +202,10 @@ class EZIO4O(functions.SetAndState, Base):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-<<<<<<< HEAD
-        LOG.info("EZIO4O %s grp: %s cmd: off", self.label, group)
-        assert 1 <= group <= 4
-        assert isinstance(mode, on_off.Mode)
-
-        if transition or mode == on_off.Mode.RAMP:
-            LOG.error("Device %s does not support transition.", self.addr)
-            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
-=======
         # See __init__ code comments for what this is for.
         self._which_output.append(group)
         super().off(group=group, mode=mode, reason=reason,
                     transition=transition, on_done=on_done)
->>>>>>> Move EZIO4O to SetAndState; Remove Weird Functions Wrap Instead
 
     #-----------------------------------------------------------------------
     def cmd_on_values(self, mode, level, transition, group):

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -710,7 +710,8 @@ class IOLinc(functions.SetAndState, Base):
         # This state is for the relay.
         LOG.debug("IOLinc %s ACK: %s", self.addr, msg)
         reason = reason if reason else on_off.REASON_COMMAND
-        self._set_state(group=GROUP_RELAY, reason=reason, is_on=msg.cmd1 == 0x11)
+        self._set_state(group=GROUP_RELAY, reason=reason,
+                        is_on=msg.cmd1 == 0x11)
         on_done(True, "IOLinc command complete", None)
 
     #-----------------------------------------------------------------------
@@ -762,7 +763,8 @@ class IOLinc(functions.SetAndState, Base):
                     is_on = True
                 else:
                     is_on = False
-            self._set_state(group=GROUP_RELAY, is_on=is_on, reason=on_off.REASON_SCENE)
+            self._set_state(group=GROUP_RELAY, is_on=is_on,
+                            reason=on_off.REASON_SCENE)
         else:
             LOG.warning("IOLinc %s unknown group cmd %#04x", self.addr,
                         msg.cmd1)
@@ -794,7 +796,8 @@ class IOLinc(functions.SetAndState, Base):
                          self.label, self.momentary_secs)
                 self._momentary_call = \
                     self.modem.timed_call.add(run_time, self._set_state,
-                                              False, group=GROUP_RELAY, reason=reason,
+                                              False, group=GROUP_RELAY,
+                                              reason=reason,
                                               momentary=True)
             elif not is_on and self._momentary_call:
                 if self.modem.timed_call.remove(self._momentary_call):

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -18,7 +18,7 @@ from .. import util
 LOG = log.get_logger()
 
 
-class IOLinc(functions.Set, Base):
+class IOLinc(functions.SetAndState, Base):
     """Insteon IOLinc relay/sensor device.
 
     This class can be used to model the IOLinc device which has a sensor and

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -1534,7 +1534,7 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
                         msg.cmd1)
 
     #-----------------------------------------------------------------------
-    def _cache_state(self, group, is_on, level):
+    def _cache_state(self, group, is_on, level, reason):
         """Cache the State of the Device
 
         Used to help with the KPL unique functions.
@@ -1543,6 +1543,7 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
           group (int): The group which this applies
           is_on (bool): Whether the device is on.
           level (int): The new device level in the range [0,255].  0 is off.
+          reason (str): Reason string to pass around.
         """
         if is_on is not None:
             self._is_on = is_on

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -892,7 +892,8 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
 
         # Use the standard command handler which will notify us when the
         # command is ACK'ed.
-        callback = functools.partial(self.handle_ack_task, task="Button ramp rate")
+        callback = functools.partial(self.handle_ack_task,
+                                     task="Button ramp rate")
         msg_handler = handler.StandardCmd(msg, callback, on_done)
         self.send(msg, msg_handler)
 

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -288,7 +288,40 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
         return (cmd1, cmd2)
 
     #-----------------------------------------------------------------------
-    def on(self, group=0x01, level=None, mode=on_off.Mode.NORMAL, reason="",
+    def set(self, is_on=None, level=None, group=0x00, mode=on_off.Mode.NORMAL,
+            reason="", transition=None, on_done=None):
+        """Turn the device on or off.  Level zero will be off.
+
+        NOTE: This does NOT simulate a button press on the device - it just
+        changes the state of the device.  It will not trigger any responders
+        that are linked to this device.  To simulate a button press, call the
+        scene() method.
+
+        This will send the command to the device to update it's state.  When
+        we get an ACK of the result, we'll change our internal state and emit
+        the state changed signals.
+
+        Args:
+          is_on (bool): True to turn on, False for off
+          level (int): If non zero, turn the device on.  Should be in the
+                range 0 to 255.  If None, use default on-level.
+          group (int): The group to send the command to. If the group is 0,
+                it will always be the load (whether it's attached or not).
+                Otherwise it must be in the range [1,8] and controls the
+                specific button.
+          mode (on_off.Mode): The type of command to send (normal, fast, etc).
+          reason (str):  This is optional and is used to identify why the
+                 command was sent. It is passed through to the output signal
+                 when the state changes - nothing else is done with it.
+          transition (int): The transition ramp_rate if supported.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        super().set(is_on=is_on, level=level, group=group, mode=mode,
+                    reason=reason, transition=transition, on_done=on_done)
+
+    #-----------------------------------------------------------------------
+    def on(self, group=0x00, level=None, mode=on_off.Mode.NORMAL, reason="",
            transition=None, on_done=None):
         """Turn the device on.
 
@@ -296,7 +329,10 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
         a few unique KPL functions.
 
         Args:
-          group (int):  The group to send the command to.
+          group (int):  The group to send the command to.  If the group is 0,
+                it will always be the load (whether it's attached or not).
+                Otherwise it must be in the range [1,8] and controls the
+                specific button.
           level (int):  If non-zero, turn the device on.  The API is an int
                 to keep a consistent API with other devices.
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
@@ -319,7 +355,7 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
                        transition=transition, on_done=on_done)
 
     #-----------------------------------------------------------------------
-    def off(self, group=0x01, mode=on_off.Mode.NORMAL, reason="",
+    def off(self, group=0x00, mode=on_off.Mode.NORMAL, reason="",
             transition=None, on_done=None):
         """Turn the device off.
 
@@ -327,7 +363,10 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
         a few unique KPL functions.
 
         Args:
-          group (int):  The group to send the command to.
+          group (int):  The group to send the command to.  If the group is 0,
+                it will always be the load (whether it's attached or not).
+                Otherwise it must be in the range [1,8] and controls the
+                specific button.
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           transition (int): Transition time in seconds if supported.
           reason (str):  This is optional and is used to identify why the

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -80,8 +80,6 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
         # Remote (mqtt) commands mapped to methods calls.  Add to the base
         # class defined commands.
         self.cmd_map.update({
-            'on' : self.on,
-            'off' : self.off,
             'set_flags' : self.set_flags,
             'set_button_led' : self.set_button_led,
             'set_load_attached' : self.set_load_attached,
@@ -1513,15 +1511,18 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
                         msg.cmd1)
 
     #-----------------------------------------------------------------------
-    def _set_level(self, group, level):
-        """Save the Level of the Device
+    def _cache_state(self, group, is_on, level):
+        """Cache the State of the Device
 
         Used to help with the KPL unique functions.
 
         Args:
           group (int): The group which this applies
+          is_on (bool): Whether the device is on.
           level (int): The new device level in the range [0,255].  0 is off.
         """
+        if is_on is not None:
+            self._is_on = is_on
         group = 0x01 if group is None else group
         if group == self._load_group:
             self._level = level

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -1164,7 +1164,7 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
 
         # Current load group level is stored in cmd2 so update our level to
         # match.
-        self._set_state(button=self._load_group, level=msg.cmd2,
+        self._set_state(group=self._load_group, level=msg.cmd2,
                         reason=on_off.REASON_REFRESH)
 
     #-----------------------------------------------------------------------
@@ -1202,7 +1202,7 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
                "{:08b}".format(self._led_bits))
 
         # Change the level and emit the active signal.
-        self._set_state(button=group, level=0xff if is_on else 0x00,
+        self._set_state(group=group, level=0xff if is_on else 0x00,
                         reason=reason)
 
         msg = "KeypadLinc %s LED group %s updated to %s" % \
@@ -1261,7 +1261,7 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
 
             LOG.debug("Btn %d old: %d new %d", i + 1, is_on, was_on)
             if is_on != was_on:
-                self._set_state(button=i + 1, level=0xff if is_on else 0x00,
+                self._set_state(group=i + 1, level=0xff if is_on else 0x00,
                                 reason=reason)
 
         self._led_bits = led_bits
@@ -1371,11 +1371,11 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
                         # Pressing on again when already at the default on
                         # level causes the device to go to full-brightness.
                         level = 0xff
-                self._set_state(button=msg.group, level=level, mode=mode,
+                self._set_state(group=msg.group, level=level, mode=mode,
                                 reason=reason)
 
             else:
-                self._set_state(button=msg.group, level=0x00, mode=mode,
+                self._set_state(group=msg.group, level=0x00, mode=mode,
                                 reason=reason)
 
         # Starting or stopping manual increment (cmd2 0x00=up, 0x01=down)
@@ -1392,11 +1392,11 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
                 # Switches change state when the switch is held.
                 if not self.is_dimmer:
                     if manual == on_off.Manual.UP:
-                        self._set_state(button=self._load_group, level=0xff,
+                        self._set_state(group=self._load_group, level=0xff,
                                         mode=on_off.Mode.MANUAL,
                                         reason=reason)
                     elif manual == on_off.Manual.DOWN:
-                        self._set_state(button=self._load_group, level=0x00,
+                        self._set_state(group=self._load_group, level=0x00,
                                         mode=on_off.Mode.MANUAL,
                                         reason=reason)
 
@@ -1434,7 +1434,7 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
         # Add the delta and bound at [0, 255]
         level = min(self._level + delta, 255)
         level = max(level, 0)
-        self._set_state(button=self._load_group, level=level, reason=reason)
+        self._set_state(group=self._load_group, level=level, reason=reason)
 
         s = "KeypadLinc %s state updated to %s" % (self.addr, self._level)
         on_done(True, s, msg.cmd2)
@@ -1478,20 +1478,20 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
             if self.is_dimmer and is_on and localGroup == self._load_group:
                 level = entry.data[0]
 
-            self._set_state(button=localGroup, level=level, mode=mode,
+            self._set_state(group=localGroup, level=level, mode=mode,
                             reason=reason)
 
         # Increment up 1 unit which is 8 levels.
         elif msg.cmd1 == 0x15:
             assert localGroup == self._load_group
-            self._set_state(button=localGroup, level=min(0xff,
+            self._set_state(group=localGroup, level=min(0xff,
                                                          self._level + 8),
                             reason=reason)
 
         # Increment down 1 unit which is 8 levels.
         elif msg.cmd1 == 0x16:
             assert msg.group == self._load_group
-            self._set_state(button=localGroup, level=max(0x00,
+            self._set_state(group=localGroup, level=max(0x00,
                                                          self._level - 8),
                             reason=reason)
 

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -19,7 +19,7 @@ LOG = log.get_logger()
 
 
 #===========================================================================
-class KeypadLinc(functions.State, functions.Set, functions.Scene, Base):
+class KeypadLinc(functions.SetAndState, functions.Scene, Base):
     """Insteon KeypadLinc dimmer/switch device.
 
     This class can be used to model a 6 or 8 button KeypadLinc with dimming

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -239,12 +239,14 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           level (int): On level between 0-255.
           transition (int): Ramp rate for the transition in seconds.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """
         if not self.is_dimmer:
             level = 0xff
-        # TODO this is direclty copied from Dimmer, would be better to have
+        # TODO this is directly copied from Dimmer, would be better to have
         # this as shared code.
         elif level is None:
             # Not specified - choose brightness as pressing the button would do
@@ -274,6 +276,8 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
         Args:
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           transition (int): Ramp rate for the transition in seconds.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """
@@ -317,7 +321,7 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
     #-----------------------------------------------------------------------
     def off(self, group=0x01, mode=on_off.Mode.NORMAL, reason="",
             transition=None, on_done=None):
-        """Turn the device on.
+        """Turn the device off.
 
         This is a wrapper around the SetAndState functions class, that adds
         a few unique KPL functions.

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -57,8 +57,6 @@ class Outlet(functions.SetAndState, Base):
         # Remote (mqtt) commands mapped to methods calls.  Add to the
         # base class defined commands.
         self.cmd_map.update({
-            'on' : self.on,
-            'off' : self.off,
             'set_flags' : self.set_flags,
             })
 
@@ -74,6 +72,9 @@ class Outlet(functions.SetAndState, Base):
         # Can the outlet really act as a controller?
         self.group_map.update({0x01: self.handle_on_off,
                                0x02: self.handle_on_off})
+
+        # List of responder group numbers
+        self.responder_groups = [0x01, 0x02]
 
     #-----------------------------------------------------------------------
     def refresh(self, force=False, on_done=None):
@@ -136,36 +137,22 @@ class Outlet(functions.SetAndState, Base):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        LOG.info("Outlet %s grp: %s cmd: on", group, self.addr)
-        assert 1 <= group <= 2
-        assert isinstance(mode, on_off.Mode)
-
-        if transition or mode == on_off.Mode.RAMP:
-            LOG.error("Device %s does not support transition.", self.addr)
-            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
-
-        # Send the requested on code value.
-        cmd1 = on_off.Mode.encode(True, mode)
-
-        # Top outlet uses a standard message
-        if group == 1:
-            msg = Msg.OutStandard.direct(self.addr, cmd1, 0xff)
-
-        # Bottom outlet uses an extended message
-        else:
-            data = bytes([0x02] + [0x00] * 13)
-            msg = Msg.OutExtended.direct(self.addr, cmd1, 0xff, data)
-
-        # Use the standard command handler which will notify us when
-        # the command is ACK'ed.
-        callback = functools.partial(self.handle_ack, reason=reason)
-        msg_handler = handler.StandardCmd(msg, callback, on_done)
-
         # See __init__ code comments for what this is for.
         self._which_outlet.append(group)
 
-        # Send the message to the PLM modem for protocol.
-        self.send(msg, msg_handler)
+        # Bottom outlet uses an extended message
+        if group == 2:
+            cmd1, cmd2 = self.cmd_on_values(mode, level, transition, group)
+            data = bytes([0x02] + [0x00] * 13)
+            msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2, data)
+            callback = functools.partial(self.handle_ack, reason=reason)
+            msg_handler = handler.StandardCmd(msg, callback, on_done)
+            self.send(msg, msg_handler)
+        else:
+            # Bottom outlet uses a regular on command pass to SetAndState
+            super().on(group=group, level=level, mode=mode, reason=reason,
+                       transition=transition, on_done=on_done)
+
 
     #-----------------------------------------------------------------------
     def off(self, group=0x01, mode=on_off.Mode.NORMAL, reason="",
@@ -186,36 +173,21 @@ class Outlet(functions.SetAndState, Base):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        LOG.info("Outlet %s cmd: off", self.addr)
-        assert 1 <= group <= 2
-        assert isinstance(mode, on_off.Mode)
-
-        if transition or mode == on_off.Mode.RAMP:
-            LOG.error("Device %s does not support transition.", self.addr)
-            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
-
-        # Send the correct off code.
-        cmd1 = on_off.Mode.encode(False, mode)
-
-        # Top outlet uses a standard message
-        if group == 1:
-            msg = Msg.OutStandard.direct(self.addr, cmd1, 0x00)
-
-        # Bottom outlet uses an extended message
-        else:
-            data = bytes([0x02] + [0x00] * 13)
-            msg = Msg.OutExtended.direct(self.addr, cmd1, 0x00, data)
-
-        # Use the standard command handler which will notify us when the
-        # command is ACK'ed.
-        callback = functools.partial(self.handle_ack, reason=reason)
-        msg_handler = handler.StandardCmd(msg, callback, on_done)
-
         # See __init__ code comments for what this is for.
         self._which_outlet.append(group)
 
-        # Send the message to the PLM modem for protocol.
-        self.send(msg, msg_handler)
+        # Bottom outlet uses an extended message
+        if group == 2:
+            cmd1, cmd2 = self.cmd_off_values(mode, transition, group)
+            data = bytes([0x02] + [0x00] * 13)
+            msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2, data)
+            callback = functools.partial(self.handle_ack, reason=reason)
+            msg_handler = handler.StandardCmd(msg, callback, on_done)
+            self.send(msg, msg_handler)
+        else:
+            # Bottom outlet uses a regular on command pass to SetAndState
+            super().off(group=group, mode=mode, reason=reason,
+                        transition=transition, on_done=on_done)
 
     #-----------------------------------------------------------------------
     def set_backlight(self, level, on_done=None):
@@ -334,7 +306,8 @@ class Outlet(functions.SetAndState, Base):
             LOG.info("Outlet %s broadcast grp: %s on: %s mode: %s", self.addr,
                      msg.group, is_on, mode)
 
-            self._set_is_on(msg.group, is_on, mode, reason)
+            self._set_state(group=msg.group, is_on=is_on, mode=mode,
+                            reason=reason)
 
             self.update_linked_devices(msg)
 
@@ -367,51 +340,48 @@ class Outlet(functions.SetAndState, Base):
                    is_on[1])
 
             # Set the state for each outlet.
-            self._set_is_on(1, is_on[0], reason=on_off.REASON_REFRESH)
-            self._set_is_on(2, is_on[1], reason=on_off.REASON_REFRESH)
+            self._set_state(group=1, is_on=is_on[0],
+                            reason=on_off.REASON_REFRESH)
+            self._set_state(group=2, is_on=is_on[1],
+                            reason=on_off.REASON_REFRESH)
 
         else:
             LOG.error("Outlet %s unknown refresh response %s", self.label,
                       msg.cmd2)
 
     #-----------------------------------------------------------------------
-    def handle_ack(self, msg, on_done, reason=""):
+    def decode_on_level(self, cmd1, cmd2):
         """Callback for standard commanded messages.
 
-        This callback is run when we get a reply back from one of our
-        commands to the device.  If the command was ACK'ed, we know it worked
-        so we'll update the internal state of the device and emit the signals
-        to notify others of the state change.
+        Decodes the cmds recevied from the device into is_on, level, and mode
+        to be consumed by _set_state().
 
         Args:
-          msg (message.InpStandard):  The reply message from the device.
-              The on/off level will be in the cmd2 field.
-          on_done: Finished callback.  This is called when the command has
-                   completed.  Signature is: on_done(success, msg, data)
-          reason (str):  This is optional and is used to identify why the
-                 command was sent. It is passed through to the output signal
-                 when the state changes - nothing else is done with it.
+          cmd1 (byte): The command 1 value
+          cmd2 (byte): The command 2 value
+        Returns:
+          is_on (bool): Is the device on.
+          mode (on_off.Mode): The type of command to send (normal, fast, etc).
+          level (int): On level between 0-255.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
         """
+        # Default Returns
+        group = None
+        is_on = None
+        level = None
+        mode = on_off.Mode.NORMAL
+
         # Get the last outlet we were commanding.  The message doesn't tell
         # us which outlet it was so we have to track it here.  See __init__
         # code comments for more info.
         if not self._which_outlet:
             LOG.error("Outlet %s ACK error.  No outlet ID's were saved",
                       self.addr)
-            on_done(False, "Outlet update failed - no ID's saved", None)
-            return
-
-        group = self._which_outlet.pop(0)
-
-        # If this it the ACK we're expecting, update the internal
-        # state and emit our signals.
-        LOG.debug("Outlet %s grp: %s ACK: %s", self.addr, group, msg)
-
-        is_on, mode = on_off.Mode.decode(msg.cmd1)
-        reason = reason if reason else on_off.REASON_COMMAND
-        self._set_is_on(group, is_on, mode, reason)
-        on_done(True, "Outlet state updated to on=%s" % self._is_on,
-                self._is_on)
+        else:
+            group = self._which_outlet.pop(0)
+            is_on, mode = on_off.Mode.decode(cmd1)
+        return (is_on, level, mode, group)
 
     #-----------------------------------------------------------------------
     def handle_group_cmd(self, addr, msg):
@@ -443,7 +413,8 @@ class Outlet(functions.SetAndState, Base):
         # Handle on/off commands codes.
         if on_off.Mode.is_valid(msg.cmd1):
             is_on, mode = on_off.Mode.decode(msg.cmd1)
-            self._set_is_on(localGroup, is_on, mode, on_off.REASON_SCENE)
+            self._set_state(group=localGroup, is_on=is_on, mode=mode,
+                            reason=on_off.REASON_SCENE)
 
         # Note: I don't believe the on/off switch can participate in manual
         # mode stopping commands since it changes state when the button is
@@ -453,30 +424,17 @@ class Outlet(functions.SetAndState, Base):
                         msg.cmd1)
 
     #-----------------------------------------------------------------------
-    def _set_is_on(self, group, is_on, mode=on_off.Mode.NORMAL, reason=""):
-        """Update the device on/off state.
+    def _cache_state(self, group, is_on, level, reason):
+        """Cache the State of the Device
 
-        This will change the internal state and emit the state changed
-        signals.  It is called by whenever we're informed that the device has
-        changed state.
+        Used to help with the unique device functions.
 
         Args:
-          group (int):  The group to update (1 for upper outlet, 2 for lower).
-          is_on (bool):  True if the switch is on, False if it isn't.
-          mode (on_off.Mode): The type of on/off that was triggered (normal,
-               fast, etc).
-          reason (str):  This is optional and is used to identify why the
-                 command was sent. It is passed through to the output signal
-                 when the state changes - nothing else is done with it.
+          group (int): The group which this applies
+          is_on (bool): Whether the device is on.
+          level (int): The new device level in the range [0,255].  0 is off.
+          reason (str): Reason string to pass around.
         """
-        is_on = bool(is_on)
-
-        LOG.info("Setting device %s grp: %s on %s %s %s", self.label, group,
-                 is_on, mode, reason)
         self._is_on[group - 1] = is_on
-
-        # Notify others that the outlet state has changed.
-        self.signal_state.emit(self, button=group, is_on=is_on, mode=mode,
-                               reason=reason)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -153,7 +153,6 @@ class Outlet(functions.SetAndState, Base):
             super().on(group=group, level=level, mode=mode, reason=reason,
                        transition=transition, on_done=on_done)
 
-
     #-----------------------------------------------------------------------
     def off(self, group=0x01, mode=on_off.Mode.NORMAL, reason="",
             transition=None, on_done=None):

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -17,7 +17,7 @@ from .. import util
 LOG = log.get_logger()
 
 
-class Outlet(functions.Set, Base):
+class Outlet(functions.SetAndState, Base):
     """Insteon on/off outlet device.
 
     This is used for in-wall on/off outlets.  Each outlet (top and bottom) is

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -149,7 +149,7 @@ class Outlet(functions.SetAndState, Base):
             msg_handler = handler.StandardCmd(msg, callback, on_done)
             self.send(msg, msg_handler)
         else:
-            # Bottom outlet uses a regular on command pass to SetAndState
+            # Top outlet uses a regular on command pass to SetAndState
             super().on(group=group, level=level, mode=mode, reason=reason,
                        transition=transition, on_done=on_done)
 
@@ -185,7 +185,7 @@ class Outlet(functions.SetAndState, Base):
             msg_handler = handler.StandardCmd(msg, callback, on_done)
             self.send(msg, msg_handler)
         else:
-            # Bottom outlet uses a regular on command pass to SetAndState
+            # Top outlet uses a regular on command pass to SetAndState
             super().off(group=group, mode=mode, reason=reason,
                         transition=transition, on_done=on_done)
 

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -3,7 +3,6 @@
 # Insteon on/off device
 #
 #===========================================================================
-import functools
 from .Base import Base
 from . import functions
 from ..CommandSeq import CommandSeq

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -18,7 +18,7 @@ LOG = log.get_logger()
 
 
 #===========================================================================
-class Switch(functions.State, functions.Set, functions.Scene, Base):
+class Switch(functions.SetAndState, functions.Scene, Base):
     """Insteon on/off switch device.
 
     This class can be used to model any device that acts like a on/off switch

--- a/insteon_mqtt/device/functions/Set.py
+++ b/insteon_mqtt/device/functions/Set.py
@@ -3,9 +3,13 @@
 # Set Functions.
 #
 #===========================================================================
+import functools
 from ..Base import Base
+from ... import message as Msg
+from ... import handler
 from ... import log
 from ... import on_off
+
 
 LOG = log.get_logger()
 
@@ -29,8 +33,13 @@ class Set(Base):
         super().__init__(protocol, modem, address, name)
 
         self.cmd_map.update({
+            'on' : self.on,
+            'off' : self.off,
             'set' : self.set,
             })
+
+        # List of responder group numbers
+        self.responder_groups = [0x01]
 
     #-----------------------------------------------------------------------
     def set(self, is_on=None, level=None, group=0x01, mode=on_off.Mode.NORMAL,
@@ -69,13 +78,152 @@ class Set(Base):
                      transition=transition, on_done=on_done)
 
     #-----------------------------------------------------------------------
-    def on(self, group, level, mode, reason, transition, on_done):
-        # TODO Might be able to move these functions in here too
-        # Probably put switch functions here and dimmer in a seperate
-        # level file.  Need to move handle_ack and all subsequent functions
-        # too.  KPL, IO devices would remain their own thing
-        raise NotImplementedError()
+    def on(self, group=0x01, level=None, mode=on_off.Mode.NORMAL, reason="",
+           transition=None, on_done=None):
+        """Turn the device on.
+
+        NOTE: This does NOT simulate a button press on the device - it just
+        changes the state of the device.  It will not trigger any responders
+        that are linked to this device.  To simulate a button press, call the
+        scene() method.
+
+        This will send the command to the device to update it's state.  When
+        we get an ACK of the result, we'll change our internal state and emit
+        the state changed signals.
+
+        Args:
+          group (int):  The group to send the command to.
+          level (int):  If non-zero, turn the device on.  The API is an int
+                to keep a consistent API with other devices.
+          mode (on_off.Mode): The type of command to send (normal, fast, etc).
+          reason (str):  This is optional and is used to identify why the
+                 command was sent. It is passed through to the output signal
+                 when the state changes - nothing else is done with it.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        LOG.info("Device %s cmd: on %s", self.addr, mode)
+        assert group in self.responder_groups
+        assert isinstance(mode, on_off.Mode)
+
+        mode, transition = self.adjust_transition(mode, transition)
+        mode, level = self.adjust_level(mode, level)
+
+        # Send the requested on code value.
+        cmd1 = on_off.Mode.encode(True, mode)
+
+        # Use the standard command handler which will notify us when the
+        # command is ACK'ed.
+        msg = Msg.OutStandard.direct(self.addr, cmd1, level)
+        callback = functools.partial(self.handle_ack, reason=reason)
+        msg_handler = handler.StandardCmd(msg, callback, on_done)
+        self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
-    def off(self, group, mode, reason, transition, on_done):
+    def off(self, group=0x01, mode=on_off.Mode.NORMAL, reason="",
+            transition=None, on_done=None):
+        """Turn the device off.
+
+        NOTE: This does NOT simulate a button press on the device - it just
+        changes the state of the device.  It will not trigger any responders
+        that are linked to this device.  To simulate a button press, call the
+        scene() method.
+
+        This will send the command to the device to update it's state.  When
+        we get an ACK of the result, we'll change our internal state and emit
+        the state changed signals.
+
+        Args:
+          group (int):  The group to send the command to.
+          mode (on_off.Mode): The type of command to send (normal, fast, etc).
+          reason (str):  This is optional and is used to identify why the
+                 command was sent. It is passed through to the output signal
+                 when the state changes - nothing else is done with it.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+        """
+        LOG.info("Device %s cmd: off %s", self.addr, mode)
+        assert group in self.responder_groups
+        assert isinstance(mode, on_off.Mode)
+
+        mode, transition = self.adjust_transition(mode, transition)
+
+        # Send an off or instant off command.
+        cmd1 = on_off.Mode.encode(False, mode)
+        cmd2 = 0x00
+
+        # Use the standard command handler which will notify us when the
+        # command is ACK'ed.
+        msg = Msg.OutStandard.direct(self.addr, cmd1, cmd2)
+        callback = functools.partial(self.handle_ack, reason=reason)
+        msg_handler = handler.StandardCmd(msg, callback, on_done)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def adjust_transition(self, mode, transition):
+        """Check whether device supports transition
+
+        Adjusts mode and transition based on device support
+
+        Args:
+          mode (on_off.Mode): The type of command to send (normal, fast, etc).
+          transition (int): Ramp rate for the transition in seconds.
+        Returns
+          mode (on_off.Mode): Adjusted mode based on device supports.
+          transition (int): Adjusted transition based on device supports.
+        """
+        if transition:
+            LOG.error("Device %s does not support transition.", self.addr)
+            transition = None
+        return (mode, transition)
+
+    #-----------------------------------------------------------------------
+    def adjust_level(self, mode, level):
+        """Check whether device supports level
+
+        Adjusts mode and level based on device support
+
+        Args:
+          mode (on_off.Mode): The type of command to send (normal, fast, etc).
+          level (int): On level between 0-255.
+        Returns
+          mode (on_off.Mode): Adjusted mode based on device supports.
+          level (int): Adjusted on level based on device supports.  Always
+                       returns 0xFF for default devices.
+        """
+        if level:
+            LOG.error("Device %s does not support level.", self.addr)
+        level = 0xFF
+        return (mode, level)
+
+    #-----------------------------------------------------------------------
+    def handle_ack(self, msg, on_done, reason=""):
+        """Callback for standard commanded messages.
+
+        This callback is run when we get a reply back from one of our
+        commands to the device.  If the command was ACK'ed, we know it worked
+        so we'll update the internal state of the device and emit the signals
+        to notify others of the state change.
+
+        Args:
+          msg (message.InpStandard):  The reply message from the device.
+              The on/off level will be in the cmd2 field.
+          on_done: Finished callback.  This is called when the command has
+                   completed.  Signature is: on_done(success, msg, data)
+          reason (str):  This is optional and is used to identify why the
+                 command was sent. It is passed through to the output signal
+                 when the state changes - nothing else is done with it.
+        """
+        # If this it the ACK we're expecting, update the internal state and
+        # emit our signals.
+        LOG.debug("Device %s ACK: %s", self.addr, msg)
+
+        is_on, mode = on_off.Mode.decode(msg.cmd1)
+        reason = reason if reason else on_off.REASON_COMMAND
+        self._set_state(is_on=is_on, mode=mode, reason=reason)
+        on_done(True, "Switch state updated to on=%s" % is_on, is_on)
+
+    #-----------------------------------------------------------------------
+    def _set_state(self, is_on=None, level=None, mode=on_off.Mode.NORMAL,
+                   reason=""):
         raise NotImplementedError()

--- a/insteon_mqtt/device/functions/SetAndState.py
+++ b/insteon_mqtt/device/functions/SetAndState.py
@@ -4,7 +4,6 @@
 #
 #===========================================================================
 import functools
-from ..Base import Base
 from ... import message as Msg
 from ... import handler
 from ... import log

--- a/insteon_mqtt/device/functions/SetAndState.py
+++ b/insteon_mqtt/device/functions/SetAndState.py
@@ -142,11 +142,6 @@ class SetAndState(State):
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
-        group = self.adjust_set_group(group)
-
-        if self.use_alt_set_cmd(group, False, reason, on_done):
-            return
-
         LOG.info("Device %s grp: %s cmd: off %s", self.addr, group, mode)
         assert group in self.responder_groups
         assert isinstance(mode, on_off.Mode)
@@ -195,37 +190,6 @@ class SetAndState(State):
         cmd1 = on_off.Mode.encode(False, mode)
         cmd2 = 0x00
         return (cmd1, cmd2)
-
-    #-----------------------------------------------------------------------
-    def use_alt_set_cmd(self, group, is_on, reason, on_done):
-        """Should this be processed using an alternate command?
-
-        Exists for the KPL to intercept on/off commands for the non-load group.
-        If should process using an alternate command, do that here and return
-        True.
-
-        Args:
-          group (int): The group the command should be sent to.
-          is_on (bool): Should the command be on?
-          reason (str): The reason string
-          on_done (callback): The on_done callback.
-        Returns
-          True if the command has been processed elsewhere, False otherwise.
-        """
-        return False
-
-    #-----------------------------------------------------------------------
-    def adjust_set_group(self, group):
-        """Adjust the group number for processing by the set command?
-
-        Exists for the KPL to alter the group number based on the load_group
-
-        Args:
-          group (int): The group the command should be sent to.
-        Returns
-          Group(int): The adjusted group number.
-        """
-        return group
 
     #-----------------------------------------------------------------------
     def handle_ack(self, msg, on_done, reason=""):

--- a/insteon_mqtt/device/functions/SetAndState.py
+++ b/insteon_mqtt/device/functions/SetAndState.py
@@ -164,6 +164,8 @@ class SetAndState(State):
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           level (int): On level between 0-255.
           transition (int): Ramp rate for the transition in seconds.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """
@@ -183,6 +185,8 @@ class SetAndState(State):
         Args:
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           transition (int): Ramp rate for the transition in seconds.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """

--- a/insteon_mqtt/device/functions/SetAndState.py
+++ b/insteon_mqtt/device/functions/SetAndState.py
@@ -1,6 +1,6 @@
 #===========================================================================
 #
-# Set Functions.
+# Provides BOTH the Set and State Functions.
 #
 #===========================================================================
 import functools
@@ -9,15 +9,18 @@ from ... import message as Msg
 from ... import handler
 from ... import log
 from ... import on_off
+from .State import State
 
 
 LOG = log.get_logger()
 
 
-class Set(Base):
-    """Scene Trait Abstract Class
+class SetAndState(State):
+    """Set and State Abstract Classes
 
-    This is an abstract class that provides support for the Scene topic.
+    This is an abstract class that provides support for the set and state
+    functions.  A device SHOULD NOT also inherit from the State function if
+    it is using this.  Some devices BatterSensor may only inherit from State.
     """
     def __init__(self, protocol, modem, address, name=None):
         """Constructor
@@ -256,8 +259,3 @@ class Set(Base):
         reason = reason if reason else on_off.REASON_COMMAND
         self._set_state(is_on=is_on, level=level, mode=mode, reason=reason)
         on_done(True, "Device state updated to on=%s" % is_on, is_on)
-
-    #-----------------------------------------------------------------------
-    def _set_state(self, is_on=None, level=None, mode=on_off.Mode.NORMAL,
-                   button=None, reason=""):
-        raise NotImplementedError()

--- a/insteon_mqtt/device/functions/SetAndState.py
+++ b/insteon_mqtt/device/functions/SetAndState.py
@@ -167,8 +167,9 @@ class SetAndState(State):
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
         if level:
             LOG.error("Device %s does not support level.", self.addr)
         cmd1 = on_off.Mode.encode(True, mode)
@@ -185,8 +186,9 @@ class SetAndState(State):
         Returns
           cmd1, cmd2 (int): Value of cmds for this device.
         """
-        if transition:
+        if transition or mode == on_off.Mode.RAMP:
             LOG.error("Device %s does not support transition.", self.addr)
+            mode = on_off.Mode.NORMAL if mode == on_off.Mode.RAMP else mode
         cmd1 = on_off.Mode.encode(False, mode)
         cmd2 = 0x00
         return (cmd1, cmd2)

--- a/insteon_mqtt/device/functions/SetAndState.py
+++ b/insteon_mqtt/device/functions/SetAndState.py
@@ -213,13 +213,14 @@ class SetAndState(State):
         # emit our signals.
         LOG.debug("Device %s ACK: %s", self.addr, msg)
 
-        is_on, level, mode = self.decode_on_level(msg.cmd1, msg.cmd2)
+        is_on, level, mode, group = self.decode_on_level(msg.cmd1, msg.cmd2)
         if is_on is None:
             on_done(False, "Unable to decode Device %s state. %s" % self.addr,
                     msg)
         else:
             reason = reason if reason else on_off.REASON_COMMAND
-            self._set_state(is_on=is_on, level=level, mode=mode, reason=reason)
+            self._set_state(is_on=is_on, level=level, mode=mode, group=group,
+                            reason=reason)
             on_done(True, "Device state updated to on=%s" % is_on, is_on)
 
     #-----------------------------------------------------------------------
@@ -236,7 +237,9 @@ class SetAndState(State):
           is_on (bool): Is the device on.
           mode (on_off.Mode): The type of command to send (normal, fast, etc).
           level (int): On level between 0-255.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
         """
         is_on, mode = on_off.Mode.decode(cmd1)
         level = on_off.Mode.decode_level(cmd1, cmd2)
-        return (is_on, level, mode)
+        return (is_on, level, mode, None)

--- a/insteon_mqtt/device/functions/State.py
+++ b/insteon_mqtt/device/functions/State.py
@@ -1,0 +1,65 @@
+#===========================================================================
+#
+# State Functions.
+#
+#===========================================================================
+from ..Base import Base
+from ...Signal import Signal
+from ... import log
+from ... import on_off
+
+LOG = log.get_logger()
+
+
+class State(Base):
+    """State Trait Abstract Class
+
+    This is an abstract class that provides support for the State topic.
+    """
+    def __init__(self, protocol, modem, address, name=None):
+        """Constructor
+
+        Args:
+          protocol (Protocol): The Protocol object used to communicate
+                   with the Insteon network.  This is needed to allow the
+                   device to send messages to the PLM modem.
+          modem (Modem): The Insteon modem used to find other devices.
+          address (Address): The address of the device.
+          name (str): Nice alias name to use for the device.
+        """
+        super().__init__(protocol, modem, address, name)
+
+        self._is_on = False
+        self._level = 0x00
+
+        # Support dimmer style signals and motion on/off style signals.
+        # API:  func(Device, int level, on_off.Mode mode, str reason)
+        self.signal_state = Signal()
+
+    #-----------------------------------------------------------------------
+    def _set_state(self, is_on=None, level=None, mode=on_off.Mode.NORMAL,
+                   reason=""):
+        """Update the device level or on/off state.
+
+        This will change the internal state and emit the state changed
+        signals.  It is called by whenever we're informed that the device has
+        changed state.
+
+        Args:
+          is_on (bool):  True if the switch is on, False if it isn't.
+          level (int): The new device level in the range [0,255].  0 is off.
+          mode (on_off.Mode): The type of on/off that was triggered (normal,
+               fast, etc).
+          reason (str):  This is optional and is used to identify why the
+                 command was sent. It is passed through to the output signal
+                 when the state changes - nothing else is done with it.
+        """
+        LOG.info("Setting device %s on %s level %s %s %s", self.label, is_on,
+                 level, mode, reason)
+        if is_on is not None:
+            self._is_on = is_on
+        if level is not None:
+            self._level = level
+
+        self.signal_state.emit(self, is_on=is_on, level=level, mode=mode,
+                               reason=reason)

--- a/insteon_mqtt/device/functions/State.py
+++ b/insteon_mqtt/device/functions/State.py
@@ -37,8 +37,8 @@ class State(Base):
         self.signal_state = Signal()
 
     #-----------------------------------------------------------------------
-    def _set_state(self, is_on=None, level=None, mode=on_off.Mode.NORMAL,
-                   reason=""):
+    def _set_state(self, is_on=None, level=None,
+                   mode=on_off.Mode.NORMAL, reason=""):
         """Update the device level or on/off state.
 
         This will change the internal state and emit the state changed

--- a/insteon_mqtt/device/functions/State.py
+++ b/insteon_mqtt/device/functions/State.py
@@ -37,7 +37,7 @@ class State(Base):
         self.signal_state = Signal()
 
     #-----------------------------------------------------------------------
-    def _set_state(self, is_on=None, level=None,
+    def _set_state(self, is_on=None, level=None, button=None,
                    mode=on_off.Mode.NORMAL, reason=""):
         """Update the device level or on/off state.
 
@@ -62,4 +62,4 @@ class State(Base):
             self._level = level
 
         self.signal_state.emit(self, is_on=is_on, level=level, mode=mode,
-                               reason=reason)
+                               button=None, reason=reason)

--- a/insteon_mqtt/device/functions/State.py
+++ b/insteon_mqtt/device/functions/State.py
@@ -57,22 +57,23 @@ class State(Base):
         """
         LOG.info("Setting device %s on %s level %s %s %s", self.label, is_on,
                  level, mode, reason)
-        if is_on is not None:
-            self._is_on = is_on
-        self._set_level(button, level)
+        self._cache_state(button, is_on, level)
 
         self.signal_state.emit(self, is_on=is_on, level=level, mode=mode,
                                button=button, reason=reason)
 
     #-----------------------------------------------------------------------
-    def _set_level(self, group, level):
-        """Save the Level of the Device
+    def _cache_state(self, group, is_on, level):
+        """Cache the State of the Device
 
         Used to help with the KPL unique functions.
 
         Args:
           group (int): The group which this applies
+          is_on (bool): Whether the device is on.
           level (int): The new device level in the range [0,255].  0 is off.
         """
+        if is_on is not None:
+            self._is_on = is_on
         if level is not None:
             self._level = level

--- a/insteon_mqtt/device/functions/State.py
+++ b/insteon_mqtt/device/functions/State.py
@@ -57,21 +57,22 @@ class State(Base):
         """
         LOG.info("Setting device %s on %s level %s %s %s", self.label, is_on,
                  level, mode, reason)
-        self._cache_state(group, is_on, level)
+        self._cache_state(group, is_on, level, reason)
 
         self.signal_state.emit(self, is_on=is_on, level=level, mode=mode,
                                button=group, reason=reason)
 
     #-----------------------------------------------------------------------
-    def _cache_state(self, group, is_on, level):
+    def _cache_state(self, group, is_on, level, reason):
         """Cache the State of the Device
 
-        Used to help with the KPL unique functions.
+        Used to help with the unique device functions.
 
         Args:
           group (int): The group which this applies
           is_on (bool): Whether the device is on.
           level (int): The new device level in the range [0,255].  0 is off.
+          reason (str): Reason string to pass around.
         """
         if is_on is not None:
             self._is_on = is_on

--- a/insteon_mqtt/device/functions/State.py
+++ b/insteon_mqtt/device/functions/State.py
@@ -37,7 +37,7 @@ class State(Base):
         self.signal_state = Signal()
 
     #-----------------------------------------------------------------------
-    def _set_state(self, is_on=None, level=None, button=None,
+    def _set_state(self, is_on=None, level=None, group=None,
                    mode=on_off.Mode.NORMAL, reason=""):
         """Update the device level or on/off state.
 
@@ -48,7 +48,7 @@ class State(Base):
         Args:
           is_on (bool):  True if the switch is on, False if it isn't.
           level (int): The new device level in the range [0,255].  0 is off.
-          button (int): The button to which this applies
+          group (int): The group to which this applies
           mode (on_off.Mode): The type of on/off that was triggered (normal,
                fast, etc).
           reason (str):  This is optional and is used to identify why the
@@ -57,10 +57,10 @@ class State(Base):
         """
         LOG.info("Setting device %s on %s level %s %s %s", self.label, is_on,
                  level, mode, reason)
-        self._cache_state(button, is_on, level)
+        self._cache_state(group, is_on, level)
 
         self.signal_state.emit(self, is_on=is_on, level=level, mode=mode,
-                               button=button, reason=reason)
+                               button=group, reason=reason)
 
     #-----------------------------------------------------------------------
     def _cache_state(self, group, is_on, level):

--- a/insteon_mqtt/device/functions/State.py
+++ b/insteon_mqtt/device/functions/State.py
@@ -48,6 +48,7 @@ class State(Base):
         Args:
           is_on (bool):  True if the switch is on, False if it isn't.
           level (int): The new device level in the range [0,255].  0 is off.
+          button (int): The button to which this applies
           mode (on_off.Mode): The type of on/off that was triggered (normal,
                fast, etc).
           reason (str):  This is optional and is used to identify why the
@@ -58,8 +59,20 @@ class State(Base):
                  level, mode, reason)
         if is_on is not None:
             self._is_on = is_on
-        if level is not None:
-            self._level = level
+        self._set_level(button, level)
 
         self.signal_state.emit(self, is_on=is_on, level=level, mode=mode,
-                               button=None, reason=reason)
+                               button=button, reason=reason)
+
+    #-----------------------------------------------------------------------
+    def _set_level(self, group, level):
+        """Save the Level of the Device
+
+        Used to help with the KPL unique functions.
+
+        Args:
+          group (int): The group which this applies
+          level (int): The new device level in the range [0,255].  0 is off.
+        """
+        if level is not None:
+            self._level = level

--- a/insteon_mqtt/device/functions/__init__.py
+++ b/insteon_mqtt/device/functions/__init__.py
@@ -20,3 +20,4 @@ the list of available functions to inherit from.
 from ..Base import Base
 from .Scene import Scene
 from .Set import Set
+from .State import State

--- a/insteon_mqtt/device/functions/__init__.py
+++ b/insteon_mqtt/device/functions/__init__.py
@@ -19,5 +19,5 @@ the list of available functions to inherit from.
 
 from ..Base import Base
 from .Scene import Scene
-from .Set import Set
+from .SetAndState import SetAndState
 from .State import State

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -128,6 +128,6 @@ class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
             # Tell the device to change its level.
             self.device.set(is_on=is_on, level=level, mode=mode, reason=reason)
         except:
-            LOG.error("Invalid dimmer command: %s", data)
+            LOG.exception("Invalid dimmer command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/IOLinc.py
+++ b/insteon_mqtt/mqtt/IOLinc.py
@@ -10,7 +10,7 @@ from . import topic
 LOG = log.get_logger()
 
 
-class IOLinc(topic.SetTopic):
+class IOLinc(topic.StateTopic, topic.SetTopic):
     """MQTT interface to an Insteon IOLinc device.
 
     This class connects to a device.IOLinc object and converts it's
@@ -24,13 +24,9 @@ class IOLinc(topic.SetTopic):
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.IOLinc):  The Insteon object to link to.
         """
-        super().__init__(mqtt, device)
-
-        # Output state change reporting template.
-        self.msg_state = MsgTemplate(
-            topic='insteon/{{address}}/state',
-            payload='{"sensor": "{{sensor_on_str.lower()}}",' +
-            ' "relay": "{{relay_on_str.lower()}}"}')
+        super().__init__(mqtt, device,
+                         state_payload='{"sensor":"{{sensor_on_str.lower()}}",'
+                                       ' "relay":"{{relay_on_str.lower()}}"}')
 
         # Output relay state change reporting template.
         self.msg_relay_state = MsgTemplate(
@@ -42,7 +38,7 @@ class IOLinc(topic.SetTopic):
             topic='insteon/{{address}}/sensor',
             payload='{{sensor_on_str.lower()}}')
 
-        device.signal_on_off.connect(self._insteon_on_off)
+        device.signal_state.connect(self._insteon_on_off)
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
@@ -57,7 +53,7 @@ class IOLinc(topic.SetTopic):
         if not data:
             return
 
-        self.msg_state.load_config(data, 'state_topic', 'state_payload', qos)
+        self.load_state_data(data, qos)
         self.msg_relay_state.load_config(data, 'relay_state_topic',
                                          'relay_state_payload', qos)
         self.msg_sensor_state.load_config(data, 'sensor_state_topic',
@@ -88,30 +84,38 @@ class IOLinc(topic.SetTopic):
         self.set_unsubscribe(link)
 
     #-----------------------------------------------------------------------
-    def template_data(self, sensor_is_on=None, relay_is_on=None):
+    def state_template_data(self, **kwargs):
         """Create the Jinja templating data variables for on/off messages.
 
-        Args:
+        kwargs includes:
           is_on (bool):  The on/off state of the switch.  If None, on/off and
                 mode attributes are not added to the data.
+          mode (on_off.Mode):  The on/off mode state.
+          manual (on_off.Manual):  The manual mode state.  If None, manual
+                 attributes are not added to the data.
+          reason (str):  The reason the device was triggered.  This is an
+                 arbitrary string set into the template variables.
+          level (int):  A brightness level between 0-255
+          button (int): Passed to base_template_data, the group numer to use
 
         Returns:
           dict:  Returns a dict with the variables available for templating.
         """
-        # Set up the variables that can be used in the templates.
-        data = self.base_template_data()
+        data = super().state_template_data(**kwargs)
 
+        # Insert IOLinc specific items
+        sensor_is_on = kwargs.get('sensor_is_on', None)
+        relay_is_on = kwargs.get('relay_is_on', None)
         if sensor_is_on is not None:
             data["sensor_on"] = 1 if sensor_is_on else 0
             data["sensor_on_str"] = "on" if sensor_is_on else "off"
         if relay_is_on is not None:
             data["relay_on"] = 1 if relay_is_on else 0
             data["relay_on_str"] = "on" if relay_is_on else "off"
-
         return data
 
     #-----------------------------------------------------------------------
-    def _insteon_on_off(self, device, sensor_is_on, relay_is_on):
+    def _insteon_on_off(self, device, **kwargs):
         """Device active on/off callback.
 
         This is triggered via signal when the Insteon device goes active or
@@ -121,11 +125,10 @@ class IOLinc(topic.SetTopic):
           device (device.IOLinc):   The Insteon device that changed.
           is_on (bool):   True for on, False for off.
         """
-        LOG.info("MQTT received active change %s, sensor = %s relay = %s",
-                 device.label, sensor_is_on, relay_is_on)
+        LOG.info("MQTT received active change %s, %s",
+                 device.label, kwargs)
 
-        data = self.template_data(sensor_is_on, relay_is_on)
-        self.msg_state.publish(self.mqtt, data)
+        data = self.state_template_data(**kwargs)
         self.msg_relay_state.publish(self.mqtt, data)
         self.msg_sensor_state.publish(self.mqtt, data)
 

--- a/insteon_mqtt/mqtt/IOLinc.py
+++ b/insteon_mqtt/mqtt/IOLinc.py
@@ -114,10 +114,10 @@ class IOLinc(topic.StateTopic, topic.SetTopic):
             # things the sensor and the relay.  Had these been kept in
             # different topics this would not be needed.  Consider that if
             # copying this code.
-            if button == 1:
+            if button == 1:  # This was a sensor emit
                 sensor_is_on = kwargs['is_on']
                 relay_is_on = self.device.relay_is_on
-            elif button == 2:
+            elif button == 2:  # This was a relay emit
                 relay_is_on = kwargs['is_on']
                 sensor_is_on = self.device.sensor_is_on
 

--- a/insteon_mqtt/mqtt/IOLinc.py
+++ b/insteon_mqtt/mqtt/IOLinc.py
@@ -106,10 +106,23 @@ class IOLinc(topic.StateTopic, topic.SetTopic):
         # Insert IOLinc specific items
         sensor_is_on = kwargs.get('sensor_is_on', None)
         relay_is_on = kwargs.get('relay_is_on', None)
-        if sensor_is_on is not None:
+        button = kwargs.get('button', None)
+        if button is not None and 'is_on' in kwargs:
+            # I am not very happy about having to query back to the device
+            # here.  But this is needed because when first designing this
+            # class I allowed a state topic that produced the states of two
+            # things the sensor and the relay.  Had these been kept in
+            # different topics this would not be needed.  Consider that if
+            # copying this code.
+            if button == 1:
+                sensor_is_on = kwargs['is_on']
+                relay_is_on = self.device.relay_is_on
+            elif button == 2:
+                relay_is_on = kwargs['is_on']
+                sensor_is_on = self.device.sensor_is_on
+
             data["sensor_on"] = 1 if sensor_is_on else 0
             data["sensor_on_str"] = "on" if sensor_is_on else "off"
-        if relay_is_on is not None:
             data["relay_on"] = 1 if relay_is_on else 0
             data["relay_on_str"] = "on" if relay_is_on else "off"
         return data

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -64,7 +64,9 @@ class KeypadLinc(topic.SetTopic, topic.SceneTopic, topic.StateTopic,
         # Load the various topics
         self.load_state_data(data, qos,
                              topic='btn_state_topic',
-                             payload='btn_state_payload')
+                             payload='btn_state_payload',
+                             topic_1='dimmer_state_topic',
+                             payload_1='dimmer_state_payload')
         self.load_manual_data(data, qos)
         self.load_scene_data(data, qos,
                              topic='btn_scene_topic',

--- a/insteon_mqtt/mqtt/topic/SetTopic.py
+++ b/insteon_mqtt/mqtt/topic/SetTopic.py
@@ -117,6 +117,6 @@ class SetTopic(BaseTopic):
             self.device.set(is_on=is_on, level=level, group=group, mode=mode,
                             transition=transition, reason=reason)
         except:
-            LOG.error("Invalid SetTopic command: %s", data)
+            LOG.exception("Invalid SetTopic command: %s", data)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/topic/StateTopic.py
+++ b/insteon_mqtt/mqtt/topic/StateTopic.py
@@ -143,7 +143,6 @@ class StateTopic(BaseTopic):
         # Update with manual data
         manual_data = ManualTopic.manual_template_data(**kwargs)
         data.update(manual_data)
-
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/topic/StateTopic.py
+++ b/insteon_mqtt/mqtt/topic/StateTopic.py
@@ -171,9 +171,8 @@ class StateTopic(BaseTopic):
         data = self.state_template_data(**kwargs)
 
         # If this has a distinct template for group 1 use it.
-        if ('button' in kwargs and
-                kwargs['button'] == 1 and
-                self.msg_state_1 is not None):
+        button = kwargs.get('button', None)
+        if (button == 1 or button is None) and self.msg_state_1 is not None:
             self.msg_state_1.publish(self.mqtt, data, retain=retain)
         else:
             self.msg_state.publish(self.mqtt, data, retain=retain)

--- a/tests/device/test_BatterySensorDev.py
+++ b/tests/device/test_BatterySensorDev.py
@@ -48,14 +48,14 @@ class Test_Base_Config():
         (Msg.CmdType.LINK_CLEANUP_REPORT, None),
     ])
     def test_broadcast_1(self, test_device, cmd1, expected):
-        with mock.patch.object(Device.BatterySensor, '_set_is_on') as mocked:
+        with mock.patch.object(Device.BatterySensor, '_set_state') as mocked:
             flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
             group = IM.Address(0x00, 0x00, 0x01)
             addr = IM.Address(0x01, 0x02, 0x03)
             msg = Msg.InpStandard(addr, group, flags, cmd1, 0x00)
             test_device.handle_broadcast(msg)
             if expected is not None:
-                mocked.assert_called_once_with(expected)
+                mocked.assert_called_once_with(is_on=expected)
             else:
                 mocked.assert_not_called()
 

--- a/tests/device/test_DimmerDev.py
+++ b/tests/device/test_DimmerDev.py
@@ -38,10 +38,10 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 2
 
     @pytest.mark.parametrize("group,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,{"level":255,"is_on":None,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-        (0x01,Msg.CmdType.OFF, 0x00, {"level":0,"is_on":None,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,{"level":255,"is_on":None,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"level":0,"is_on":None,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
+        (0x01,Msg.CmdType.ON, 0x00,{"level":255,"is_on":None,"mode":IM.on_off.Mode.NORMAL, "button":None, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"level":0,"is_on":None,"mode":IM.on_off.Mode.NORMAL, "button":None, "reason":'device'}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"level":255,"is_on":None,"mode":IM.on_off.Mode.FAST, "button":None, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"level":0,"is_on":None,"mode":IM.on_off.Mode.FAST, "button":None, "reason":'device'}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])
     def test_handle_on_off(self, test_device, group, cmd1, cmd2, expected):
@@ -106,23 +106,23 @@ class Test_Base_Config():
         # default on-level then to full brightness, as expected.
         # Fast-on should always go to full brightness.
         params = [
-            (Msg.CmdType.ON, 0x00, {"level":64, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-            (Msg.CmdType.ON, 0x00, {"level":255, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-            (Msg.CmdType.ON, 0x00, {"level":64, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-            (Msg.CmdType.OFF, 0x00, {"level":0, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+            (Msg.CmdType.ON, 0x00, {"level":64, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "button":None, "reason":'device'}),
+            (Msg.CmdType.ON, 0x00, {"level":255, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "button":None, "reason":'device'}),
+            (Msg.CmdType.ON, 0x00, {"level":64, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "button":None, "reason":'device'}),
+            (Msg.CmdType.OFF, 0x00, {"level":0, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "button":None, "reason":'device'}),
             (Msg.CmdType.ON_FAST, 0x00, {"level":255, "is_on":None,
                                          "mode":IM.on_off.Mode.FAST,
-                                         "reason":'device'}),
+                                         "button":None, "reason":'device'}),
             (Msg.CmdType.ON_FAST, 0x00, {"level":255, "is_on":None,
                                          "mode":IM.on_off.Mode.FAST,
-                                         "reason":'device'}),
-            (Msg.CmdType.OFF_FAST, 0x00, {"level":0, "is_on":None, "mode":IM.on_off.Mode.FAST, "reason":'device'}),
+                                         "button":None, "reason":'device'}),
+            (Msg.CmdType.OFF_FAST, 0x00, {"level":0, "is_on":None, "mode":IM.on_off.Mode.FAST, "button":None, "reason":'device'}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                {"level":64, "is_on":None, "mode":IM.on_off.Mode.INSTANT, "reason":'device'}),
+                {"level":64, "is_on":None, "mode":IM.on_off.Mode.INSTANT, "button":None, "reason":'device'}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                {"level":255, "is_on":None, "mode": IM.on_off.Mode.INSTANT, "reason":'device'}),
+                {"level":255, "is_on":None, "mode": IM.on_off.Mode.INSTANT, "button":None, "reason":'device'}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                {"level":64, "is_on":None, "mode":IM.on_off.Mode.INSTANT, "reason":'device'})]
+                {"level":64, "is_on":None, "mode":IM.on_off.Mode.INSTANT, "button":None, "reason":'device'})]
         for cmd1, cmd2, expected in params:
             with mock.patch.object(IM.Signal, 'emit') as mocked:
                 print("Trying:", "[%x, %x]" % (cmd1, cmd2))

--- a/tests/device/test_DimmerDev.py
+++ b/tests/device/test_DimmerDev.py
@@ -38,10 +38,10 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 2
 
     @pytest.mark.parametrize("group,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-        (0x01,Msg.CmdType.OFF, 0x00, {"level":0,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,{"level":255,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"level":0,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
+        (0x01,Msg.CmdType.ON, 0x00,{"level":255,"is_on":None,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"level":0,"is_on":None,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"level":255,"is_on":None,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"level":0,"is_on":None,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])
     def test_handle_on_off(self, test_device, group, cmd1, cmd2, expected):
@@ -106,19 +106,23 @@ class Test_Base_Config():
         # default on-level then to full brightness, as expected.
         # Fast-on should always go to full brightness.
         params = [
-            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-            (Msg.CmdType.ON, 0x00, {"level":255, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-            (Msg.CmdType.OFF, 0x00, {"level":0, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "reason":'device'}),
-            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "reason":'device'}),
-            (Msg.CmdType.OFF_FAST, 0x00, {"level":0, "mode":IM.on_off.Mode.FAST, "reason":'device'}),
+            (Msg.CmdType.ON, 0x00, {"level":64, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+            (Msg.CmdType.ON, 0x00, {"level":255, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+            (Msg.CmdType.ON, 0x00, {"level":64, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+            (Msg.CmdType.OFF, 0x00, {"level":0, "is_on":None, "mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "is_on":None,
+                                         "mode":IM.on_off.Mode.FAST,
+                                         "reason":'device'}),
+            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "is_on":None,
+                                         "mode":IM.on_off.Mode.FAST,
+                                         "reason":'device'}),
+            (Msg.CmdType.OFF_FAST, 0x00, {"level":0, "is_on":None, "mode":IM.on_off.Mode.FAST, "reason":'device'}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                {"level":64, "mode":IM.on_off.Mode.INSTANT, "reason":'device'}),
+                {"level":64, "is_on":None, "mode":IM.on_off.Mode.INSTANT, "reason":'device'}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                {"level":255,"mode": IM.on_off.Mode.INSTANT, "reason":'device'}),
+                {"level":255, "is_on":None, "mode": IM.on_off.Mode.INSTANT, "reason":'device'}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                {"level":64, "mode":IM.on_off.Mode.INSTANT, "reason":'device'})]
+                {"level":64, "is_on":None, "mode":IM.on_off.Mode.INSTANT, "reason":'device'})]
         for cmd1, cmd2, expected in params:
             with mock.patch.object(IM.Signal, 'emit') as mocked:
                 print("Trying:", "[%x, %x]" % (cmd1, cmd2))

--- a/tests/device/test_IOLincDev.py
+++ b/tests/device/test_IOLincDev.py
@@ -159,7 +159,7 @@ class Test_IOLinc_Set():
         with mock.patch.object(IM.Signal, 'emit'):
             test_iolinc._set_sensor_is_on(is_on)
             calls = IM.Signal.emit.call_args_list
-            assert calls[0][0][1] == expected
+            assert calls[0][1]['sensor_is_on'] == expected
             assert IM.Signal.emit.call_count == 1
 
     @pytest.mark.parametrize("is_on, mode, moment, relay, add, remove", [
@@ -180,7 +180,7 @@ class Test_IOLinc_Set():
                         test_iolinc._momentary_call = True
                     test_iolinc._set_relay_is_on(is_on, momentary=moment)
                     emit_calls = IM.Signal.emit.call_args_list
-                    assert emit_calls[0][0][2] == relay
+                    assert emit_calls[0][1]['relay_is_on'] == relay
                     assert IM.Signal.emit.call_count == 1
                     assert test_iolinc.modem.timed_call.add.call_count == add
                     assert test_iolinc.modem.timed_call.remove.call_count == remove
@@ -206,10 +206,10 @@ class Test_Handles():
             test_iolinc.handle_broadcast(msg)
             calls = IM.Signal.emit.call_args_list
             if linked:
-                assert calls[1][0][2] == relay
+                assert calls[1][1]['relay_is_on'] == relay
                 assert IM.Signal.emit.call_count == 2
             elif sensor is not None:
-                assert calls[0][0][1] == sensor
+                assert calls[0][1]['sensor_is_on'] == sensor
                 assert IM.Signal.emit.call_count == 1
             else:
                 assert IM.Signal.emit.call_count == 0
@@ -286,7 +286,7 @@ class Test_Handles():
             msg = IM.message.InpStandard(from_addr, to_addr, flags, 0x19, cmd2)
             test_iolinc.handle_refresh_relay(msg)
             calls = IM.Signal.emit.call_args_list
-            assert calls[0][0][2] == expected
+            assert calls[0][1]['relay_is_on'] == expected
             assert IM.Signal.emit.call_count == 1
 
     @pytest.mark.parametrize("cmd2,expected", [
@@ -301,7 +301,7 @@ class Test_Handles():
             msg = IM.message.InpStandard(from_addr, to_addr, flags, 0x19, cmd2)
             test_iolinc.handle_refresh_sensor(msg)
             calls = IM.Signal.emit.call_args_list
-            assert calls[0][0][1] == expected
+            assert calls[0][1]['sensor_is_on'] == expected
             assert IM.Signal.emit.call_count == 1
 
     @pytest.mark.parametrize("cmd1, type, expected", [
@@ -316,7 +316,7 @@ class Test_Handles():
             msg = IM.message.InpStandard(from_addr, to_addr, flags, cmd1, 0x01)
             test_iolinc.handle_ack(msg, lambda success, msg, cmd: True)
             calls = IM.Signal.emit.call_args_list
-            assert calls[0][0][2] == expected
+            assert calls[0][1]['relay_is_on'] == expected
             assert IM.Signal.emit.call_count == 1
 
     @pytest.mark.parametrize("cmd1, entry_d1, mode, sensor, expected", [
@@ -363,7 +363,7 @@ class Test_Handles():
             # Test the responses received
             calls = IM.Signal.emit.call_args_list
             if expected is not None:
-                assert calls[0][0][2] == expected
+                assert calls[0][1]['relay_is_on'] == expected
                 assert IM.Signal.emit.call_count == 1
             else:
                 assert IM.Signal.emit.call_count == 0

--- a/tests/device/test_KeypadLincDev.py
+++ b/tests/device/test_KeypadLincDev.py
@@ -278,19 +278,19 @@ class Test_KPL():
         # default on-level then to full brightness, as expected.
         # Fast-on should always go to full brightness.
         params = [
-            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
-            (Msg.CmdType.ON, 0x00, {"level":255, "mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
-            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
-            (Msg.CmdType.OFF, 0x00, {"level":0, "mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
-            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
-            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
-            (Msg.CmdType.OFF_FAST, 0x00, {"level":0, "mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
+            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":1}),
+            (Msg.CmdType.ON, 0x00, {"level":255, "mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":1}),
+            (Msg.CmdType.ON, 0x00, {"level":64, "mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":1}),
+            (Msg.CmdType.OFF, 0x00, {"level":0, "mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":1}),
+            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "is_on": None, "reason":'device', "button":1}),
+            (Msg.CmdType.ON_FAST, 0x00, {"level":255, "mode":IM.on_off.Mode.FAST, "is_on": None, "reason":'device', "button":1}),
+            (Msg.CmdType.OFF_FAST, 0x00, {"level":0, "mode":IM.on_off.Mode.FAST, "is_on": None, "reason":'device', "button":1}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                {"level":64, "mode":IM.on_off.Mode.INSTANT, "reason":'device', "button":1}),
+                {"level":64, "mode":IM.on_off.Mode.INSTANT, "is_on": None, "reason":'device', "button":1}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                {"level":255, "mode":IM.on_off.Mode.INSTANT, "reason":'device', "button":1}),
+                {"level":255, "mode":IM.on_off.Mode.INSTANT, "is_on": None, "reason":'device', "button":1}),
             (Msg.CmdType.ON_INSTANT, 0x00,
-                {"level":64, "mode":IM.on_off.Mode.INSTANT, "reason":'device', "button":1})]
+                {"level":64, "mode":IM.on_off.Mode.INSTANT, "is_on": None, "reason":'device', "button":1})]
         for cmd1, cmd2, expected in params:
             with mock.patch.object(IM.Signal, 'emit') as mocked:
                 print("Trying:", "[%x, %x]" % (cmd1, cmd2))
@@ -336,21 +336,21 @@ class Test_KPL():
 
 
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
-        (0x01,Msg.CmdType.OFF, 0x00, {"level":0,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":1}),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,{"level":255,"mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"level":0,"mode":IM.on_off.Mode.FAST, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"level":0,"mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"level":255,"mode":IM.on_off.Mode.FAST, "is_on": None, "reason":'device', "button":1}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"level":0,"mode":IM.on_off.Mode.FAST, "is_on": None, "reason":'device', "button":1}),
         (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, {"manual":IM.on_off.Manual.DOWN, "reason":'device', "button":1}),
         (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x01, {"manual":IM.on_off.Manual.UP, "reason":'device', "button":1}),
         (0x01,Msg.CmdType.STOP_MANUAL_CHANGE, 0x00, {"manual":IM.on_off.Manual.STOP, "reason":'device', "button":1}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
-        (0x02,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":2}),
-        (0x03,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":3}),
-        (0x04,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":4}),
-        (0x05,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":5}),
-        (0x06,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":6}),
-        (0x07,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":7}),
-        (0x08,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "reason":'device', "button":8}),
+        (0x02,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":2}),
+        (0x03,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":3}),
+        (0x04,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":4}),
+        (0x05,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":5}),
+        (0x06,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":6}),
+        (0x07,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":7}),
+        (0x08,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": None, "reason":'device', "button":8}),
     ])
     def test_handle_on_off(self, test_device, group_num, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:

--- a/tests/device/test_MotionDev.py
+++ b/tests/device/test_MotionDev.py
@@ -45,8 +45,10 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 5
 
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True}),
-        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False}),
+        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True, "level":None, "reason":'',
+         "mode":IM.on_off.Mode.NORMAL}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False, "level":None, "reason":'',
+         "mode":IM.on_off.Mode.NORMAL}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])
     def test_handle_broadcast_state(self, test_device, group_num, cmd1, cmd2, expected):

--- a/tests/device/test_MotionDev.py
+++ b/tests/device/test_MotionDev.py
@@ -45,9 +45,9 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 5
 
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True, "level":None, "reason":'',
+        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True, "level":None, "button":None, "reason":'',
          "mode":IM.on_off.Mode.NORMAL}),
-        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False, "level":None, "reason":'',
+        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False, "level":None, "button":None, "reason":'',
          "mode":IM.on_off.Mode.NORMAL}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])

--- a/tests/device/test_OutletDev.py
+++ b/tests/device/test_OutletDev.py
@@ -40,13 +40,13 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 3
 
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL, "reason":'device',"button":1}),
-        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":0,"mode":IM.on_off.Mode.NORMAL, "reason":'device',"button":1}),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,{"is_on":True,"mode":IM.on_off.Mode.FAST, "reason":'device',"button":1}),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"is_on":0,"mode":IM.on_off.Mode.FAST, "reason":'device',"button":1}),
+        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL, "level": None, "reason":'device',"button":1}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":0,"mode":IM.on_off.Mode.NORMAL, "level": None, "reason":'device',"button":1}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"is_on":True,"mode":IM.on_off.Mode.FAST, "level": None, "reason":'device',"button":1}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"is_on":0,"mode":IM.on_off.Mode.FAST, "level": None, "reason":'device',"button":1}),
         (0x01,Msg.CmdType.START_MANUAL_CHANGE, 0x00, None),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
-        (0x02,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL, "reason":'device',"button":2}),
+        (0x02,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL, "level": None, "reason":'device',"button":2}),
     ])
     def test_handle_on_off(self, test_device, group_num, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:

--- a/tests/device/test_SwitchDev.py
+++ b/tests/device/test_SwitchDev.py
@@ -38,10 +38,10 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 2
 
     @pytest.mark.parametrize("group,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True,"level":None,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False,"level":None,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,{"is_on":True,"level":None,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"is_on":False,"level":None,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
+        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True,"level":None,"mode":IM.on_off.Mode.NORMAL, "button":None, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False,"level":None,"mode":IM.on_off.Mode.NORMAL, "button":None, "reason":'device'}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"is_on":True,"level":None,"mode":IM.on_off.Mode.FAST, "button":None, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"is_on":False,"level":None,"mode":IM.on_off.Mode.FAST, "button":None, "reason":'device'}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])
     def test_handle_on_off(self, test_device, group, cmd1, cmd2, expected):
@@ -66,7 +66,7 @@ class Test_Base_Config():
             assert mocked.call_count == 2
             calls = [call(test_device, manual=IM.on_off.Manual.DOWN),
                      call(test_device, is_on=False, level=None,
-                          mode=IM.on_off.Mode.MANUAL, reason='device')]
+                          mode=IM.on_off.Mode.MANUAL, button=None, reason='device')]
             mocked.assert_has_calls(calls)
         with mock.patch.object(IM.Signal, 'emit') as mocked:
             flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
@@ -76,7 +76,7 @@ class Test_Base_Config():
             test_device.handle_broadcast(msg)
             assert mocked.call_count == 2
             calls = [call(test_device, manual=IM.on_off.Manual.UP),
-                     call(test_device, is_on=True, level=None,
+                     call(test_device, is_on=True, button=None, level=None,
                           mode=IM.on_off.Mode.MANUAL, reason='device')]
             mocked.assert_has_calls(calls)
 

--- a/tests/device/test_SwitchDev.py
+++ b/tests/device/test_SwitchDev.py
@@ -38,10 +38,10 @@ class Test_Base_Config():
             assert IM.CommandSeq.add.call_count == 2
 
     @pytest.mark.parametrize("group,cmd1,cmd2,expected", [
-        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
-        (0x01,Msg.CmdType.ON_FAST, 0x00,{"is_on":True,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
-        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"is_on":False,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
+        (0x01,Msg.CmdType.ON, 0x00,{"is_on":True,"level":None,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False,"level":None,"mode":IM.on_off.Mode.NORMAL, "reason":'device'}),
+        (0x01,Msg.CmdType.ON_FAST, 0x00,{"is_on":True,"level":None,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
+        (0x01,Msg.CmdType.OFF_FAST, 0x00, {"is_on":False,"level":None,"mode":IM.on_off.Mode.FAST, "reason":'device'}),
         (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])
     def test_handle_on_off(self, test_device, group, cmd1, cmd2, expected):
@@ -65,7 +65,8 @@ class Test_Base_Config():
             test_device.handle_broadcast(msg)
             assert mocked.call_count == 2
             calls = [call(test_device, manual=IM.on_off.Manual.DOWN),
-                     call(test_device, is_on=False, mode=IM.on_off.Mode.MANUAL, reason='device')]
+                     call(test_device, is_on=False, level=None,
+                          mode=IM.on_off.Mode.MANUAL, reason='device')]
             mocked.assert_has_calls(calls)
         with mock.patch.object(IM.Signal, 'emit') as mocked:
             flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
@@ -75,7 +76,8 @@ class Test_Base_Config():
             test_device.handle_broadcast(msg)
             assert mocked.call_count == 2
             calls = [call(test_device, manual=IM.on_off.Manual.UP),
-                     call(test_device, is_on=True, mode=IM.on_off.Mode.MANUAL, reason='device')]
+                     call(test_device, is_on=True, level=None,
+                          mode=IM.on_off.Mode.MANUAL, reason='device')]
             mocked.assert_has_calls(calls)
 
     def test_set_backlight(self, test_device):

--- a/tests/mqtt/test_IOLincMqtt.py
+++ b/tests/mqtt/test_IOLincMqtt.py
@@ -59,17 +59,17 @@ class Test_IOLinc:
     def test_template(self, setup):
         mdev, addr, name = setup.getAll(['mdev', 'addr', 'name'])
 
-        data = mdev.template_data()
+        data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
         assert data == right
 
-        data = mdev.template_data(relay_is_on=True, sensor_is_on=True)
+        data = mdev.state_template_data(relay_is_on=True, sensor_is_on=True)
         right = {"address" : addr.hex, "name" : name,
                  "relay_on" : 1, "relay_on_str" : "on",
                  "sensor_on" : 1, "sensor_on_str" : "on"}
         assert data == right
 
-        data = mdev.template_data(relay_is_on=False, sensor_is_on=False)
+        data = mdev.state_template_data(relay_is_on=False, sensor_is_on=False)
         right = {"address" : addr.hex, "name" : name,
                  "relay_on" : 0, "relay_on_str" : "off",
                  "sensor_on" : 0, "sensor_on_str" : "off"}
@@ -84,13 +84,13 @@ class Test_IOLinc:
         mdev.load_config({})
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, True, True)
-        dev.signal_on_off.emit(dev, False, False)
+        dev.signal_state.emit(dev, relay_is_on=True, sensor_is_on=True)
+        dev.signal_state.emit(dev, relay_is_on=False, sensor_is_on=False)
         # There are three topics per message state, relay, sensor
         assert len(link.client.pub) == 6
         assert link.client.pub[0] == dict(
             topic='%s/state' % topic,
-            payload='{"sensor": "on", "relay": "on"}',
+            payload='{"sensor":"on", "relay":"on"}',
             qos=0, retain=True)
         assert link.client.pub[1] == dict(
             topic='%s/relay' % topic,
@@ -102,7 +102,7 @@ class Test_IOLinc:
             qos=0, retain=True)
         assert link.client.pub[3] == dict(
             topic='%s/state' % topic,
-            payload='{"sensor": "off", "relay": "off"}',
+            payload='{"sensor":"off", "relay":"off"}',
             qos=0, retain=True)
         assert link.client.pub[4] == dict(
             topic='%s/relay' % topic,
@@ -132,8 +132,8 @@ class Test_IOLinc:
         stopic = "foo/%s" % setup.addr.hex
 
         # Send an on/off signal
-        dev.signal_on_off.emit(dev, True, True)
-        dev.signal_on_off.emit(dev, False, False)
+        dev.signal_state.emit(dev, relay_is_on=True, sensor_is_on=True)
+        dev.signal_state.emit(dev, relay_is_on=False, sensor_is_on=False)
         assert len(link.client.pub) == 6
         assert link.client.pub[0] == dict(
             topic=stopic, payload='1 ON', qos=qos, retain=True)

--- a/tests/mqtt/test_KeypadLinc.py
+++ b/tests/mqtt/test_KeypadLinc.py
@@ -318,7 +318,7 @@ class Test_KeypadLinc:
                 ack = IM.message.InpStandard(dev.addr.hex,
                                              dev.modem.addr.hex,
                                              flags, cmd1, cmd2)
-                dev.handle_set_load(ack, IM.util.make_callback(None))
+                dev.handle_ack(ack, IM.util.make_callback(None))
                 assert dev._level == cmd2
 
 #-----------------------------------------------------------------------
@@ -395,7 +395,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x2f, 0x08)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -417,7 +417,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x2e, 0xf5)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -439,7 +439,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x2f, 0x00)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -461,7 +461,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x2e, 0x4e)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -483,7 +483,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x2f, 0x0d)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -505,7 +505,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x2e, 0xfd)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -531,7 +531,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x14, 0x00)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -554,7 +554,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x21, 0x43)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
         # Check that reported state matches command
         assert len(link.client.pub) == 2
         assert link.client.pub[1] == dict(
@@ -575,7 +575,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x14, 0x00)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -598,7 +598,7 @@ class Test_KeypadLinc:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x21, 0x43)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
         # Check that reported state matches command
         assert len(link.client.pub) == 2
         assert link.client.pub[1] == dict(

--- a/tests/mqtt/test_KeypadLinc_sw.py
+++ b/tests/mqtt/test_KeypadLinc_sw.py
@@ -233,7 +233,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x13, 0x00)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -255,7 +255,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x11, 0xff)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -277,7 +277,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x13, 0x00)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -299,7 +299,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x11, 0xff)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -321,7 +321,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x13, 0x00)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -343,7 +343,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x11, 0xff)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -369,7 +369,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x14, 0x00)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -392,7 +392,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x21, 0xff)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
         # Check that reported state matches command
         assert len(link.client.pub) == 2
         assert link.client.pub[1] == dict(
@@ -413,7 +413,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x14, 0x00)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
 
         # Check that reported state matches command
         assert len(link.client.pub) == 2
@@ -436,7 +436,7 @@ class Test_KeypadLinc_sw:
         flags = IM.message.Flags(IM.message.Flags.Type.DIRECT_ACK, False)
         ack = IM.message.InpStandard(setup.addr.hex, modem.addr.hex, flags,
                                      0x21, 0xff)
-        dev.handle_set_load(ack, IM.util.make_callback(None))
+        dev.handle_ack(ack, IM.util.make_callback(None))
         # Check that reported state matches command
         assert len(link.client.pub) == 2
         assert link.client.pub[1] == dict(


### PR DESCRIPTION
Continuing the process of condensing everything.  This moves the following functions which were largely duplicated into a single location:
- On
- Off
- Set
- Handle_Ack - The callback for the above functions
- _Set_State - Called by Handle_Ack (among others).  Used to cache the device state and emit the data to the state topic.  It was previously named all sorts of things in various files.

Again, this probably adds support to the "reason" attribute in some places where it was not previously enabled.

- [x] Unit tests updated and passing
- [x] Code documentation updated
- [x] This should not alter the functionality from the user perspective
- [x] Linters
- [x] Running locally for a period of time

There are still a few more things that can be cleaned up.  The set-flags regime is looking ripe for a cleanup as well.  