### PR TITLE
Add Get_Flags Function to Modem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ to add new devices and features. This is the reason for the jump to 0.8.0.
   to the command line `insteon-mqtt config.yaml -v`.  Both will return the
   version of Insteon-MQTT. ([PR 355][P355])
 
+- Adds get_flags suppport to the modem.  Only needed for debugging.
+  ([PR 359][P359])
+
 ### Fixes
 
 - Fixed an error where setting the MQTT id would prevent subscribing to
@@ -621,3 +624,4 @@ will add new features.
 [P324]: https://github.com/TD22057/insteon-mqtt/pull/324
 [P354]: https://github.com/TD22057/insteon-mqtt/pull/354
 [P355]: https://github.com/TD22057/insteon-mqtt/pull/355
+[P359]: https://github.com/TD22057/insteon-mqtt/pull/359

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -453,7 +453,19 @@ commands.
 
 ### Get and set operating flags.
 
-Supported: devices
+Supported: devices, modem (get_flags only)
+
+To request the current flag settings on a device:
+
+  ```
+  insteon-mqtt config.yaml get-flags aa.bb.cc
+  ```
+
+The MQTT format of the command is:
+
+  ```
+  { "cmd" : "get_flags"}
+  ```
 
 This command gets and sets various Insteon device flags.  The set of
 supported flags depends on the device type.  The command line tool accepts an

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -87,6 +87,7 @@ class Modem:
             'linking' : self.linking,
             'scene' : self.scene,
             'factory_reset' : self.factory_reset,
+            'get_flags' : self.get_flags,
             'sync_all' : self.sync_all,
             'sync' : self.sync,
             'import_scenes': self.import_scenes,
@@ -710,6 +711,18 @@ class Modem:
         LOG.warning("Modem being reset.  All data will be lost")
         msg = Msg.OutResetModem()
         msg_handler = handler.ModemReset(self, on_done)
+        self.send(msg, msg_handler)
+
+    #-----------------------------------------------------------------------
+    def get_flags(self, on_done=None):
+        """Queries and Prints the Modem Flags to the Log
+
+        Args:
+          on_done:  Finished callback.  This is called when the command has
+                    completed.  Signature is: on_done(success, msg, data)
+        """
+        msg = Msg.OutGetModemFlags()
+        msg_handler = handler.ModemGetFlags(self, on_done)
         self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/ModemGetFlags.py
+++ b/insteon_mqtt/handler/ModemGetFlags.py
@@ -1,0 +1,63 @@
+#===========================================================================
+#
+# Modem get_flags handler.
+#
+#===========================================================================
+from .. import log
+from .. import message as Msg
+from .Base import Base
+
+LOG = log.get_logger()
+
+
+class ModemGetFlags(Base):
+    """Modem get_flags handler.
+
+    This handles a `get flags` command being sent to the modem. The response
+    to this command is a single message containing the flags and 2 spare
+    bytes.
+    """
+    def __init__(self, modem, on_done=None):
+        """Constructor
+
+        Args
+          modem (Modem):  The Insteon modem object.
+          on_done: The finished callback.  Calling signature:
+                   on_done( bool success, str message, data )
+        """
+        super().__init__(on_done)
+
+        self.modem = modem
+
+    #-----------------------------------------------------------------------
+    def msg_received(self, protocol, msg):
+        """See if we can handle the message.
+
+        If we get an ACK of the user reset, we'll clear the modem database.
+
+        Args:
+          protocol  (Protocol):  The Insteon Protocol object
+          msg:  Insteon message object that was read.
+
+        Returns:
+          Msg.UNKNOWN if we can't handle this message.
+          Msg.CONTINUE if we handled the message and expect more.
+          Msg.FINISHED if we handled the message and are done.
+        """
+        if not self._PLM_sent:
+            # If PLM hasn't sent our message yet, this can't be for us
+            return Msg.UNKNOWN
+        if isinstance(msg, Msg.OutGetModemFlags):
+            if msg.is_ack:
+                LOG.ui("Modem flag byte is: %s, spare bytes are: %s, %s",
+                       msg.modem_flags, msg.spare1, msg.spare2)
+                self.on_done(True, "Modem get_flags complete", None)
+            else:
+                LOG.error("Modem get_flags failed")
+                self.on_done(False, "Modem get_flags failed", None)
+
+            return Msg.FINISHED
+
+        return Msg.UNKNOWN
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/__init__.py
+++ b/insteon_mqtt/handler/__init__.py
@@ -44,6 +44,7 @@ from .ModemInfo import ModemInfo
 from .ModemLinkComplete import ModemLinkComplete
 from .ModemLinkStart import ModemLinkStart
 from .ModemReset import ModemReset
+from .ModemGetFlags import ModemGetFlags
 from .ModemScene import ModemScene
 from .StandardCmd import StandardCmd
 from .StandardCmdNAK import StandardCmdNAK

--- a/insteon_mqtt/message/OutGetModemFlags.py
+++ b/insteon_mqtt/message/OutGetModemFlags.py
@@ -1,0 +1,87 @@
+#===========================================================================
+#
+# Output insteon reset the PLM modem message.
+#
+#===========================================================================
+from .Base import Base
+
+
+class OutGetModemFlags(Base):
+    """Command requesting the modem configuration
+
+    This command will retun 6 bytes:
+      - 0x02
+      - 0x73
+      - Modem Configuration Flags
+      - Spare 1
+      - Spare 2
+      - Ack/Nak
+    """
+    msg_code = 0x73
+    fixed_msg_size = 6
+
+    #-----------------------------------------------------------------------
+    @classmethod
+    def from_bytes(cls, raw):
+        """Read the message from a byte stream.
+
+        This should only be called if raw[1] == msg_code and len(raw) >=
+        msg_size().
+
+        You cannot pass the output of to_bytes() to this.  to_bytes() is used
+        to output to the PLM but the modem sends back the same message with
+        an extra ack byte which this function can read.
+
+        Args:
+          raw (bytes):  The current byte stream to read from.
+
+        Returns:
+          Returns the constructed OutResetModem object.
+        """
+        assert len(raw) >= cls.fixed_msg_size
+        assert raw[0] == 0x02 and raw[1] == cls.msg_code
+        modem_flags = raw[2]
+        spare1 = raw[3]
+        spare2 = raw[4]
+        is_ack = raw[5] == 0x06
+        return OutGetModemFlags(is_ack, modem_flags, spare1, spare2)
+
+    #-----------------------------------------------------------------------
+    def __init__(self, is_ack=None, modem_flags=None, spare1=None,
+                 spare2=None):
+        """Constructor
+
+        Args:
+          is_ack (bool):  True for ACK, False for NAK.  None for output
+                 commands to the modem.
+        """
+        super().__init__()
+
+        self.is_ack = is_ack
+        self.modem_flags = modem_flags
+        self.spare1 = spare1
+        self.spare2 = spare2
+
+    #-----------------------------------------------------------------------
+    def to_bytes(self):
+        """Convert the message to a byte array.
+
+        Returns:
+          bytes:  Returns the message as bytes.
+        """
+        return bytes([0x02, self.msg_code])
+
+    #-----------------------------------------------------------------------
+    def __str__(self):
+        ack = ""
+        flags = ""
+        spares = ""
+        if self.is_ack is not None:
+            ack = " ack: %s" % str(self.is_ack)
+            flags = " modem flags: %s" % str(self.modem_flags)
+            spares = " spares: %s %s" % (str(self.spare1), str(self.spare2))
+        return "OutGetModemFlags%s%s%s" % (flags, spares, ack)
+
+    #-----------------------------------------------------------------------
+
+#===========================================================================

--- a/insteon_mqtt/message/__init__.py
+++ b/insteon_mqtt/message/__init__.py
@@ -52,6 +52,7 @@ from .OutModemInfo import OutModemInfo
 from .OutModemLinking import OutModemLinking
 from .OutModemScene import OutModemScene
 from .OutResetModem import OutResetModem
+from .OutGetModemFlags import OutGetModemFlags
 from .OutStandard import OutStandard, OutExtended
 
 # Hub Messages
@@ -85,6 +86,7 @@ types = {
     0x69 : OutAllLinkGetFirst,
     0x6a : OutAllLinkGetNext,
     0x6f : OutAllLinkUpdate,
+    0x73 : OutGetModemFlags,
 
     # Hub Messages
     0x7f : HubRFUnknown,

--- a/tests/handler/test_ModemGetFlags.py
+++ b/tests/handler/test_ModemGetFlags.py
@@ -1,0 +1,70 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/handler/ModemGetFlags.py
+#
+# pylint: disable=attribute-defined-outside-init
+#===========================================================================
+import insteon_mqtt as IM
+import insteon_mqtt.message as Msg
+import helpers as H
+
+
+class Test_ModemGetFlags:
+    def test_acks(self, tmpdir):
+        calls = []
+
+        def callback(success, msg, done):
+            calls.append((success, msg, done))
+
+        modem = H.main.MockModem(tmpdir)
+        proto = H.main.MockProtocol()
+        handler = IM.handler.ModemGetFlags(modem, callback)
+        handler._PLM_sent = True
+        handler._PLM_ACK = True
+
+        #Try a good message
+        msg = Msg.OutGetModemFlags(is_ack=True, modem_flags=0x01, spare1=0x02,
+                                   spare2=0x03)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert calls[0][0]
+
+        #Try a NAK message
+        msg = Msg.OutGetModemFlags(is_ack=False, modem_flags=0x01, spare1=0x02,
+                                   spare2=0x03)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert not calls[1][0]
+
+        #Wrong Message
+        msg = Msg.OutResetModem(is_ack=True)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+    #-----------------------------------------------------------------------
+    def test_plm_sent(self, tmpdir):
+        calls = []
+
+        def callback(success, msg, done):
+            calls.append((success, msg, done))
+
+        modem = H.main.MockModem(tmpdir)
+        proto = H.main.MockProtocol()
+        handler = IM.handler.ModemGetFlags(modem, callback)
+        assert not handler._PLM_sent
+
+        #Try a message prior to sent
+        msg = Msg.OutGetModemFlags(is_ack=False, modem_flags=0x01, spare1=0x02,
+                                   spare2=0x03)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.UNKNOWN
+
+        # Signal Sent
+        handler.sending_message(msg)
+        assert handler._PLM_sent
+
+        #Try a message prior to sent
+        msg = Msg.OutGetModemFlags(is_ack=False, modem_flags=0x01, spare1=0x02,
+                                   spare2=0x03)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED

--- a/tests/message/test_OutGetModemFlags.py
+++ b/tests/message/test_OutGetModemFlags.py
@@ -1,0 +1,47 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/message/OutGetModemFlags.py
+#
+#===========================================================================
+import insteon_mqtt.message as Msg
+
+
+class Test_OutGetModemFlags:
+    #-----------------------------------------------------------------------
+    def test_out(self):
+        obj = Msg.OutGetModemFlags()
+        assert obj.fixed_msg_size == 6
+
+        b = obj.to_bytes()
+        rt = bytes([0x02, 0x73])
+        assert b == rt
+
+        str(obj)
+
+    #-----------------------------------------------------------------------
+    def test_in_ack(self):
+        b = bytes([0x02, 0x73, 0x01, 0x02, 0x03, 0x06])
+        obj = Msg.OutGetModemFlags.from_bytes(b)
+        assert obj.is_ack is True
+        assert obj.modem_flags == 0x01
+        assert obj.spare1 == 0x02
+        assert obj.spare2 == 0x03
+
+        str(obj)
+
+    #-----------------------------------------------------------------------
+    def test_in_nack(self):
+        b = bytes([0x02, 0x73, 0x01, 0x02, 0x03, 0x15])
+        obj = Msg.OutGetModemFlags.from_bytes(b)
+        assert obj.is_ack is False
+        assert obj.modem_flags == 0x01
+        assert obj.spare1 == 0x02
+        assert obj.spare2 == 0x03
+
+        str(obj)
+
+
+    #-----------------------------------------------------------------------
+
+
+#===========================================================================


### PR DESCRIPTION
## Proposed change
Adds support for the `get_flags` command on the modem.  The value is only outputted to the log and the UI, it is not saved.

## Additional information
This may be helpful for debugging obscure modem issues, or might be useful in the future.

- This PR is related to issue: #351

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary
- [x] Documentation added/updated
