### PR TITLE
Move Paho Client Log Messages into Log at Same Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Corrects a bug which prevented Keypadlincs of the Switch variety from
   reporting their state via the MQTT state topic.  ([PR 368][P368])
 
+### Additions
+
+- Adds logging of Paho MQTT client.  ([PR 369][P339])
+
 ## [0.8.1]
 
 ### Fixes
@@ -645,3 +649,4 @@ will add new features.
 [P359]: https://github.com/TD22057/insteon-mqtt/pull/359
 [P363]: https://github.com/TD22057/insteon-mqtt/pull/363
 [P368]: https://github.com/TD22057/insteon-mqtt/pull/368
+[P369]: https://github.com/TD22057/insteon-mqtt/pull/369

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -25,7 +25,8 @@
 #
 #==========================================================================
 logging:
-  # 10=DEBUG, 20=INFO, 30=WARNING, 40=ERROR
+  # 5=VERBOSE, 10=DEBUG, 20=INFO, 30=WARNING, 40=ERROR
+  # VERBOSE only adds logging of MQTT ping requests to DEBUG
   level: 10
 
   # Print messages to the screen.

--- a/insteon_mqtt/network/Mqtt.py
+++ b/insteon_mqtt/network/Mqtt.py
@@ -348,10 +348,17 @@ class Mqtt(Link):
           level (int):  Logging level.
           buf (str):  The message to log.
         """
-        # Send a very low level logging message so we can turn on level 5
-        # logging at the top level to see what is happening in the MQTT
-        # client.
-        LOG.log(5, buf)
+        # Pass on the majority of paho client logging messages at the same
+        # level.
+        # However, the ping messages are a bit verbose and cause 2 log entries
+        # every thirty seconds.  To see these messages set the debug to level
+        # 5
+        verbose = ["Sending PINGREQ", "Sending PINGRESP", "Received PINGREQ",
+                   "Received PINGRESP"]
+        if buf not in verbose:
+            LOG.log(paho.LOGGING_LEVEL[level], buf)
+        else:
+            LOG.log(5, buf)
 
     #-----------------------------------------------------------------------
     def __str__(self):


### PR DESCRIPTION
## Proposed change
Logging of the Paho Client was previously available through a somewhat hidden log level of 5.  This means that Paho Error messages were only visible in the log if the logging level was at 5 or lower.

This change moves all Paho Client log messages into the log at their defined level.  So if a user has Error messages enabled
Paho Error messages will appear in the log.

The one exception, is that the Paho Client logs ping messages at the debug level, which is a little verbose I think for our needs.
So all logging of ping messages have been moved to level 5.

Added notes to the config example about the level 5 logging level.

## Additional information
- This PR is related to issue: #366

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Code documentation was added where necessary

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation updated in config example to note log level 5
