### PR TITLE
Store Name in Case as Entered by User

### DIFF
--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -130,7 +130,9 @@ class Base:
         self.modem = modem
         self.addr = Address(address)
         self.name_user_case = name
-        self.name = name.lower()
+        self.name = name
+        if name is not None:
+            self.name = name.lower()
         self.config_extra = {}
         if config_extra is not None:
             self.config_extra = config_extra

--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -67,8 +67,6 @@ class Base:
                 if len(config) == 1:
                     # This has no config_extra values
                     addr, name = next(iter(config.items()))
-                    if name:
-                        name = name.lower()
                 elif len(config) > 1:
                     # This has config_extra values
                     # Loop through each key.  One and only one should be a
@@ -85,7 +83,7 @@ class Base:
                             addrs_found.append(key)
                     if len(addrs_found) == 1:
                         addr = addrs_found[0]
-                        name = config[addr].lower()
+                        name = config[addr]
                         config_extra = config.copy()
                         del config_extra[addr]
                     elif len(addrs_found) > 1:
@@ -131,7 +129,8 @@ class Base:
         self.protocol = protocol
         self.modem = modem
         self.addr = Address(address)
-        self.name = name
+        self.name_user_case = name
+        self.name = name.lower()
         self.config_extra = {}
         if config_extra is not None:
             self.config_extra = config_extra

--- a/tests/db/test_DeviceEntry.py
+++ b/tests/db/test_DeviceEntry.py
@@ -80,7 +80,7 @@ class Test_DeviceEntry:
         device = IM.device.base.Base(protocol, modem, addr, name="Awesomesauce")
         modem.set_linked_device(device)
 
-        assert obj.label == "12.34.ab (Awesomesauce)"
+        assert obj.label == "12.34.ab (awesomesauce)"
 
     #-----------------------------------------------------------------------
     def test_repr(self):

--- a/tests/db/test_ModemEntry.py
+++ b/tests/db/test_ModemEntry.py
@@ -90,7 +90,7 @@ class Test_ModemEntry:
         device = IM.device.base.Base(protocol, modem, addr, name="Awesomesauce")
         modem.set_linked_device(device)
 
-        assert obj.label == "03.04.05 (Awesomesauce)"
+        assert obj.label == "03.04.05 (awesomesauce)"
 
     #-----------------------------------------------------------------------
 

--- a/tests/device/base/test_BaseDev.py
+++ b/tests/device/base/test_BaseDev.py
@@ -97,6 +97,14 @@ class Test_Base_Config():
         device = Base.from_config([{"32 34 56": 'test'}], protocol, modem)
         assert device
 
+    def test_with_name_case(self, test_device):
+        protocol = test_device.protocol
+        modem = test_device.modem
+        #address is intentionally badly formatted
+        device = Base.from_config([{"32 34 56": 'tEst'}], protocol, modem)
+        assert device[0].name == 'test'
+        assert device[0].name_user_case == 'tEst'
+
     def test_load_config_extra_good(self, test_device, caplog):
         protocol = test_device.protocol
         modem = test_device.modem

--- a/tests/test_Scenes.py
+++ b/tests/test_Scenes.py
@@ -251,7 +251,7 @@ class Test_Scenes:
         assert len(scenes.entries) == 1
         assert len(scenes.data[0]['controllers']) == 2
         assert len(scenes.data[0]['responders']) == 1
-        assert scenes.data[0]['responders'][0]['Dimmer']['ramp_rate'] == 19
+        assert scenes.data[0]['responders'][0]['dimmer']['ramp_rate'] == 19
 
     def test_Dimmer_scenes_different_ramp_rates(self):
         modem = MockModem()
@@ -325,7 +325,7 @@ class Test_Scenes:
         assert len(scenes.entries) == 1
         assert len(scenes.data[0]['controllers']) == 2
         assert len(scenes.data[0]['responders']) == 1
-        assert scenes.data[0]['responders'][0]['FanLinc']['ramp_rate'] == 19
+        assert scenes.data[0]['responders'][0]['fanlinc']['ramp_rate'] == 19
 
     def test_FanLinc_scenes_different_ramp_rates(self):
         modem = MockModem()
@@ -400,7 +400,7 @@ class Test_Scenes:
         assert len(scenes.entries) == 1
         assert len(scenes.data[0]['controllers']) == 2
         assert len(scenes.data[0]['responders']) == 1
-        assert scenes.data[0]['responders'][0]['KeypadLinc']['ramp_rate'] == 19
+        assert scenes.data[0]['responders'][0]['keypadlinc']['ramp_rate'] == 19
 
     def test_KeypadLinc_scenes_different_ramp_rates(self):
         modem = MockModem()
@@ -573,8 +573,8 @@ class Test_Scenes:
         assert scenes.entries[0].controllers[0].group == 2
         assert scenes.entries[0].controllers[0].link_data == [3, 0, 2]
         assert scenes.entries[0].controllers[0].style == 0
-        assert scenes.data[0]['controllers'][0]['Remote']['group'] == 2
-        assert scenes.data[0]['controllers'][0]['Remote']['data_3'] == 2
+        assert scenes.data[0]['controllers'][0]['remote']['group'] == 2
+        assert scenes.data[0]['controllers'][0]['remote']['data_3'] == 2
 
     def test_foreign_hub_keypad_button_backlights_scene(self):
         modem = MockModem()


### PR DESCRIPTION
## Proposed change
Adds an attribute to the base device class `name_user_case` which contains the name of the device in the case as entered by the user.  To be used for setting the `name` in the discovery payload.

### Discovery Branch
I am starting the process of adding discovery support.  This may take a little bit of time, but shouldn't be too bad.  Rather than keep my commits hidden, I thought it would be better to create a new branch and frequently merge PRs to that branch.  I will probably merge these PRs rather quickly, but if you see errors or have comments, please let me know.  They can be addressed in further PRs.

Once the Discovery branch is complete, it can be merged into dev.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.
