### PR TITLE
Add Config_Extra Option; Add Min_Hops as First Setting

### DIFF
--- a/docs/config_extra.md
+++ b/docs/config_extra.md
@@ -1,0 +1,48 @@
+# Additional Device Specific Configuration Settings
+These settings can be set using the following format:
+```yaml
+insteon:
+  devices:
+    switch:
+      - aa.bb.cc: lamp1
+        extra_config: 1
+      - 11.22.33: lamp2
+```
+In this case, `lamp1` would have the value of 1 set for the `extra_config` setting.  This setting __only__ affects `lamp1` and will not affect `lamp2`.
+
+> Device names __must be defined__ to use a device specific configuration.
+
+> Note the indentation and __the lack of a dash__ on the line specifying the device specific configuration entry.
+
+## Settings for Specific Device Types
+Some device types have additional settings.
+
+> No such settings yet.
+
+## Advanced Settings
+These settings can be used with all device types, but should be considered advanced.  These settings may cause undesirable effects.
+
+### `min_hops` - Minimum Hops
+If a specific device frequently takes between 5-15 seconds to respond to a command.  Try setting the `min_hops` for that device to 1.  Restart InsteonMQTT and test out the device.  If there continues to be a delay, `min_hops` can be increased to 2 or 3.  Ideally, you want __the lowest value for `min_hops` that removes the delay.__
+
+For example, the configuration of a device in `config.yaml` could look like:
+```yaml
+insteon:
+  devices:
+    switch:
+      - aa.bb.cc: lamp1
+        min_hops: 1
+      - 11.22.33: lamp2
+```
+In this case, all messages sent to `lamp1` would have a minimum of 1 hops set.  While `lamp2` would continue to use the calculated smart-hops value.
+
+> Setting `min_hops` likely will __not help__ a device that frequently fails to respond to commands at all.
+
+#### Detailed Minimum Hops Explanation
+Each message sent _to_ a device has a hops value (between 0 and 3) that defines the number of times the message will be rebroadcast to the network.  InsteonMQTT calculates the optimum hop count by monitoring the number of hops it takes for messages _from_ the device to reach the Modem.
+
+However, in some cases, the hops distance is asymetric in that the amount of hops necessary to _send_ to the device is more than the amount of hops to _receive_ messages from the device.  When this happens, messages sent to this device frequently have to be resent, which may result in a delay of 5-15 seconds for the device to respond.
+
+Setting the `min_hops` value will ensure that InsteonMQTT never uses less than the amount of hops defined when sending a message and should remove the delay in the device response to a command.
+
+>__Be warned__ that setting `min_hops` when it is not needed or setting a value higher than is needed, may cause issues on your Insteon network.  This is because a message may be rebroadcast more than necessary causing delays and congestion, which can cause other devices to fail to respond or can cause corrupted messages.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,3 +19,6 @@ The device storage folder contains a json file for each device that is used to c
 #### `mqtt` - device templates
 
 Insteon-MQTT uses Jinja2 templates for the greatest interoperability.  Each device category `modem`, `modem`, `switch`, `dimmer`, ... uses templates for defining the mqtt topic and payload for each message type.  See [Templating](templating.md) for help with Jinja2 templates.
+
+#### Device Specific Configuration Settings
+See [Device Specific Configuration Settings](config_extra.md)

--- a/insteon_mqtt/device/BatterySensor.py
+++ b/insteon_mqtt/device/BatterySensor.py
@@ -45,7 +45,7 @@ class BatterySensor(Base):
     """
     type_name = "battery_sensor"
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -55,8 +55,9 @@ class BatterySensor(Base):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address):  The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Sensor low battery signal.  API: func( Device, bool is_low )
         self.signal_low_battery = Signal()

--- a/insteon_mqtt/device/Dimmer.py
+++ b/insteon_mqtt/device/Dimmer.py
@@ -26,7 +26,7 @@ class Dimmer(Scene, Backlight, DimmerBase):
     connect to these signals to perform an action when a change is made to
     the device (like sending MQTT messages).
     """
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -35,9 +35,10 @@ class Dimmer(Scene, Backlight, DimmerBase):
                    device to send messages to the PLM modem.
           modem (Modem): The Insteon modem used to find other devices.
           address (Address): The address of the device.
-          name (str): Nice alias name to use for the device.
+          name (str): Nice alias name to use for the device
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Update the group map with the groups to be paired and the handler
         # for broadcast messages from this group

--- a/insteon_mqtt/device/EZIO4O.py
+++ b/insteon_mqtt/device/EZIO4O.py
@@ -68,7 +68,7 @@ class EZIO4O(ResponderBase):
     the device (like sending MQTT messages).
     """
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -78,8 +78,9 @@ class EZIO4O(ResponderBase):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address):  The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         self._is_on = [False, False, False, False]  # output state
 

--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -45,7 +45,7 @@ class FanLinc(Dimmer):
         HIGH = 0xff
         ON = -0x01   # turn on at last known speed
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -55,8 +55,9 @@ class FanLinc(Dimmer):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address):  The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Current fan speed.  We also store the last speed so that a generic
         # "on" command will use the last non-off speed that was seen.  Note

--- a/insteon_mqtt/device/HiddenDoor.py
+++ b/insteon_mqtt/device/HiddenDoor.py
@@ -82,7 +82,7 @@ class HiddenDoor(BatterySensor):
     # Currently set at 3 hours
     BATTERY_TIME = (60 * 60) * 3
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -92,8 +92,9 @@ class HiddenDoor(BatterySensor):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address): The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         self.signal_voltage = Signal()
 

--- a/insteon_mqtt/device/IOLinc.py
+++ b/insteon_mqtt/device/IOLinc.py
@@ -113,7 +113,7 @@ class IOLinc(ResponderBase):
         MOMENTARY_B = 0x02
         MOMENTARY_C = 0x03
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -123,8 +123,9 @@ class IOLinc(ResponderBase):
           modem:       (Modem) The Insteon modem used to find other devices.
           address:     (Address) The address of the device.
           name         (str) Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Used to track the state of sensor and relay
         self._sensor_is_on = False

--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -38,7 +38,7 @@ class KeypadLinc(Scene, Backlight, ManualCtrl, ResponderBase):
     """
 
     #-----------------------------------------------------------------------
-    def __init__(self, protocol, modem, address, name):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -48,10 +48,9 @@ class KeypadLinc(Scene, Backlight, ManualCtrl, ResponderBase):
           modem:       (Modem) The Insteon modem used to find other devices.
           address:     (Address) The address of the device.
           name:        (str) Nice alias name to use for the device.
-          dimmer:      (bool) True if the device supports dimming - False if
-                       it's a regular switch.
+          config_extra (dict) Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Switch or dimmer type.
         self.type_name = "keypad_linc_sw"

--- a/insteon_mqtt/device/KeypadLincDimmer.py
+++ b/insteon_mqtt/device/KeypadLincDimmer.py
@@ -39,7 +39,7 @@ class KeypadLincDimmer(KeypadLinc, DimmerBase):
     """
 
     #-----------------------------------------------------------------------
-    def __init__(self, protocol, modem, address, name):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -49,10 +49,9 @@ class KeypadLincDimmer(KeypadLinc, DimmerBase):
           modem:       (Modem) The Insteon modem used to find other devices.
           address:     (Address) The address of the device.
           name:        (str) Nice alias name to use for the device.
-          dimmer:      (bool) True if the device supports dimming - False if
-                       it's a regular switch.
+          config_extra (dict) Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Switch or dimmer type.
         # Here for compatibility purposes can likely be removed eventually.

--- a/insteon_mqtt/device/Leak.py
+++ b/insteon_mqtt/device/Leak.py
@@ -44,7 +44,7 @@ class Leak(BatterySensor):
     GROUP_DRY = 1
     GROUP_WET = 2
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -54,8 +54,9 @@ class Leak(BatterySensor):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address):  The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Maps Insteon groups to message type for this sensor.
         self.group_map = {

--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -64,7 +64,7 @@ class Motion(BatterySensor):
     # Currently set at 4 Days
     BATTERY_TIME = (60 * 60) * 24 * 4
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -74,8 +74,9 @@ class Motion(BatterySensor):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address): The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         self.signal_dawn = Signal()  # (Device, bool is_dawn)
 

--- a/insteon_mqtt/device/Outlet.py
+++ b/insteon_mqtt/device/Outlet.py
@@ -27,7 +27,7 @@ class Outlet(Backlight, ResponderBase):
     the device (like sending MQTT messages).
     """
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -37,8 +37,9 @@ class Outlet(Backlight, ResponderBase):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address):  The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         self._is_on = [False, False]  # top outlet, bottom outlet
 

--- a/insteon_mqtt/device/Remote.py
+++ b/insteon_mqtt/device/Remote.py
@@ -43,7 +43,8 @@ class Remote(ManualCtrl, BatterySensor):
     # I also tried to drain the battery of one of my devices
     BATTERY_VOLTAGE_LOW = 3.4
 
-    def __init__(self, protocol, modem, address, name, num_button):
+    def __init__(self, protocol, modem, address, name, config_extra,
+                 num_button):
         """Constructor
 
         Args:
@@ -53,10 +54,11 @@ class Remote(ManualCtrl, BatterySensor):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address):  The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
           num_button (int):  Number of buttons on the remote.
         """
         assert num_button > 0
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         self.num = num_button
         self.type_name = "mini_remote_%d" % self.num

--- a/insteon_mqtt/device/SmokeBridge.py
+++ b/insteon_mqtt/device/SmokeBridge.py
@@ -48,7 +48,7 @@ class SmokeBridge(Base):
         ERROR = 0x07
         HEARTBEAT = 0x0A
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -58,8 +58,9 @@ class SmokeBridge(Base):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address):  The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # State change notification signal.
         # API: func( Device, Type type, bool is_on )

--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -21,7 +21,7 @@ class Switch(Scene, Backlight, ManualCtrl, ResponderBase):
     connect to these signals to perform an action when a change is made to
     the device (like sending MQTT messages).
     """
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -31,8 +31,9 @@ class Switch(Scene, Backlight, ManualCtrl, ResponderBase):
           modem (Modem):  The Insteon modem used to find other devices.
           address (Address):  The address of the device.
           name (str):  Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Update the group map with the groups to be paired and the handler
         # for broadcast messages from this group

--- a/insteon_mqtt/device/Thermostat.py
+++ b/insteon_mqtt/device/Thermostat.py
@@ -85,7 +85,7 @@ class Thermostat(Base):
     FARENHEIT = 0
     CELSIUS = 1
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -95,11 +95,10 @@ class Thermostat(Base):
           modem:       (Modem) The Insteon modem used to find other devices.
           address:     (Address) The address of the device.
           name:        (str) Nice alias name to use for the device.
-          dimmer:      (bool) True if the device supports dimming - False if
-                       it's a regular switch.
+          config_extra (dict) Extra configuration settings
         """
         # Set default values to attributes, may be overwritten by saved values
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         self.cmd_map.update({
             'get_status' : self.get_status

--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -85,7 +85,7 @@ class Base:
                             addrs_found.append(key)
                     if len(addrs_found) == 1:
                         addr = addrs_found[0]
-                        name = config[addr]
+                        name = config[addr].lower()
                         config_extra = config.copy()
                         del config_extra[addr]
                     elif len(addrs_found) > 1:

--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -89,13 +89,15 @@ class Base:
                         config_extra = config.copy()
                         del config_extra[addr]
                     elif len(addrs_found) > 1:
-                        LOG.error("Multiple insteon address found in config "
+                        LOG.error("Multiple insteon addresses found in config "
                                   "for entry: %s",
                                   config)
+                        continue
                     else:
                         LOG.error("No insteon address found in config "
                                   "for entry: %s",
                                   config)
+                        continue
 
             # Otherwise it's just the address
             else:

--- a/insteon_mqtt/device/base/DimmerBase.py
+++ b/insteon_mqtt/device/base/DimmerBase.py
@@ -36,7 +36,7 @@ class DimmerBase(ManualCtrl, ResponderBase, Base):
                    0x15: 23.5, 0x16: 21.5, 0x17: 19, 0x18: 8.5, 0x19: 6.5,
                    0x1a: 4.5, 0x1b: 2, 0x1c: .5, 0x1d: .3, 0x1e: .2, 0x1f: .1}
 
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -46,8 +46,9 @@ class DimmerBase(ManualCtrl, ResponderBase, Base):
           modem (Modem): The Insteon modem used to find other devices.
           address (Address): The address of the device.
           name (str): Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Remote (mqtt) commands mapped to methods calls.  Add to the base
         # class defined commands.

--- a/insteon_mqtt/device/base/ResponderBase.py
+++ b/insteon_mqtt/device/base/ResponderBase.py
@@ -26,7 +26,7 @@ class ResponderBase(Base):
     This class is meant to be extended by other classes including DimmerBase
     so it should generally be inheritted last.
     """
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -36,8 +36,9 @@ class ResponderBase(Base):
           modem (Modem): The Insteon modem used to find other devices.
           address (Address): The address of the device.
           name (str): Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         self.cmd_map.update({
             'on' : self.on,

--- a/insteon_mqtt/device/functions/Backlight.py
+++ b/insteon_mqtt/device/functions/Backlight.py
@@ -20,7 +20,7 @@ class Backlight(Base):
     This is an abstract class that provides support for controlling the
     backlight on devices.
     """
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -30,8 +30,9 @@ class Backlight(Base):
           modem (Modem): The Insteon modem used to find other devices.
           address (Address): The address of the device.
           name (str): Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Define the flags handled by set_flags()
         self.set_flags_map.update({'backlight': self.set_backlight})

--- a/insteon_mqtt/device/functions/ManualCtrl.py
+++ b/insteon_mqtt/device/functions/ManualCtrl.py
@@ -38,7 +38,7 @@ class ManualCtrl(Base):
       device starts or stops manual mode (when a button is held down or
       released).
     """
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -48,8 +48,9 @@ class ManualCtrl(Base):
           modem (Modem): The Insteon modem used to find other devices.
           address (Address): The address of the device.
           name (str): Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         # Manual mode start up, down, off
         # API: func(Device, on_off.Manual mode, str reason)

--- a/insteon_mqtt/device/functions/Scene.py
+++ b/insteon_mqtt/device/functions/Scene.py
@@ -20,7 +20,7 @@ class Scene(Base):
 
     This is an abstract class that provides support for the Scene topic.
     """
-    def __init__(self, protocol, modem, address, name=None):
+    def __init__(self, protocol, modem, address, name=None, config_extra=None):
         """Constructor
 
         Args:
@@ -30,8 +30,9 @@ class Scene(Base):
           modem (Modem): The Insteon modem used to find other devices.
           address (Address): The address of the device.
           name (str): Nice alias name to use for the device.
+          config_extra (dict): Extra configuration settings
         """
-        super().__init__(protocol, modem, address, name)
+        super().__init__(protocol, modem, address, name, config_extra)
 
         self.cmd_map.update({
             'scene' : self.scene,

--- a/tests/device/base/test_BaseDev.py
+++ b/tests/device/base/test_BaseDev.py
@@ -97,6 +97,30 @@ class Test_Base_Config():
         device = Base.from_config([{"32 34 56": 'test'}], protocol, modem)
         assert device
 
+    def test_load_config_extra_good(self, test_device, caplog):
+        protocol = test_device.protocol
+        modem = test_device.modem
+        device = Base.from_config([{"11.22.33": 'test', "min_hops": 1}],
+                                  protocol, modem)
+        assert device
+        assert device[0].config_extra['min_hops'] == 1
+
+    def test_load_config_extra_no_addr(self, test_device, caplog):
+        protocol = test_device.protocol
+        modem = test_device.modem
+        device = Base.from_config([{"not_addr": 'test', "min_hops": 1}],
+                                  protocol, modem)
+        assert 'No insteon address found in config' in caplog.text
+        assert len(device) == 0
+
+    def test_load_config_extra_two_addr(self, test_device, caplog):
+        protocol = test_device.protocol
+        modem = test_device.modem
+        device = Base.from_config([{"11.22.33": 'test', "aa.bb.cc": 1}],
+                                  protocol, modem)
+        assert 'Multiple insteon addresses found in config' in caplog.text
+        assert len(device) == 0
+
     def test_info_entry(self, test_device):
         assert test_device.info_entry() == {'01.02.03':
                                             {'label': None,

--- a/tests/device/test_RemoteDev.py
+++ b/tests/device/test_RemoteDev.py
@@ -21,7 +21,7 @@ def test_device4(tmpdir):
     protocol = H.main.MockProtocol()
     modem = H.main.MockModem(tmpdir)
     addr = IM.Address(0x01, 0x02, 0x03)
-    device = Remote(protocol, modem, addr, "4button", 4)
+    device = Remote(protocol, modem, addr, "4button", None, 4)
     return device
 
 @pytest.fixture
@@ -32,7 +32,7 @@ def test_device8(tmpdir):
     protocol = H.main.MockProtocol()
     modem = H.main.MockModem(tmpdir)
     addr = IM.Address(0x01, 0x02, 0x03)
-    device = Remote(protocol, modem, addr, "8button", 8)
+    device = Remote(protocol, modem, addr, "8button", None, 8)
     return device
 
 class Test_Base_Config():

--- a/tests/mqtt/test_Remote.py
+++ b/tests/mqtt/test_Remote.py
@@ -27,7 +27,7 @@ def setup(mock_paho_mqtt, tmpdir):
     modem = H.main.MockModem(tmpdir)
     addr = IM.Address(1, 2, 3)
     name = "device name"
-    dev = IM.device.Remote(proto, modem, addr, name, 6)
+    dev = IM.device.Remote(proto, modem, addr, name, None, 6)
 
     link = IM.network.Mqtt()
     mqttModem = H.mqtt.MockModem()

--- a/tests/mqtt/test_config.py
+++ b/tests/mqtt/test_config.py
@@ -15,7 +15,7 @@ class Test_config:
         addr = IM.Address(1, 2, 3)
 
         types = ["BatterySensor", "Dimmer", "EZIO4O", "FanLinc", "IOLinc",
-                "KeypadLinc","Leak", "Motion", "Outlet", "SmokeBridge", 
+                "KeypadLinc","Leak", "Motion", "Outlet", "SmokeBridge",
                 "Switch","Thermostat"]
         instances = []
         for t in types:
@@ -25,7 +25,7 @@ class Test_config:
             instances.append(inst)
 
         types.append("Remote")
-        inst = IM.device.Remote(proto, modem, addr, "dummy", 3)
+        inst = IM.device.Remote(proto, modem, addr, "dummy", None, 3)
         instances.append(inst)
 
         types.append("Modem")

--- a/tests/mqtt/test_config.py
+++ b/tests/mqtt/test_config.py
@@ -15,7 +15,7 @@ class Test_config:
         addr = IM.Address(1, 2, 3)
 
         types = ["BatterySensor", "Dimmer", "EZIO4O", "FanLinc", "IOLinc",
-                "KeypadLinc","Leak", "Motion", "Outlet", "SmokeBridge",
+                "KeypadLinc", "Leak", "Motion", "Outlet", "SmokeBridge",
                 "Switch","Thermostat"]
         instances = []
         for t in types:

--- a/tests/test_Scenes.py
+++ b/tests/test_Scenes.py
@@ -512,7 +512,8 @@ class Test_Scenes:
 
     def test_mini_remote_button_config_no_data3(self):
         modem = MockModem()
-        remote = Remote(modem.protocol, modem, Address("11.22.33"), "Remote", 4)
+        remote = Remote(modem.protocol, modem, Address("11.22.33"), "Remote",
+                        None, 4)
         modem.devices[str(remote.addr)] = remote
         device = modem.find(Address("aa.bb.cc"))
         modem.devices[device.label] = device
@@ -543,7 +544,8 @@ class Test_Scenes:
 
     def test_mini_remote_button_config_with_data3(self):
         modem = MockModem()
-        remote = Remote(modem.protocol, modem, Address("11.22.33"), "Remote", 4)
+        remote = Remote(modem.protocol, modem, Address("11.22.33"), "Remote",
+                        None, 4)
         modem.devices[str(remote.addr)] = remote
         device = modem.find(Address("aa.bb.cc"))
         modem.devices[device.label] = device


### PR DESCRIPTION
## Proposed change
This adds the ability to define extra device specific configuration settings in the `config.yaml` file.  At the moment, the only additional setting that is used is the `min_hops` setting.  This sets the minimum hop count that is set for the `max_hops` flag in outgoing messages to this particular device.

Device specific configuration is defined using the following format:
```yaml
insteon:
  devices:
    switch:
      - aa.bb.cc: lamp1
        extra_config: 1
      - 11.22.33: lamp2
```

Each config_extra key and value is added to a dict that is available as the attribute `config_extra` for each device.  It is up to the device to decide how to handle this.

Due to this format in yaml, there is one major limitation:

> extra_config keys cannot be interpreted as a device address.  As such, the key needs to be longer than 6 characters __or__ use a character outside the range [0-9]+[A-F].

If a key is used that can be parsed to a device address, it will throw an error as it is ambiguous what the actual device address is.

The next extra_config key is likely to be related to the MQTT discovery feature and would be used to set a unique template for the discovery payload for a device.

Other settings that are not actually stored on insteon devices, but are only saved in the device data file, should probably also be moved here such as the `set_battery_low_voltage` value for motion sensors.  

## Additional information
- This PR closes issue: #271 
- This PR is related to discussion:  #371

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary
- [x] Documentation added/updated

We won't have confirmation that this change actually solves a user issue until it is merged into master.  But I feel confident that the PR has value beyond the `min_hops` setting.
