### PR TITLE
Add Button to Decode_On_Level;  Add Unit Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision Change History
 
+## [0.8.2]
+
+### Fixes
+
+- Corrects a bug which prevented Keypadlincs of the Switch variety from
+  reporting their state via the MQTT state topic.  ([PR 368][P368])
+
 ## [0.8.1]
 
 ### Fixes
@@ -637,3 +644,4 @@ will add new features.
 [P355]: https://github.com/TD22057/insteon-mqtt/pull/355
 [P359]: https://github.com/TD22057/insteon-mqtt/pull/359
 [P363]: https://github.com/TD22057/insteon-mqtt/pull/363
+[P368]: https://github.com/TD22057/insteon-mqtt/pull/368

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -202,6 +202,9 @@ class KeypadLinc(Scene, Backlight, ManualCtrl, ResponderBase):
         we get an ACK of the result, we'll change our internal state and emit
         the state changed signals.
 
+        This exists here in this class solely to override the default group
+        value in the passed arguments.
+
         Args:
           is_on (bool): True to turn on, False for off
           level (int): If non zero, turn the device on.  Should be in the
@@ -286,6 +289,29 @@ class KeypadLinc(Scene, Backlight, ManualCtrl, ResponderBase):
             # This is a regular on command pass to SetAndState class
             super().off(group=group, mode=mode, reason=reason,
                         transition=transition, on_done=on_done)
+
+    #-----------------------------------------------------------------------
+    def decode_on_level(self, cmd1, cmd2):
+        """Callback for standard commanded messages.
+
+        Decodes the cmds recevied from the device into is_on, level, and mode
+        to be consumed by _set_state().
+
+        This overrides the base function to insert the correct group number.
+
+        Args:
+          cmd1 (byte): The command 1 value
+          cmd2 (byte): The command 2 value
+        Returns:
+          is_on (bool): Is the device on.
+          mode (on_off.Mode): The type of command to send (normal, fast, etc).
+          level (int): On level between 0-255.
+          group (int): The group number that this state applies to. Defaults
+                       to None.
+        """
+        is_on, level, mode, group = super().decode_on_level(cmd1, cmd2)
+        group = self._load_group
+        return (is_on, level, mode, group)
 
     #-----------------------------------------------------------------------
     def mode_transition_supported(self, mode, transition):


### PR DESCRIPTION
## Proposed change
Extend decode_on_level for keypadlincs to insert the proper group number instead of the default None.

Fixes a glitch where the switch variety of Keypadlincs were unable to render the proper topic without the button value.

Also adds unit tests.

## Additional information
- This PR fixes or closes issue: fixes at least one bug in #366

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary
- [ ] Verify that it solves the issue for those with the switch variety of KPLs