### PR TITLE
Rename Config.yaml -> Config-Example.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   some were not able to delete a link on the Modem.  (thanks @zimmer62)
   ([PR 363][P363])
 
+- Change the name of the example config file to avoid warnings with Home
+  Assistant Supervisor. ([PR 363][P363])
+
 ## [0.8.0]
 
 This update is the culmination of a significant refactor of the underlying

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -2,6 +2,15 @@
 #
 # Insteon <-> MQTT bridge configuration file.
 #
+# THIS IS JUST AN EXAMPLE FILE!
+#
+# At minimum, you need to make the following edits to use this as your
+# config file:
+# 1. Set the Modem attributes, including port
+# 2. Remove the example devices
+# 3. Add your insteon devices
+# 4. Confirm your MQTT broker settings
+#
 # NOTE: the loader supports using a !include tag to load other as a
 # item entry so you can do things like this:
 #
@@ -475,7 +484,7 @@ mqtt:
     #   address = 'aa.bb.cc'
     #   name = 'device name'
     #   batt_volt = raw insteon voltage level
-  
+
     battery_voltage_topic: 'insteon/{{address}}/battery_voltage'
     battery_voltage_payload: '{"voltage" : {{batt_volt}}}'
 

--- a/docs/auto_start.md
+++ b/docs/auto_start.md
@@ -53,13 +53,13 @@ can be ignored.
    pip3 install .
    ```
 
-Copy the configuration file to the install location.  Edit it to add
+Copy the example configuration file to the install location.  Edit it to add
 your insteon devices and configure your MQTT settings.  Also update
 the storage directory to point at '/opt/insteon-mqtt/data'.  You may
 also want to update the log file locations as well.
 
    ```
-   cp config.yaml /opt/insteon-mqtt/config.yaml
+   cp config-example.yaml /opt/insteon-mqtt/config.yaml
    cd /opt/insteon-mqtt/
    mkdir data
    nano config.yaml
@@ -101,8 +101,8 @@ If everything looks OK, enable the service to start at the next boot.
    ```
    sudo systemctl enable insteon-mqtt
    ```
-You can view the system logs for the process after the service is 
-enabled with this journalctl command (or by manually looking at the 
+You can view the system logs for the process after the service is
+enabled with this journalctl command (or by manually looking at the
 log file).
 
    ```

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -47,8 +47,8 @@ This package assumes that you:
    pip install .
    ```
 
-3) Edit the configuration file `config.yaml`.  You may want to make a
-   copy and place it in the virtual env directory or somewhere like
+3) Edit the example configuration file `config-example.yaml`.  You may want to
+   make a copy and place it in the virtual env directory or somewhere like
    /etc/insteon-mqtt.yaml.
 
    - Set the Insteon port to be the USB port or address of the PLM modem.

--- a/hassio/entrypoint.sh
+++ b/hassio/entrypoint.sh
@@ -2,7 +2,7 @@
 
 /bin/mkdir /config/insteon-mqtt/
 
-/bin/cp /opt/insteon-mqtt/config.yaml /config/insteon-mqtt/config.yaml.default
+/bin/cp /opt/insteon-mqtt/config-example.yaml /config/insteon-mqtt/config.yaml.default
 
 if [ ! -f /config/insteon-mqtt/config.yaml ]; then
     echo "Copying default config.yaml"

--- a/tests/test_Integration.py
+++ b/tests/test_Integration.py
@@ -18,8 +18,8 @@ Tests can be performed on stack.written_msgs and stack.published_topics
 Each test function will create and tear down a full stack fixture.  So use
 sparingly to decrease testing times.
 
-The test devices are created from the sample config.yaml file included in the
-base directory
+The test devices are created from the sample config-example.yaml file included
+in the base directory
 
 """
 from unittest.mock import patch
@@ -78,7 +78,7 @@ class Patch_Stack():
 
         @patch('insteon_mqtt.network.Mqtt.subscribe', self._mqtt_subscribe)
         @patch('insteon_mqtt.config.apply', self._config_apply)
-        @patch('sys.argv', ["", "config.yaml", "start"])
+        @patch('sys.argv', ["", "config-example.yaml", "start"])
         @patch.object(IM.network.Manager, 'active', return_value=False)
         @patch.object(log, 'initialize')
         def start(*args):

--- a/tests/test_Modem.py
+++ b/tests/test_Modem.py
@@ -26,7 +26,7 @@ def test_device():
 
 class Test_Base_Config():
     def test_load_config_no_addr(self, test_device):
-        cfg = IM.config.load('config.yaml')
+        cfg = IM.config.load('config-example.yaml')
         test_device.load_config(cfg)
         # Protocol should load
         test_device.protocol.load_config.assert_called_once_with(cfg)
@@ -37,20 +37,20 @@ class Test_Base_Config():
         assert isinstance(arg_list.args[1], IM.handler.ModemInfo)
 
     def test_load_config_addr(self, test_device):
-        cfg = IM.config.load('config.yaml')
+        cfg = IM.config.load('config-example.yaml')
         cfg['address'] = '44.85.11'
         test_device.load_config(cfg)
         assert test_device.addr == IM.Address('44.85.11')
 
     def test_load_config_step2_fail_no_addr(self, test_device, tmpdir):
-        cfg = IM.config.load('config.yaml')
+        cfg = IM.config.load('config-example.yaml')
         cfg['storage'] = tmpdir
         with mock.patch('sys.exit') as mocked:
             test_device.load_config_step2(False, 'message', None, cfg)
             mocked.assert_called_once()
 
     def test_load_config_step2_fail_addr(self, test_device, tmpdir, caplog):
-        cfg = IM.config.load('config.yaml')
+        cfg = IM.config.load('config-example.yaml')
         cfg['storage'] = tmpdir
         test_device.addr = IM.Address('44.85.11')
         test_device.load_config_step2(False, 'message', None, cfg)
@@ -58,7 +58,7 @@ class Test_Base_Config():
 
     def test_load_config_step2_success_addr_same(self, test_device, tmpdir,
                                                  caplog):
-        cfg = IM.config.load('config.yaml')
+        cfg = IM.config.load('config-example.yaml')
         cfg['storage'] = tmpdir
         test_device.addr = IM.Address('44.85.11')
         msg = Msg.OutModemInfo(addr=test_device.addr, dev_cat=None,
@@ -69,7 +69,7 @@ class Test_Base_Config():
 
     def test_load_config_step2_success_addr_diff(self, test_device, tmpdir,
                                                  caplog):
-        cfg = IM.config.load('config.yaml')
+        cfg = IM.config.load('config-example.yaml')
         cfg['storage'] = tmpdir
         test_device.addr = IM.Address('44.85.11')
         msg = Msg.OutModemInfo(addr=IM.Address('44.85.12'), dev_cat=None,
@@ -79,7 +79,7 @@ class Test_Base_Config():
 
     def test_load_config_step2_success_no_addr(self, test_device, tmpdir,
                                                caplog):
-        cfg = IM.config.load('config.yaml')
+        cfg = IM.config.load('config-example.yaml')
         cfg['storage'] = tmpdir
         msg = Msg.OutModemInfo(addr=IM.Address('44.85.12'), dev_cat=None,
                                sub_cat=None, firmware=None, is_ack=True)


### PR DESCRIPTION
## Proposed change
Home Assistant now supports defining the supervisor config in yaml form.  Which is causing it to read our config.yaml file as a Supervisor config and throwing all sorts of warnings.

This renames the included config file, which also has the benefit of making it more clear to users that they need to modify the
file before using it.

## Additional information
- This PR fixes or closes issue: fixes #362

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been updated to verify that the new code works.
- [x] Documentation added/updated (added notes to config-example.yaml)
