### PR TITLE
Add Github Templates for Issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,56 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. The command used on the command line `command> `
+4. The MQTT topic you posted to '....'
+5. The MQTT payload you posted to the topic '....'
+6. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Log Output**
+Please change your logging level to 10 by editing Logging.level in your config.yaml file.
+
+```txt
+# Put your relevant logging output below this line
+
+```
+
+**Your Configuration**
+What are the relevant entries in your config.yaml?  Please include the device definition of the device affected.
+```yaml
+# Put your relevant config.yaml text below this line
+
+```
+
+**Hardware Details**
+- What OS is Insteon-MQTT runnning on?
+
+- The model of your Modem, see https://github.com/TD22057/insteon-mqtt/blob/master/docs/mqtt.md#get-device-model-information
+```txt
+# Please paste the output of get-model for the modem below this line
+
+```
+
+- The model of the affected Device, see https://github.com/TD22057/insteon-mqtt/blob/master/docs/mqtt.md#get-device-model-information
+```txt
+# Please paste the output of get-model for the affected device below this line
+
+```
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,48 @@
+<!--
+  You are amazing! Thanks for contributing to our project!
+-->
+## Breaking change
+<!--
+  If your PR contains a breaking change for existing users, it is important
+  to tell them what breaks, how to make it work again and why we did this.
+  This piece of text is published with the release notes, so it helps if you
+  write it towards our users, not us.
+  Note: Remove this section if this PR is NOT a breaking change.
+-->
+
+
+## Proposed change
+<!--
+  Describe the big picture of your changes here to communicate to the
+  maintainers why we should accept this pull request. If it fixes a bug
+  or resolves a feature request, be sure to link to that issue in the
+  additional information section.
+-->
+
+
+## Additional information
+<!--
+  Details are important, and help maintainers processing your PR.
+  Please be sure to fill out additional details, if applicable.
+-->
+
+- This PR fixes or closes issue: fixes #
+- This PR is related to issue:
+- Link to documentation pull request:
+
+## Checklist
+<!--
+  Put an `x` in the boxes that apply. You can also fill these out after
+  creating the PR. If you're unsure about any of them, don't hesitate to ask.
+  We're here to help! This is simply a reminder of what we are going to look
+  for before merging your code.
+-->
+
+- [ ] The code change is tested and works locally.
+- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
+- [ ] Tests have been added to verify that the new code works.
+- [ ] Code documentation was added where necessary
+
+If user exposed functionality or configuration variables are added/changed:
+
+- [ ] Documentation added/updated


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add github templates for Issues and Pull Requests.  I tried to keep them concise but complete.  These should help things go a little more smoothly and will encourage me to be more thoughtful in my documentation and notification of changes.