### PR TITLE
Remove Link_Cleanup_Report from Broadcast Callbacks

### DIFF
--- a/insteon_mqtt/device/Base.py
+++ b/insteon_mqtt/device/Base.py
@@ -1054,10 +1054,9 @@ class Base:
         The broadcast message from a device is sent when the device is
         triggered.  The message has the group ID in it, this uses the class
         attribute group_map to map the group to the handler that should process
-        the message.  This handler should be prepared to receive both broadcast
-        messages and CmdType.LINK_CLEANUP_REPORT messages as well. The handler
-        should likely pass all valid broadcast commands to
-        update_linked_devices() so that the associated devices can be updated.
+        the message.  The handler should likely pass all valid broadcast
+        commands to update_linked_devices() so that the associated devices can
+        be updated.
 
         Args:
           msg (InpStandard): Broadcast message from the device.

--- a/insteon_mqtt/device/BatterySensor.py
+++ b/insteon_mqtt/device/BatterySensor.py
@@ -169,15 +169,10 @@ class BatterySensor(functions.State, Base):
         Args:
           msg (InpStandard):  Broadcast message from the device.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("BatterySensor %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-        else:
-            LOG.info("BatterySensor %s on_off broadcast cmd: %s", self.addr,
-                     msg.cmd1)
-            self._set_state(is_on=(msg.cmd1 == Msg.CmdType.ON))
-            self.update_linked_devices(msg)
+        LOG.info("BatterySensor %s on_off broadcast cmd: %s", self.addr,
+                 msg.cmd1)
+        self._set_state(is_on=(msg.cmd1 == Msg.CmdType.ON))
+        self.update_linked_devices(msg)
 
     #-----------------------------------------------------------------------
     def handle_low_battery(self, msg):
@@ -190,16 +185,11 @@ class BatterySensor(functions.State, Base):
           msg (InpStandard):  Broadcast message from the device.  On/off is
               stored in msg.cmd1.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("BatterySensor %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-        else:
-            LOG.info("BatterySensor %s low battery broadcast cmd: %s",
-                     self.addr, msg.cmd1)
-            # Send True for low battery, False for regular.
-            self.signal_low_battery.emit(self, msg.cmd1 == Msg.CmdType.ON)
-            self.update_linked_devices(msg)
+        LOG.info("BatterySensor %s low battery broadcast cmd: %s",
+                 self.addr, msg.cmd1)
+        # Send True for low battery, False for regular.
+        self.signal_low_battery.emit(self, msg.cmd1 == Msg.CmdType.ON)
+        self.update_linked_devices(msg)
 
     #-----------------------------------------------------------------------
     def handle_heartbeat(self, msg):
@@ -211,16 +201,11 @@ class BatterySensor(functions.State, Base):
         Args:
           msg (InpStandard):  Broadcast message from the device.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("BatterySensor %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-        else:
-            LOG.info("BatterySensor %s heartbeat broadcast cmd: %s", self.addr,
-                     msg.cmd1)
-            # Send True for any heart beat message
-            self.signal_heartbeat.emit(self, True)
-            self.update_linked_devices(msg)
+        LOG.info("BatterySensor %s heartbeat broadcast cmd: %s", self.addr,
+                 msg.cmd1)
+        # Send True for any heart beat message
+        self.signal_heartbeat.emit(self, True)
+        self.update_linked_devices(msg)
 
     #-----------------------------------------------------------------------
     def handle_refresh(self, msg):

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -563,15 +563,7 @@ class Dimmer(functions.Scene, functions.SetAndState, Base):
                  on_off.REASON_DEVICE
         self.broadcast_reason = ""
 
-        # ACK of the broadcast.  Ignore this unless we sent a simulated off
-        # scene in which case run the broadcast done handler.  This is a
-        # weird special case - see scene() for details.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("Dimmer %s broadcast ACK grp: %s", self.addr, msg.group)
-            return
-
-        # On/off commands.
-        elif on_off.Mode.is_valid(msg.cmd1):
+        if on_off.Mode.is_valid(msg.cmd1):
             is_on, mode = on_off.Mode.decode(msg.cmd1)
             LOG.info("Dimmer %s broadcast grp: %s on: %s mode: %s", self.addr,
                      msg.group, is_on, mode)

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -523,13 +523,8 @@ class IOLinc(functions.SetAndState, Base):
         Args:
           msg (InpStandard):  Broadcast message from the device.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("IOLinc %s broadcast ACK grp: %s", self.addr, msg.group)
-            return
-
         # On command.  0x11: on
-        elif msg.cmd1 == Msg.CmdType.ON:
+        if msg.cmd1 == Msg.CmdType.ON:
             LOG.info("IOLinc %s broadcast ON grp: %s", self.addr, msg.group)
             self._set_state(group=GROUP_SENSOR, is_on=True)
             if self.relay_linked:

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -1405,16 +1405,8 @@ class KeypadLinc(functions.SetAndState, functions.Scene, Base):
                  on_off.REASON_DEVICE
         self.broadcast_reason = ""
 
-        # ACK of the broadcast.  Ignore this unless we sent a simulated off
-        # scene in which case run the broadcast done handler.  This is a
-        # weird special case - see scene() for details.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("KeypadLinc %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-            return
-
         # On/off commands.
-        elif on_off.Mode.is_valid(msg.cmd1):
+        if on_off.Mode.is_valid(msg.cmd1):
             is_on, mode = on_off.Mode.decode(msg.cmd1)
             LOG.info("KeypadLinc %s broadcast grp: %s on: %s mode: %s",
                      self.addr, msg.group, is_on, mode)

--- a/insteon_mqtt/device/Leak.py
+++ b/insteon_mqtt/device/Leak.py
@@ -82,14 +82,9 @@ class Leak(BatterySensor):
         Args:
           msg (InpStandard):  Broadcast message from the device.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("LeakSensor %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-        else:
-            LOG.info("LeakSensor %s received is-dry message", self.label)
-            self._set_is_wet(False)
-            self.update_linked_devices(msg)
+        LOG.info("LeakSensor %s received is-dry message", self.label)
+        self._set_is_wet(False)
+        self.update_linked_devices(msg)
 
     #-----------------------------------------------------------------------
     def handle_wet(self, msg):
@@ -101,14 +96,9 @@ class Leak(BatterySensor):
         Args:
           msg (InpStandard):  Broadcast message from the device.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("LeakSensor %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-        else:
-            LOG.info("LeakSensor %s received is-wet message", self.label)
-            self._set_is_wet(True)
-            self.update_linked_devices(msg)
+        LOG.info("LeakSensor %s received is-wet message", self.label)
+        self._set_is_wet(True)
+        self.update_linked_devices(msg)
 
     #-----------------------------------------------------------------------
     def handle_heartbeat(self, msg):
@@ -123,20 +113,15 @@ class Leak(BatterySensor):
         Args:
           msg (InpStandard):  Broadcast message from the device.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("LeakSensor %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-        else:
-            LOG.info("LeakSensor %s received heartbeat", self.label)
-            # Update the wet/dry state using the heartbeat if needed.
-            is_wet = msg.cmd1 == 0x13
-            if self._is_wet != is_wet:
-                self._set_is_wet(is_wet)
+        LOG.info("LeakSensor %s received heartbeat", self.label)
+        # Update the wet/dry state using the heartbeat if needed.
+        is_wet = msg.cmd1 == 0x13
+        if self._is_wet != is_wet:
+            self._set_is_wet(is_wet)
 
-            # Send True for any heart beat message
-            self.signal_heartbeat.emit(self, True)
-            self.update_linked_devices(msg)
+        # Send True for any heart beat message
+        self.signal_heartbeat.emit(self, True)
+        self.update_linked_devices(msg)
 
     #-----------------------------------------------------------------------
     def handle_refresh(self, msg):

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -198,15 +198,10 @@ class Motion(BatterySensor):
           msg (InpStandard):  Broadcast message from the device.
 
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("Motion %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-        else:
-            # Send True for dawn, False for dusk.
-            LOG.info("Motion %s broadcast grp: %s cmd %s", self.addr,
-                     msg.group, msg.cmd1)
-            self.signal_dawn.emit(self, msg.cmd1 == Msg.CmdType.ON)
+        # Send True for dawn, False for dusk.
+        LOG.info("Motion %s broadcast grp: %s cmd %s", self.addr,
+                 msg.group, msg.cmd1)
+        self.signal_dawn.emit(self, msg.cmd1 == Msg.CmdType.ON)
 
     #-----------------------------------------------------------------------
     def set_flags(self, on_done, **kwargs):

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -296,11 +296,8 @@ class Outlet(functions.SetAndState, Base):
           msg (InpStandard):  Broadcast message from the device.
         """
         reason = on_off.REASON_DEVICE
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("Outlet %s broadcast ACK grp: %s", self.addr, msg.group)
-
         # On/off command codes.
-        elif on_off.Mode.is_valid(msg.cmd1):
+        if on_off.Mode.is_valid(msg.cmd1):
             is_on, mode = on_off.Mode.decode(msg.cmd1)
             LOG.info("Outlet %s broadcast grp: %s on: %s mode: %s", self.addr,
                      msg.group, is_on, mode)

--- a/insteon_mqtt/device/Remote.py
+++ b/insteon_mqtt/device/Remote.py
@@ -146,30 +146,25 @@ class Remote(BatterySensor):
         Args:
           msg (InpStandard):  Broadcast message from the device.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("BatterySensor %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-        else:
-            # On/off command codes.
-            if on_off.Mode.is_valid(msg.cmd1):
-                is_on, mode = on_off.Mode.decode(msg.cmd1)
-                LOG.info("Remote %s broadcast grp: %s on: %s mode: %s",
-                         self.addr, msg.group, is_on, mode)
+        # On/off command codes.
+        if on_off.Mode.is_valid(msg.cmd1):
+            is_on, mode = on_off.Mode.decode(msg.cmd1)
+            LOG.info("Remote %s broadcast grp: %s on: %s mode: %s",
+                     self.addr, msg.group, is_on, mode)
 
-                # Notify others that the button was pressed.
-                self.signal_state.emit(self, button=msg.group, is_on=is_on,
-                                       mode=mode)
-                self.update_linked_devices(msg)
+            # Notify others that the button was pressed.
+            self.signal_state.emit(self, button=msg.group, is_on=is_on,
+                                   mode=mode)
+            self.update_linked_devices(msg)
 
-            # Starting or stopping manual increment (cmd2 0x00=up, 0x01=down)
-            elif on_off.Manual.is_valid(msg.cmd1):
-                manual = on_off.Manual.decode(msg.cmd1, msg.cmd2)
-                LOG.info("Remote %s manual change group: %s %s", self.addr,
-                         msg.group, manual)
+        # Starting or stopping manual increment (cmd2 0x00=up, 0x01=down)
+        elif on_off.Manual.is_valid(msg.cmd1):
+            manual = on_off.Manual.decode(msg.cmd1, msg.cmd2)
+            LOG.info("Remote %s manual change group: %s %s", self.addr,
+                     msg.group, manual)
 
-                self.signal_manual.emit(self, button=msg.group, manual=manual)
-                self.update_linked_devices(msg)
+            self.signal_manual.emit(self, button=msg.group, manual=manual)
+            self.update_linked_devices(msg)
 
     #-----------------------------------------------------------------------
     def link_data(self, is_controller, group, data=None):

--- a/insteon_mqtt/device/SmokeBridge.py
+++ b/insteon_mqtt/device/SmokeBridge.py
@@ -120,15 +120,10 @@ class SmokeBridge(Base):
         Args:
           msg (InpStandard):  Broadcast message from the device.
         """
-        # ACK of the broadcast - ignore this.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("Smoke bridge %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-
         # 0x11 ON command for the smoke bridge means the error is active.
         # NOTE: there is no off command - that seems to be handled by the
         # bridge sending the CLEAR condition group.
-        elif msg.cmd1 == Msg.CmdType.ON:
+        if msg.cmd1 == Msg.CmdType.ON:
             LOG.info("Smoke bridge %s broadcast ON grp: %s", self.addr,
                      msg.group)
 

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -173,15 +173,8 @@ class Switch(functions.SetAndState, functions.Scene, Base):
                  on_off.REASON_DEVICE
         self.broadcast_reason = ""
 
-        # ACK of the broadcast.  Ignore this unless we sent a simulated off
-        # scene in which case run the broadcast done handler.  This is a
-        # weird special case - see scene() for details.
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("Switch %s broadcast ACK grp: %s", self.addr, msg.group)
-            return
-
         # On/off command codes.
-        elif on_off.Mode.is_valid(msg.cmd1):
+        if on_off.Mode.is_valid(msg.cmd1):
             is_on, mode = on_off.Mode.decode(msg.cmd1)
             LOG.info("Switch %s broadcast grp: %s on: %s mode: %s", self.addr,
                      msg.group, is_on, mode)

--- a/insteon_mqtt/device/Thermostat.py
+++ b/insteon_mqtt/device/Thermostat.py
@@ -436,11 +436,7 @@ class Thermostat(Base):
         Args:
           msg (InpStandard): Broadcast message from the device.
         """
-        if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
-            LOG.info("Thermostat %s broadcast ACK grp: %s", self.addr,
-                     msg.group)
-            return
-        elif msg.cmd1 in [Msg.CmdType.ON, Msg.CmdType.OFF]:
+        if msg.cmd1 in [Msg.CmdType.ON, Msg.CmdType.OFF]:
             LOG.info("Thermostat %s broadcast %s grp: %s", self.addr, msg.cmd1,
                      msg.group)
 

--- a/insteon_mqtt/handler/Broadcast.py
+++ b/insteon_mqtt/handler/Broadcast.py
@@ -28,7 +28,10 @@ class Broadcast(Base):
     Finally a broadcast LINK_CLEANUP_REPORT is sent.  This message indicates
     if the device received ACKs from all linked devices or not.  This message
     indicates that the device is finished sending messages.  However, as
-    broadcast message, it is not guaranteed to be received.
+    broadcast message, it is not guaranteed to be received.  Some devices
+    even have a user option to turn off these messages.  These messages
+    contain information about how the success or failure of the broadcast but
+    do not contain the ON/OFF value of the broadcast.
 
     This handler will call device.handle_broadcast(msg) for the device that
     sends the message.
@@ -92,8 +95,6 @@ class Broadcast(Base):
         if msg.flags.type == Msg.Flags.Type.ALL_LINK_BROADCAST:
             if msg.cmd1 == Msg.CmdType.LINK_CLEANUP_REPORT:
                 # This is the final broadcast signalling completion.
-                # All of these messages will be forwarded to the device
-                # potentially even duplicates
                 # Re-enable sending
                 # First clear wait time
                 protocol.set_wait_time(0)
@@ -106,7 +107,7 @@ class Broadcast(Base):
                 else:
                     text = "Cleanup report for %s, grp %s had %d fails."
                     LOG.warning(text, msg.from_addr, msg.group, msg.cmd2)
-                return self._process(msg, protocol, wait_time)
+                return Msg.CONTINUE
             else:
                 # This is the initial broadcast or an echo of it.
                 if self._should_process(msg, wait_time):

--- a/insteon_mqtt/handler/Broadcast.py
+++ b/insteon_mqtt/handler/Broadcast.py
@@ -30,7 +30,7 @@ class Broadcast(Base):
     indicates that the device is finished sending messages.  However, as
     broadcast message, it is not guaranteed to be received.  Some devices
     even have a user option to turn off these messages.  These messages
-    contain information about how the success or failure of the broadcast but
+    contain information about the success or failure of the broadcast but
     do not contain the ON/OFF value of the broadcast.
 
     This handler will call device.handle_broadcast(msg) for the device that

--- a/tests/device/test_BatterySensorDev.py
+++ b/tests/device/test_BatterySensorDev.py
@@ -45,7 +45,6 @@ class Test_Base_Config():
     @pytest.mark.parametrize("cmd1,expected", [
         (Msg.CmdType.ON, True),
         (Msg.CmdType.OFF, False),
-        (Msg.CmdType.LINK_CLEANUP_REPORT, None),
     ])
     def test_broadcast_1(self, test_device, cmd1, expected):
         with mock.patch.object(Device.BatterySensor, '_set_state') as mocked:
@@ -62,7 +61,6 @@ class Test_Base_Config():
     @pytest.mark.parametrize("cmd1,expected", [
         (Msg.CmdType.ON, True),
         (Msg.CmdType.OFF, False),
-        (Msg.CmdType.LINK_CLEANUP_REPORT, None),
     ])
     def test_broadcast_3(self, test_device, cmd1, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:
@@ -79,7 +77,6 @@ class Test_Base_Config():
     @pytest.mark.parametrize("cmd1,expected", [
         (Msg.CmdType.ON, True),
         (Msg.CmdType.OFF, True),
-        (Msg.CmdType.LINK_CLEANUP_REPORT, None),
     ])
     def test_broadcast_4(self, test_device, cmd1, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:

--- a/tests/device/test_LeakDev.py
+++ b/tests/device/test_LeakDev.py
@@ -44,12 +44,9 @@ class Test_Base_Config():
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
         (0x01,Msg.CmdType.ON, 0x00,[False]),
         (0x01,Msg.CmdType.OFF, 0x00, [False]),
-        (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
         (0x02,Msg.CmdType.ON, 0x00,[True]),
         (0x02,Msg.CmdType.OFF, 0x00, [True]),
-        (0x02,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
         (0x04,Msg.CmdType.ON, 0x00,[True]),
-        (0x04,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])
     def test_handle_broadcast(self, test_device, group_num, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:

--- a/tests/device/test_MotionDev.py
+++ b/tests/device/test_MotionDev.py
@@ -49,7 +49,6 @@ class Test_Base_Config():
          "mode":IM.on_off.Mode.NORMAL}),
         (0x01,Msg.CmdType.OFF, 0x00, {"is_on":False, "level":None, "button":None, "reason":'',
          "mode":IM.on_off.Mode.NORMAL}),
-        (0x01,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])
     def test_handle_broadcast_state(self, test_device, group_num, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:
@@ -67,13 +66,10 @@ class Test_Base_Config():
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
         (0x02,Msg.CmdType.ON, 0x00,[True]),
         (0x02,Msg.CmdType.OFF, 0x00, [False]),
-        (0x02,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
         (0x03,Msg.CmdType.ON, 0x00,[True]),
         (0x03,Msg.CmdType.OFF, 0x00, [False]),
-        (0x03,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
         (0x04,Msg.CmdType.ON, 0x00,[True]),
         (0x04,Msg.CmdType.OFF, 0x00, [True]),
-        (0x04,Msg.CmdType.LINK_CLEANUP_REPORT, 0x00, None),
     ])
     def test_handle_broadcast(self, test_device, group_num, cmd1, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit') as mocked:

--- a/tests/handler/test_Broadcast.py
+++ b/tests/handler/test_Broadcast.py
@@ -22,7 +22,6 @@ class Test_Broadcast:
 
         r = handler.msg_received(proto, "dummy")
         assert r == Msg.UNKNOWN
-        assert len(calls) == 0
 
         flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
         msg = Msg.InpStandard(addr, broadcast_to_addr, flags, 0x11, 0x01)
@@ -30,11 +29,11 @@ class Test_Broadcast:
         # no device
         r = handler.msg_received(proto, msg)
         assert r == Msg.UNKNOWN
-        assert len(calls) == 0
 
         # test good broadcat
         assert proto.wait_time == 0
         device = IM.device.Base(proto, modem, addr, "foo")
+        device.handle_broadcast = calls.append
 
         # add 10 device db entries for this group
         for count in range(10):
@@ -45,7 +44,6 @@ class Test_Broadcast:
                                       bytes([0x01, 0x02, 0x03]))
             device.db.add_entry(entry)
 
-        device.handle_broadcast = calls.append
         modem.add(device)
         r = handler.msg_received(proto, msg)
 
@@ -76,33 +74,37 @@ class Test_Broadcast:
         assert r == Msg.CONTINUE
         assert len(calls) == 2
 
+        # A direct message should be unknown
         flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
         msg = Msg.InpStandard(addr, addr, flags, 0x11, 0x01)
         r = handler.msg_received(proto, msg)
         assert r == Msg.UNKNOWN
+        assert len(calls) == 2
 
-        # Success Report Broadcast
+        # Success Report Broadcast, should not be sent to device
         pre_success_time = proto.wait_time
         flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
         success_report_to_addr = IM.Address(0x11, 1, 0x1)
-        msg = Msg.InpStandard(addr, addr, flags, 0x06, 0x00)
+        msg = Msg.InpStandard(addr, addr, flags,
+                              Msg.CmdType.LINK_CLEANUP_REPORT, 0x00)
         r = handler.msg_received(proto, msg)
 
         assert r == Msg.CONTINUE
-        assert len(calls) == 3
+        assert len(calls) == 2
         # wait time should be cleared
         assert proto.wait_time < pre_success_time
 
-        # Failure Report Broadcast
+        # Failure Report Broadcast, should not be sent to device
         pre_success_time = proto.wait_time
         flags = Msg.Flags(Msg.Flags.Type.ALL_LINK_BROADCAST, False)
         success_report_to_addr = IM.Address(0x11, 1, 0x1)
-        msg = Msg.InpStandard(addr, addr, flags, 0x06, 0x01)
+        msg = Msg.InpStandard(addr, addr, flags,
+                              Msg.CmdType.LINK_CLEANUP_REPORT, 0x01)
         r = handler.msg_received(proto, msg)
 
         assert 'Cleanup report for 0a.12.34, grp 52 had 1 fails.' in caplog.text
         assert r == Msg.CONTINUE
-        assert len(calls) == 4
+        assert len(calls) == 2
 
         # Pretend that a new broadcast message dropped / not received by PLM
 
@@ -112,7 +114,7 @@ class Test_Broadcast:
         r = handler.msg_received(proto, msg)
 
         assert r == Msg.CONTINUE
-        assert len(calls) == 5
+        assert len(calls) == 3
 
     #-----------------------------------------------------------------------
 


### PR DESCRIPTION
After fixing #283, there is no longer a need to pass these messages on to the callbacks.

- Not all devices send these messages
- Some devices allow users to disable these messages
- The messages do not contain any valid ON/OFF data that the callback can process
- Removing them simplifies the callback code.
- We shouldn't expect to handle such a low level messaging at the device level