### PR TITLE
Update Example Config for Fan in HomeAssistant

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -716,8 +716,29 @@ mqtt:
   #   - platform: mqtt
   #     command_topic: 'insteon/aa.bb.cc/fan/set'
   #     state_topic: 'insteon/aa.bb.cc/fan/state'
-  #     speed_command_topic: 'insteon/aa.bb.cc/fan/speed/set'
-  #     speed_state_topic: 'insteon/aa.bb.cc/fan/state'
+  #     percentage_command_topic: 'insteon/aa.bb.cc/fan/speed/set'
+  #     percentage_command_template: >
+  #       {% if value < 10 %}
+  #         off
+  #       {% elif value < 40 %}
+  #         low
+  #       {% elif value < 75 %}
+  #         medium
+  #       {% else %}
+  #         high 
+  #       {% endif %}
+  #     percentage_state_topic: 'insteon/aa.bb.cc/fan/speed/state'
+  #     percentage_value_template: >
+  #       {% if value == 'low' %}
+  #         33
+  #       {% elif value == 'medium' %}
+  #         67
+  #       {% elif value == 'high' %}
+  #         100
+  #       {% else %}
+  #         0
+  #       {% endif %}
+
   fan_linc:
     # Output fan state change topic and payload.  This message is sent
     # whenever the fan state changes for any reason.  Available

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -896,8 +896,11 @@ speed payload template must convert the input message into the format
    { "cmd" : SPEED }
    ```
 
-Here is a sample configuration that accepts and publishes messages
-matching the Home Assistant MQTT fan configuration.
+Here is a sample configuration.  HomeAssistant starting in version 2021.4.0
+dropped support for the off/low/medium/high fan speeds.  See 
+[config-example.yaml](https://github.com/TD22057/insteon-mqtt/blob/master/config-example.yaml) 
+in the mqtt -> fan section for an example HomeAssistant config that works
+with InsteonMQTT.
 
    ```
    fan_linc:


### PR DESCRIPTION
## Breaking change
This is not specifically a breaking change in InsteonMQTT, but fixing a breaking change in HomeAssistant.

## Proposed change
Suggested setup has changed because HomeAssistant now (2021.4.0) uses percentages for the fan speed instead of low/med/high.

## Additional information
Thanks @Juggler00 for the fix

- This PR closes: #377

## Checklist
- [x] The code change is tested and works locally.  (I tested in my HA installation)
- [x] Change is only to comments in config-example.yaml
