### PR TITLE
Simplify Modem DB Delete by Using DB_Flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Revision Change History
 
+## [0.8.1]
+
+### Fixes
+
+- Alters the link delete functionality on the Modem.  Solves an issue where
+  some were not able to delete a link on the Modem.  (thanks @zimmer62)
+  ([PR 363][P363])
+
 ## [0.8.0]
 
 This update is the culmination of a significant refactor of the underlying
@@ -625,3 +633,4 @@ will add new features.
 [P354]: https://github.com/TD22057/insteon-mqtt/pull/354
 [P355]: https://github.com/TD22057/insteon-mqtt/pull/355
 [P359]: https://github.com/TD22057/insteon-mqtt/pull/359
+[P363]: https://github.com/TD22057/insteon-mqtt/pull/363

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -11,7 +11,6 @@ from .. import handler
 from .. import log
 from .. import message as Msg
 from .. import util
-from ..CommandSeq import CommandSeq
 from .ModemEntry import ModemEntry
 from .DbDiff import DbDiff
 

--- a/insteon_mqtt/db/Modem.py
+++ b/insteon_mqtt/db/Modem.py
@@ -367,20 +367,6 @@ class Modem:
     def delete_on_device(self, entry, on_done=None):
         """Delete an entry on the device.
 
-        This will delete ALL the entries for an address and group.  The modem
-        doesn't support deleting a specific controller or responder entry -
-        it just deletes the first one that matches the address and group.  To
-        avoid confusion about this, this method clears all relevant entries
-        from our local cache, then it searches the modem for only these
-        relevant entries and adds them back to our cache (this ensures that
-        our cache is correct as to these entries), then it deletes all of the
-        relevant entries on the modem, and finally it restores all related
-        entries that were not marked for deletion.
-
-        This complex process means that it no longer matters if the modem
-        database cache is accurate.  And, while sounding complex, this only
-        takes a second or two to perform.
-
         The on_done callback will be passed a success flag (True/False), a
         string message about what happened, and the DeviceEntry that was
         created (if success=True).
@@ -394,108 +380,16 @@ class Modem:
         """
         on_done = util.make_callback(on_done)
 
-        seq = CommandSeq(self.device, "Modem db delete complete", on_done,
-                         name="ModemDBDel")
-
-        # Find all the entries that match the addr and group inputs.
-        for del_entry in self.find_all(entry.addr, entry.group):
-            self.delete_entry(del_entry)
-
-        # db_flags = Msg.DbFlags.from_bytes(bytes(1))
-        db_flags = Msg.DbFlags(in_use=True, is_controller=entry.is_controller,
+        # Build the delete message.  The Data1-3 values are always 0x00 as
+        # they are ignored by the modem.
+        db_flags = Msg.DbFlags(in_use=True,
+                               is_controller=entry.is_controller,
                                is_last_rec=False)
-        msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.EXISTS, db_flags,
-                                   entry.group, entry.addr, bytes(3))
-        msg_handler = handler.ModemDbSearch(self, on_done=on_done)
-
-        # Queue the search message
-        seq.add_msg(msg, msg_handler)
-
-        # Queue the post search function.
-        seq.add(self._delete_on_device_post_search, entry)
-
-        # Run the sequence
-        seq.run()
-
-    #-----------------------------------------------------------------------
-    def _delete_on_device_post_search(self, entry, on_done=None):
-        """Delete a series of entries on the device.
-
-        This is performed as part of the delete_on_device() function, after
-        the search has been performed of the device.
-
-        Args:
-          addr:          (Address) The address to delete.
-          group:         (int) The group to delete.
-          on_done:       Optional callback which will be called when the
-                         command completes.
-        """
-        on_done = util.make_callback(on_done)
-
-        # Find all the entries that match the addr and group inputs.
-        entries = self.find_all(entry.addr, entry.group)
-
-        # The modem will erase entries in the order it finds them - we can't
-        # erase a specific entry.  So find the ctrl/resp entry we want and
-        # see if there is a different entry first - if there is call delete
-        # until we delete the one we actually want and then restore the other
-        # entry after we're done.
-        #
-        # In a proper database, we should only have found 1 or 2 entries but
-        # it's possible to push duplicate records into the db.  So just find
-        # the first entry that matches our request and only restore one other
-        # which which be the opposite ctrl/responder flag version.
-        restore = None
-        erase_idx = None
-        for i in range(len(entries)):
-            if entries[i].is_controller == entry.is_controller:
-                erase_idx = i
-                break
-
-            if not restore:
-                restore = entries[i]
-
-        if erase_idx is None:
-            LOG.warning("Modem db Delete: Entry was not on modem.")
-            on_done(True, "Entry not on modem", None)
-            return
-
-        LOG.debug("Modem delete %d of %d entries", erase_idx + 1,
-                  len(entries))
-
-        # Build the first delete message.  The Handler will remove the
-        # entries from our db when it get's an ACK.
-        #
-        # Modem will only delete if we pass it an empty flags input (see the
-        # method docs).  This deletes the first entry in the database that
-        # matches the inputs.
-        db_flags = Msg.DbFlags.from_bytes(bytes(1))
         msg = Msg.OutAllLinkUpdate(Msg.OutAllLinkUpdate.Cmd.DELETE, db_flags,
                                    entry.group, entry.addr, bytes(3))
-        msg_handler = handler.ModemDbModify(self, entries[0], on_done=on_done)
+        msg_handler = handler.ModemDbModify(self, entry, on_done=on_done)
 
-        # Add the other delete calls to the handler - these will run in
-        # sequence as we get ACKs for each call.  The final call will call
-        # the on_done() callback.
-        for i in range(1, erase_idx + 1):
-            msg_handler.add_update(msg, entries[i])
-
-        # Add a command to restore the entry we didn't want to delete.
-        if restore:
-            if restore.is_controller:
-                cmd = Msg.OutAllLinkUpdate.Cmd.ADD_CONTROLLER
-            else:
-                cmd = Msg.OutAllLinkUpdate.Cmd.ADD_RESPONDER
-
-            db_flags = Msg.DbFlags(in_use=True,
-                                   is_controller=restore.is_controller,
-                                   is_last_rec=False)
-            msg2 = Msg.OutAllLinkUpdate(cmd, db_flags, restore.group,
-                                        restore.addr, restore.data)
-            msg_handler.add_update(msg2, restore)
-
-        # Send the first message.  If it ACK's, it will keep sending more
-        # deletes - one per entry.
+        # Send the message.
         self.device.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/handler/ModemDbModify.py
+++ b/insteon_mqtt/handler/ModemDbModify.py
@@ -91,10 +91,15 @@ class ModemDbModify(Base):
 
         # If we get a NAK message, signal an error and stop.
         if not msg.is_ack:
-            if msg.cmd == Msg.OutAllLinkUpdate.Cmd.DELETE or self.is_retry:
-                # We should never fail on a DELETE.  If this is a retry then
-                # the matching add/update already failed, which also should not
-                # happen.
+            if msg.cmd == Msg.OutAllLinkUpdate.Cmd.DELETE:
+                # A failed delete only happens.
+                LOG.error("Modem db delete failed: %s", msg)
+                self.on_done(False, "Delete entry from Modem db failed, " +
+                             "entry likely doesn't exist, try running " +
+                             "`refresh modem`", self.entry)
+
+            elif self.is_retry:
+                # A failed retry, stop to prevent infinite looping
                 LOG.error("Modem db update failed: %s", msg)
                 self.on_done(False, "Write to Modem db failed, try running " +
                              "`refresh modem`", self.entry)

--- a/insteon_mqtt/message/DbFlags.py
+++ b/insteon_mqtt/message/DbFlags.py
@@ -82,15 +82,11 @@ class DbFlags:
         return DbFlags(self.in_use, self.is_controller, self.is_last_rec)
 
     #-----------------------------------------------------------------------
-    def to_bytes(self, modem_delete=False):
+    def to_bytes(self):
         """Convert to bytes.
 
         The inverse of this is DbFlags.from_bytes().  This is used to output
         the flags as bytes.
-
-        Args:
-          is_delete (bool):  Set to True if this is delete call to the modem
-                    to modify the database.
 
         Returns:
            bytes:  Returns a 1 byte array containing the bit flags.
@@ -101,10 +97,8 @@ class DbFlags:
 
         # Not sure why this is needed.  Insteon docs say bit 5 is unused.
         # But all the records have it set and if it's not set here, commands
-        # sent to modify the database will fail.  But, for delete calls to
-        # the modem db, this must be zero.
-        if not modem_delete:
-            data |= 1 << 5
+        # sent to modify the database will fail.
+        data |= 1 << 5
 
         return bytes([data])
 

--- a/tests/handler/test_ModemDbModify.py
+++ b/tests/handler/test_ModemDbModify.py
@@ -134,7 +134,7 @@ class Test_ModemDbModify:
                                    data=None, is_ack=False)
         handler.msg_received(test_db.device.protocol, msg)
         assert len(test_db) == 1
-        assert "db update failed" in caplog.text
+        assert "db delete failed" in caplog.text
 
     def test_update(self, test_db, test_entry_dev1_ctrl,
                     test_entry_dev1_ctrl_mod):


### PR DESCRIPTION
## Proposed change
Contrary to the Insteon Specification, it appears the DB Flags can be used in the Delete command.  While using 0x00 for the flags worked in most circumstances, it appears that in some cases for an unknown reason the Delete command would fail on USB Dongle style PLMs.  It is possible that the command was also failing on other PLM styles as well and was not noticed or reported.

Using the DB_Flags is a net win, 1) it simplifies the delete functionality significantly and 2) it seems to solve the problem wherein entries could not be deleted. 

This change removes the complicated Command_Seq wherein the modem first had to be searched for records to delete, the records were deleted and any necessary restored records were restored.

Now, the delete function simply takes an entry and deletes it.  If a nack is return, it is likely that the entry does not exist on the device and a clear error message is returned to the user.

## Additional information
- This PR fixes or closes issue: fixes #351

## Checklist
- [x] The code change is tested and works locally.
- [x] The code changes fix the issue for those who were experiencing it.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works, mostly modified and simplified existing tests.  Many tests for the old complicated process were removed.
- [x] Code documentation was added where necessary
