### PR TITLE
Check for Device Ack in BroadcastCmdResponse; Add Unit Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ to add new devices and features. This is the reason for the jump to 0.8.0.
 
 - Updates hassio config to comply with changes in API keys. ([PR 344][P344])
 
+- Fix small bug in BroadcastCmdResponse handler that likely never affected
+  anyone. ([PR 354][P354])
+
 ## [0.7.6]
 
 A few new features and some significant bug fixes.  A significant refactor of
@@ -612,3 +615,4 @@ will add new features.
 [P352]: https://github.com/TD22057/insteon-mqtt/pull/352
 [P344]: https://github.com/TD22057/insteon-mqtt/pull/344
 [P324]: https://github.com/TD22057/insteon-mqtt/pull/324
+[P354]: https://github.com/TD22057/insteon-mqtt/pull/354

--- a/tests/handler/test_BroadcastCmdResponse.py
+++ b/tests/handler/test_BroadcastCmdResponse.py
@@ -130,6 +130,52 @@ class Test_BroadcastCmdResponse:
         assert r == Msg.CONTINUE
         assert handler._PLM_ACK
 
+    def test_device_sent_ack(self):
+        # Tests matching the command from the outbound message.
+        proto = MockProto()
+        calls = []
+
+        def callback(msg, on_done=None):
+            calls.append(msg)
+
+        addr = IM.Address('0a.12.34')
+
+        # sent message, match input command
+        out = Msg.OutStandard.direct(addr, 0x10, 0x00)
+        handler = IM.handler.BroadcastCmdResponse(out, callback)
+
+        # Signal Sent
+        handler.sending_message(out)
+        assert handler._PLM_sent
+
+        # test ack sent
+        out.is_ack = True
+        r = handler.msg_received(proto, out)
+        assert r == Msg.CONTINUE
+        assert handler._PLM_ACK
+
+        # test broadcast before device ack
+        flags = Msg.Flags(Msg.Flags.Type.BROADCAST, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x01, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+        assert len(calls) == 0
+
+        # mock a device ack
+        # expected input meesage
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x10, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.CONTINUE
+
+        # test a broadcast after device ack
+        flags = Msg.Flags(Msg.Flags.Type.BROADCAST, False)
+        msg = Msg.InpStandard(addr, addr, flags, 0x01, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert len(calls) == 1
+        assert calls[0] == msg
+
 #===========================================================================
 
 


### PR DESCRIPTION
Checks that a device ack is received before processing the
broadcast response.

Fixes #335