### PR TITLE
Move Handle_Refresh with Level from ResponderBase to DimmerBase

### DIFF
--- a/insteon_mqtt/device/base/DimmerBase.py
+++ b/insteon_mqtt/device/base/DimmerBase.py
@@ -363,6 +363,28 @@ class DimmerBase(ManualCtrl, ResponderBase, Base):
         if manual == on_off.Manual.STOP:
             self.refresh()
 
+    #-----------------------------------------------------------------------
+    def handle_refresh(self, msg, group=None):
+        """Callback for handling refresh() responses.
+
+        This is called when we get a response to the refresh() command.  The
+        refresh command reply will contain the current device state in cmd2
+        and this updates the device with that value.  It is called by
+        handler.DeviceRefresh when we can an ACK for the refresh command.
+
+        Overrides Base.handle_refresh in order to add the level key to
+        _set_state().
+
+        Args:
+          msg (message.InpStandard): The refresh message reply.  The current
+              device state is in the msg.cmd2 field.
+        """
+        LOG.ui("Device %s refresh cmd2 %s", self.addr, msg.cmd2)
+
+        # Level works for most things can add a derive state if needed.
+        self._set_state(level=msg.cmd2, group=group,
+                        reason=on_off.REASON_REFRESH)
+
     #========= Manual Functions
     #-----------------------------------------------------------------------
     def react_to_manual(self, manual, group, reason):

--- a/insteon_mqtt/device/base/ResponderBase.py
+++ b/insteon_mqtt/device/base/ResponderBase.py
@@ -308,28 +308,6 @@ class ResponderBase(Base):
                         msg.cmd1)
 
     #-----------------------------------------------------------------------
-    def handle_refresh(self, msg, group=None):
-        """Callback for handling refresh() responses.
-
-        This is called when we get a response to the refresh() command.  The
-        refresh command reply will contain the current device state in cmd2
-        and this updates the device with that value.  It is called by
-        handler.DeviceRefresh when we can an ACK for the refresh command.
-
-        Overrides Base.handle_refresh in order to add the level key to
-        _set_state().
-
-        Args:
-          msg (message.InpStandard): The refresh message reply.  The current
-              device state is in the msg.cmd2 field.
-        """
-        LOG.ui("Device %s refresh cmd2 %s", self.addr, msg.cmd2)
-
-        # Level works for most things can add a derive state if needed.
-        self._set_state(level=msg.cmd2, group=group,
-                        reason=on_off.REASON_REFRESH)
-
-    #-----------------------------------------------------------------------
     def group_cmd_local_group(self, entry):
         """Get the Local Group Affected by this Group Command
 

--- a/tests/device/test_IOLincDev.py
+++ b/tests/device/test_IOLincDev.py
@@ -285,8 +285,8 @@ class Test_Handles():
         assert test_iolinc.momentary_secs == seconds
 
     @pytest.mark.parametrize("cmd2,expected", [
-        (0x00, 0x00),
-        (0Xff, 0xFF),
+        (0x00, False),
+        (0Xff, True),
     ])
     def test_handle_refresh_relay(self, test_iolinc, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit'):
@@ -296,13 +296,13 @@ class Test_Handles():
             msg = IM.message.InpStandard(from_addr, to_addr, flags, 0x19, cmd2)
             test_iolinc.handle_refresh(msg, group=2)
             calls = IM.Signal.emit.call_args_list
-            assert calls[0][1]['level'] == expected
+            assert calls[0][1]['is_on'] == expected
             assert calls[0][1]['button'] == 2
             assert IM.Signal.emit.call_count == 1
 
     @pytest.mark.parametrize("cmd2,expected", [
-        (0x00, 0x00),
-        (0Xff, 0xff),
+        (0x00, False),
+        (0Xff, True),
     ])
     def test_handle_refresh_sensor(self, test_iolinc, cmd2, expected):
         with mock.patch.object(IM.Signal, 'emit'):
@@ -312,7 +312,7 @@ class Test_Handles():
             msg = IM.message.InpStandard(from_addr, to_addr, flags, 0x19, cmd2)
             test_iolinc.handle_refresh(msg, group=1)
             calls = IM.Signal.emit.call_args_list
-            assert calls[0][1]['level'] == expected
+            assert calls[0][1]['is_on'] == expected
             assert calls[0][1]['button'] == 1
             assert IM.Signal.emit.call_count == 1
 


### PR DESCRIPTION
## Proposed change
Moves handle_refresh with level support from ResponderBase to DimmerBase.  This was a mistake I made in #334.  There is no affect on the end user, this is only a change that alters how the code appears to a developer.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary
