### PR TITLE
Skeleton of Discovery Implementation

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -432,8 +432,8 @@ mqtt:
           {
             "uniq_id": "{{address}}_light",
             "name": "{{name_user_case}}",
-            "cmd_t": "",
-            "stat_t": "",
+            "cmd_t": "{{level_topic}}",
+            "stat_t": "{{state_topic}}",
             "brightness": true,
             "schema": "json",
             "device": {{device_info_template}}

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -190,6 +190,17 @@ mqtt:
   cmd_topic: 'insteon/command'
 
 
+  # Home Assistant implements mqtt device discovery as outlined at:
+  # https://www.home-assistant.io/docs/mqtt/discovery
+  # if discover_topic_base is defined, devices (as defined in config.yaml)
+  # announce themselves to Home Assistant. Announcing occurs once
+  # upon startup of insteon-mqtt and based on request (see announce command on
+  # modem)
+  #
+  # TO DISABLE THE DISCOVERY SERVICE: Comment out the line below by placing a
+  # hash character # at the start of the line.
+  discovery_topic_base: 'homeassistant'
+
   # Trigger modem virtual scenes.  Modem scenes are where the modem is a
   # controller and emits a scene broadcast with the specified group number.
   # There is no state topic since the scene doesn't have an on/off state.
@@ -725,7 +736,7 @@ mqtt:
   #       {% elif value < 75 %}
   #         medium
   #       {% else %}
-  #         high 
+  #         high
   #       {% endif %}
   #     percentage_state_topic: 'insteon/aa.bb.cc/fan/speed/state'
   #     percentage_value_template: >

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -189,7 +189,8 @@ mqtt:
   # send these low level commands.
   cmd_topic: 'insteon/command'
 
-
+  ### Discovery Settings
+  #
   # Home Assistant implements mqtt device discovery as outlined at:
   # https://www.home-assistant.io/docs/mqtt/discovery
   # if discover_topic_base is defined, devices (as defined in config.yaml)
@@ -200,6 +201,12 @@ mqtt:
   # TO DISABLE THE DISCOVERY SERVICE: Comment out the line below by placing a
   # hash character # at the start of the line.
   discovery_topic_base: 'homeassistant'
+
+  # The mqtt topic to monitor for HomeAssistant status.  This likely doesn't
+  # need to be changed unless you have altered it.  When the message 'online'
+  # is received on this topic, InsteonMQTT will publish the discovery
+  # entities.  See https://www.home-assistant.io/docs/mqtt/birth_will/
+  discovery_ha_status: 'homeassistant/status'
 
   # Trigger modem virtual scenes.  Modem scenes are where the modem is a
   # controller and emits a scene broadcast with the specified group number.

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -208,6 +208,24 @@ mqtt:
   # entities.  See https://www.home-assistant.io/docs/mqtt/birth_will/
   discovery_ha_status: 'homeassistant/status'
 
+  # This is a variable that is available for use in all templates, as
+  # {{device_info_template}}.  It is envisioned that it would be used to set
+  # the device map information, see e.g.
+  # https://www.home-assistant.io/integrations/switch.mqtt/#device
+  # While the identifiers or (ids) section is listed as optional, it has been
+  # my experience that it is required.
+  # This device section describes the parent device that all sub-entities are
+  # grouped under
+  device_info_template: |-
+    {
+      "ids": "{{address}}",
+      "mf": "Insteon",
+      "mdl": "{{model}}",
+      "sw": "{{firmware}}",
+      "name": "{{name_user_case}}",
+      "via_device": "{{modem_addr}}"
+    }
+
   # Trigger modem virtual scenes.  Modem scenes are where the modem is a
   # controller and emits a scene broadcast with the specified group number.
   # There is no state topic since the scene doesn't have an on/off state.
@@ -406,6 +424,20 @@ mqtt:
                           , "level" : {{json.brightness}}
                       {% endif %}
                     }'
+
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    discovery_entities:
+      - component: 'light'
+        config: |-
+          {
+            "uniq_id": "{{address}}_light",
+            "name": "{{name_user_case}}",
+            "cmd_t": "",
+            "stat_t": "",
+            "brightness": true,
+            "schema": "json",
+            "device": {{device_info_template}}
+          }
 
   #------------------------------------------------------------------------
   # Battery powered sensors

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -13,7 +13,7 @@ LOG = log.get_logger()
 
 
 class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
-             topic.SetTopic):
+             topic.SetTopic, topic.DiscoveryTopic):
     """MQTT interface to an Insteon dimmer switch.
 
     This class connects to a device.Dimmer object and converts it's output
@@ -35,6 +35,9 @@ class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
                          state_payload='{ "state" : "{{on_str.lower()}}", '
                                        '"brightness" : {{level_255}} }')
 
+        # This defines the default discovery_class for these devices
+        self.class_name = "dimmer"
+
         # Input level command template.
         self.msg_level = MsgTemplate(
             topic='insteon/{{address}}/level',
@@ -50,7 +53,10 @@ class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
                  config is stored in config['dimmer'].
           qos (int):  The default quality of service level to use.
         """
-        data = config.get("dimmer", None)
+        # The discovery topic needs the full config
+        self.load_discovery_data(config, qos)
+
+        data = config.get(self.class_name, None)
         if not data:
             return
 

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -103,6 +103,20 @@ class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
         self.scene_unsubscribe(link)
 
     #-----------------------------------------------------------------------
+    def discovery_template_data(self, **kwargs):
+        """This extends the template data variables defined in the base class
+
+        Returns the dict from the base class plus these additional keys that
+        contain the topic as defined in the config.yaml if any:
+          state_topic, on_off_topic, level_topic, scene_topic,
+          manual_state_topic
+        """
+        # Set up the variables that can be used in the templates.
+        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
+        data['level_topic'] = self.msg_level.render_topic(data)
+        return data
+
+    #-----------------------------------------------------------------------
     def _input_set_level(self, client, data, message):
         """Handle an input level change MQTT message.
 

--- a/insteon_mqtt/mqtt/Mqtt.py
+++ b/insteon_mqtt/mqtt/Mqtt.py
@@ -40,6 +40,9 @@ class Mqtt:
     implements for various things.  The payload for these messages is always
     a json data object that will get passed to the Insteon device for
     handling
+
+    This class also handles the HomeAssistant status topic and triggers the
+    devices to publish their discovery entities when necessary.
     """
     def __init__(self, mqtt_link, modem):
         """Constructor
@@ -64,6 +67,9 @@ class Mqtt:
 
         # The command topic template (MstTemplate) to use.
         self._cmd_topic = None
+
+        # The HomeAssistant status topic to use.
+        self._ha_status_topic = None
 
         # MQTT message parameters.  These get loaded via the config.
         self.qos = 1
@@ -100,6 +106,12 @@ class Mqtt:
         # Create a template for prcessing messages on the command topic.
         self._cmd_topic = MsgTemplate.clean_topic(data['cmd_topic'])
 
+        # Create a template for prcessing HomeAssistant status messages.
+        if 'discovery_ha_status' in data:
+            self._ha_status_topic = MsgTemplate.clean_topic(
+                data['discovery_ha_status']
+            )
+
         # MQTT message parameters.
         self.qos = data.get('qos', self.qos)
         self.retain = data.get('retain', self.retain)
@@ -109,7 +121,7 @@ class Mqtt:
 
         # Subscribe to the new topics.
         if self.link.connected:
-            self._subscribe()
+            self._startup()
 
     #-----------------------------------------------------------------------
     def publish(self, topic, payload, qos=None, retain=None):
@@ -152,7 +164,7 @@ class Mqtt:
           connected (bool):  True if connected, False if disconnected.
         """
         if self.link.connected:
-            self._subscribe()
+            self._startup()
 
     #-----------------------------------------------------------------------
     def handle_new_device(self, modem, device):
@@ -185,8 +197,12 @@ class Mqtt:
         self.devices[device.addr.id] = obj
 
         # If we are already connected we need to subscribe this device
+        # and publish its discovery entities
         if self.link.connected:
             obj.subscribe(self.link, self.qos)
+            if (hasattr(obj, 'publish_discovery') and
+                    callable(obj.publish_discovery)):
+                obj.publish_discovery(obj.device)
 
     #-----------------------------------------------------------------------
     def handle_cmd(self, client, userdata, message):
@@ -325,21 +341,68 @@ class Mqtt:
         self.link.publish(topic, payload)
 
     #-----------------------------------------------------------------------
-    def _subscribe(self):
-        """Subscribe to the command and set topics.
+    def handle_ha_status(self, client, userdata, message):
+        """HomeAssistant Status Topic Monitoring
+
+        See https://www.home-assistant.io/docs/mqtt/birth_will/
+        This monitors an MQTT topic where HomeAssistant publishes 'online'
+        and 'offline' status messages.  When a 'online' message is received
+        it signals that HomeAssistant was restarted and requires the
+        Discovery Entities to be published againe.  When 'online' is
+        received this method will trigger all devices to re-publish their
+        Discovery Entities.
+
+        Args:
+          client (paho.Client):  The paho mqtt client (self.link).
+          data:  Optional user data (unused).
+          message:  MQTT message - has attrs: topic, payload, qos, retain.
+        """
+        LOG.info("MQTT message %s %s", message.topic, message.payload)
+
+        payload = message.payload.decode("utf-8").strip().lower()
+        if payload == 'online':
+            self._publish_discovery()
+        elif payload != 'offline':
+            LOG.warning("Unexpected HomeAssistant status message %s %s",
+                        message.topic, message.payload)
+
+    #-----------------------------------------------------------------------
+    def _publish_discovery(self):
+        """Trigger each device to publish its discovery entities
+
+        Loops all devices and if they have the functionality, causes them to
+        publish their Discovery Entities
+        """
+        for device in self.devices.values():
+            if (hasattr(device, 'publish_discovery') and
+                    callable(device.publish_discovery)):
+                device.publish_discovery(device.device)
+
+    #-----------------------------------------------------------------------
+    def _startup(self):
+        """Startup Process When MQTT Broker Comes Online
 
         This will subscribe to the command topic and tell all the MQTT
         devices to subscribe to their command topics.
+
+        It will also subscribe to the HomeAssistant status topic and trigger
+        all devices to publish their discovery entities
         """
         if self._cmd_topic:
             self.link.subscribe(self._cmd_topic + "/+", self.qos,
                                 self.handle_cmd)
 
+        if self._ha_status_topic:
+            self.link.subscribe(self._ha_status_topic, self.qos,
+                                self.handle_ha_status)
+
         for device in self.devices.values():
             device.subscribe(self.link, self.qos)
 
+        self._publish_discovery()
+
     #-----------------------------------------------------------------------
-    def _unsubscribe(self):
+    def _shutdown(self):
         """Unsubscribe to the command and set topics.
 
         This will unsubscribe from all the topics.

--- a/insteon_mqtt/mqtt/Mqtt.py
+++ b/insteon_mqtt/mqtt/Mqtt.py
@@ -71,6 +71,9 @@ class Mqtt:
         # The HomeAssistant status topic to use.
         self._ha_status_topic = None
 
+        # The device_info_template
+        self.device_info_template = ""
+
         # MQTT message parameters.  These get loaded via the config.
         self.qos = 1
         self.retain = True
@@ -111,6 +114,11 @@ class Mqtt:
             self._ha_status_topic = MsgTemplate.clean_topic(
                 data['discovery_ha_status']
             )
+
+        # Load the device_info_template if defined this is a variable shared
+        # by all devices
+        if 'device_info_template' in data:
+            self.device_info_template = data['device_info_template']
 
         # MQTT message parameters.
         self.qos = data.get('qos', self.qos)

--- a/insteon_mqtt/mqtt/topic/BaseTopic.py
+++ b/insteon_mqtt/mqtt/topic/BaseTopic.py
@@ -20,6 +20,7 @@ class BaseTopic:
         """
         self.mqtt = mqtt
         self.device = device
+        self.class_name = None  # This should be amended by each class
 
     #-----------------------------------------------------------------------
     def base_template_data(self, **kwargs):

--- a/insteon_mqtt/mqtt/topic/BaseTopic.py
+++ b/insteon_mqtt/mqtt/topic/BaseTopic.py
@@ -21,6 +21,10 @@ class BaseTopic:
         self.mqtt = mqtt
         self.device = device
         self.class_name = None  # This should be amended by each class
+        # Any topics added here are available in discovery templates using the
+        # key as the variable name.  The key should be the yaml key for the
+        # topic
+        self.topics = {}
 
     #-----------------------------------------------------------------------
     def base_template_data(self, **kwargs):

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -99,9 +99,14 @@ class DiscoveryTopic(BaseTopic):
                  firmware = device firmware version
                  modem_addr = hexadecimal address of modem as a string
                  device_info_template = a template defined in config.yaml
+                 <<topics>> = topic keys as defined in the config.yaml file
+                      are available as variables
         """
         # Set up the variables that can be used in the templates.
         data = self.base_template_data(**kwargs)
+
+        # Insert Topics from topic classes
+        data.update(self.topics)
 
         data['name_user_case'] = self.device.addr.hex
         if self.device.name_user_case:

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -1,0 +1,176 @@
+#===========================================================================
+#
+# MQTT Discovery Topic
+#
+#===========================================================================
+import json
+import jinja2
+from ... import log
+from ..MsgTemplate import MsgTemplate
+from .BaseTopic import BaseTopic
+
+LOG = log.get_logger()
+
+
+class DiscoveryTopic(BaseTopic):
+    """MQTT interface to the Discovery Topic
+
+    This is an abstract class that provides support for the Discovery topic.
+    """
+    def __init__(self, mqtt, device, **kwargs):
+        """Discovery Topic Constructor
+
+        Args:
+          device (device):  The Insteon object to link to.
+          mqtt (mqtt.Mqtt):  The MQTT main interface.
+        """
+        super().__init__(mqtt, device, **kwargs)
+
+        # This is a list of all of the discovery entries published by this
+        # device
+        self.entries = []
+
+    #-----------------------------------------------------------------------
+    def load_discovery_data(self, config, qos=None):
+        """Load values from a configuration data object.
+
+        Args:
+          config (dict):  The mqtt section of the config dict.
+          qos (int):  The default quality of service level to use.
+        """
+        # First check to see that discovery_topic_base is set in config
+        discovery_topic_base = config.get('discovery_topic_base', None)
+        if discovery_topic_base is None:
+            LOG.debug("Discovery disabled, discovery_topic_base not defined.")
+
+        # Get the device specific discovery class
+        disc_class = self.device.config_extra.get('discovery_class',
+                                                  self.class_name)
+        class_config = config.get(disc_class, None)
+        if class_config is None:
+            LOG.error("%s - Unable to find discovery class %s",
+                      self.device.label, disc_class)
+            return
+
+        # Loop all of the discovery entities and append them to self.topics
+        entities = class_config.get('discovery_entities', None)
+        if entities is None or not isinstance(entities, list):
+            LOG.error("%s - No discovery_entities defined, or not a list %s",
+                      self.device.label, entities)
+            return
+        for entity in entities:
+            component = entity.get('component', None)
+            if component is None:
+                LOG.error("%s - No component specified in discovery entity %s",
+                          self.device.label, entity)
+                continue
+
+            payload = entity.get('config', None)
+            if payload is None:
+                LOG.error("%s - No config specified in discovery entity %s",
+                          self.device.label, entity)
+                continue
+
+            # Allowing topic to be settable in yaml, but I don't think users
+            # should worry about this, there is no utility in changing it
+            unique_id = self._get_unique_id(payload)
+            default_topic = "%s/%s/%s/%s/config" % (discovery_topic_base,
+                                                    component,
+                                                    self.device.addr.hex,
+                                                    unique_id)
+            topic = entity.get('topic', default_topic)
+            self.entries.append(MsgTemplate(topic=topic, payload=payload,
+                                            qos=qos, retain=False))
+
+    #-----------------------------------------------------------------------
+    def discovery_template_data(self, **kwargs):
+        """Create the Jinja templating data variables for on/off messages.
+
+        kwargs are empty.  Only here for conformity with base class.
+
+        Returns:
+          dict:  Returns a dict with the variables available for templating.
+                 including:
+                 name = device name in lower case
+                 address = hexadecimal address of device as a string
+                 name_user_case = device name in the case entered by the user
+                 engine = device engine version (i1, i2, i2cs)
+                 model = device model string
+                 firmware = device firmware version
+        """
+        # Set up the variables that can be used in the templates.
+        data = self.base_template_data(**kwargs)
+
+        data['name_user_case'] = self.device.addr.hex
+        if self.device.name_user_case:
+            data['name_user_case'] = self.device.name_user_case
+
+        engine_map = {0: 'i1', 1: 'i2', 2: 'i2cs'}
+        data['engine'] = engine_map.get(self.device.db.engine, 'Unknown')
+        data['model'] = self.device.db.desc
+        data['firmware'] = self.device.db.firmware
+
+        return data
+
+    #-----------------------------------------------------------------------
+    def publish_discovery(self, device, **kwargs):
+        """Device on/off callback.
+
+        This is triggered via ...
+
+        Args:
+          device (device):   The Insteon device that changed.
+          kwargs (dict): The arguments to pass to discovery_template_data
+        """
+        LOG.info("MQTT received discovery %s on: %s", device.label, kwargs)
+
+        data = self.discovery_template_data(**kwargs)
+
+        for entry in self.entries:
+            entry.publish(self.mqtt, data, retain=False)
+
+    #-----------------------------------------------------------------------
+    def _get_unique_id(self, config):
+        """Extracts the unique id from the rendered payload.
+
+        This renders the discovery payload, the decodes the json payload
+        back into a dict and extracts the unique_id.  This may seem a little
+        circuitous, but any solution requires rendering of the config and
+        json parsing if we want to know the unique_id.
+
+        Args:
+          config (dict):  The mqtt section of the config dict.
+
+        Returns:
+          unique_id (str) or None if there was an error.
+        """
+        config_template = jinja2.Template(config)
+        data = self.discovery_template_data()
+        ret = None
+        # First render template
+        try:
+            config_rendered = config_template.render(data)
+        except jinja2.exceptions.UndefinedError as exc:
+            LOG.error("Error rendering config template: %s", exc)
+            LOG.error("Template was: \n%s",
+                      config.strip())
+            LOG.error("Data passed was: %s", data)
+        else:
+            # Second, parse rendered result as json
+            # config_str = config_rendered.decode('utf-8')
+            try:
+                config_json = json.loads(config_rendered)
+            except json.JSONDecodeError as exc:
+                LOG.error("Error parsing config as json: %s", exc)
+                LOG.error("Config output was: \n%s",
+                          config_rendered.strip())
+            else:
+                # Third check for existence of unique_id or uniq_id
+                ret = config_json.get('unique_id',
+                                      config_json.get('uniq_id', None))
+                if ret is None:
+                    LOG.error("Unique_id was not specified in config: %s",
+                              config_rendered)
+        return ret
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -97,6 +97,8 @@ class DiscoveryTopic(BaseTopic):
                  engine = device engine version (i1, i2, i2cs)
                  model = device model string
                  firmware = device firmware version
+                 modem_addr = hexadecimal address of modem as a string
+                 device_info_template = a template defined in config.yaml
         """
         # Set up the variables that can be used in the templates.
         data = self.base_template_data(**kwargs)
@@ -109,6 +111,17 @@ class DiscoveryTopic(BaseTopic):
         data['engine'] = engine_map.get(self.device.db.engine, 'Unknown')
         data['model'] = self.device.db.desc
         data['firmware'] = self.device.db.firmware
+        data['modem_addr'] = self.device.modem.addr.hex
+
+        # Finally, render the device_info_template
+        device_info_template = jinja2.Template(self.mqtt.device_info_template)
+        try:
+            data['device_info_template'] = device_info_template.render(data)
+        except jinja2.exceptions.UndefinedError as exc:
+            LOG.error("Error rendering device_info_template: %s", exc)
+            LOG.error("Template was: \n%s",
+                      self.mqtt.device_info_template.strip())
+            LOG.error("Data passed was: %s", data)
 
         return data
 

--- a/insteon_mqtt/mqtt/topic/ManualTopic.py
+++ b/insteon_mqtt/mqtt/topic/ManualTopic.py
@@ -75,6 +75,11 @@ class ManualTopic(BaseTopic):
         # Update the MQTT topics and payloads from the config file.
         self.msg_manual_state.load_config(data, topic, payload, qos)
 
+        # Add ourselves to the list of topics
+        self.topics['manual_state_topic'] = self.msg_manual_state.render_topic(
+            self.base_template_data()
+        )
+
     #-----------------------------------------------------------------------
     def publish_manual(self, device, **kwargs):
         """Device Manual Change Callback.

--- a/insteon_mqtt/mqtt/topic/SceneTopic.py
+++ b/insteon_mqtt/mqtt/topic/SceneTopic.py
@@ -59,6 +59,11 @@ class SceneTopic(BaseTopic):
         # Update the MQTT topics and payloads from the config file.
         self.msg_scene.load_config(data, topic, payload, qos)
 
+        # Add ourselves to the list of topics
+        self.topics['on_off_topic'] = self.msg_scene.render_topic(
+            self.base_template_data()
+        )
+
     #-----------------------------------------------------------------------
     def scene_subscribe(self, link, qos, group=None):
         """Subscribe to any MQTT topics the object needs.

--- a/insteon_mqtt/mqtt/topic/SetTopic.py
+++ b/insteon_mqtt/mqtt/topic/SetTopic.py
@@ -56,6 +56,11 @@ class SetTopic(BaseTopic):
         # Update the MQTT topics and payloads from the config file.
         self.msg_set.load_config(data, topic, payload, qos)
 
+        # Add ourselves to the list of topics
+        self.topics['on_off_topic'] = self.msg_set.render_topic(
+            self.base_template_data()
+        )
+
     #-----------------------------------------------------------------------
     def set_subscribe(self, link, qos, group=None):
         """Subscribe to any MQTT topics the object needs.

--- a/insteon_mqtt/mqtt/topic/StateTopic.py
+++ b/insteon_mqtt/mqtt/topic/StateTopic.py
@@ -91,6 +91,15 @@ class StateTopic(BaseTopic):
             if payload_1 is None:
                 payload_1 = 'dimmer_state_payload'
             self.msg_state_1.load_config(data, topic_1, payload_1, qos)
+            # Add ourselves to the list of topics
+            self.topics['dimmer_state_topic'] = self.msg_state_1.render_topic(
+                self.base_template_data()
+            )
+
+        # Add ourselves to the list of topics
+        self.topics['state_topic'] = self.msg_state.render_topic(
+            self.base_template_data()
+        )
 
     #-----------------------------------------------------------------------
     def state_template_data(self, **kwargs):

--- a/insteon_mqtt/mqtt/topic/__init__.py
+++ b/insteon_mqtt/mqtt/topic/__init__.py
@@ -12,6 +12,7 @@ topics.  They should be extended by an MQTT device object.
 """
 
 from .BaseTopic import BaseTopic
+from .DiscoveryTopic import DiscoveryTopic
 from .ManualTopic import ManualTopic
 from .SceneTopic import SceneTopic
 from .SetTopic import SetTopic


### PR DESCRIPTION
## Proposed change
This is a functioning basic implementation of the Discovery feature.  It lacks lots of documentation, and is only implemented on Dimmers.  The idea is this:

1. There are some global yaml settings for discovery such as `discovery_topic_base` and `discovery_ha_status`
2. There is a global setting for `device_info_template` that allows the user to define a device template that can be reused as a variable in the discovery templates.  @schirner had implemented something like this, and I agree this is very handy.  This is likely to be reused in every template.
3. By default each device class will look in it's subkey under the `mqtt` key in the config.yaml file for the discovery templates.  So dimmers look to `mqtt->dimmer` by default.
4. Inside this class, a `discovery_entities` key is defined.  This key __must__ have a `component` subkey and `config` key.  The `config` key __must__ include at minimum a `unique_id`.  Other HomeAssistant config settings also need to be defined.
5. The templates have a lot of variables available to them including: `name, address, name_user_case, engine, model, firmware, modem_addr, device_info_template`.  Additionally all topics defined in yaml are also available.
6. The discovery topics are automatically generated, I don't see any reason why a user would need to edit these, they do not have any effect on how HomeAssistant functions.

#### Customization
As referenced in the `min_hops` addition, users can create new discovery classes that can be used on one or more devices.  By specifying `discovery_class` as an config_extra key for the device.  The value is a reference to a key under the `mqtt` section.  This new subkey would then need to contain a `discovery_entities` key as defined above.


## Additional information
- This PR is related to issue: #128 

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary
- [ ] Documentation added/updated

Below is a sample of the published topic `homeassistant/light/4f.23.38/4f.23.38_light/config` using the config settings shown in the attached commits:
```JSON
{
  "uniq_id": "4f.23.38_light",
  "name": "dimmer",
  "cmd_t": "insteon/4f.23.38/level",
  "stat_t": "insteon/4f.23.38/state",
  "brightness": true,
  "schema": "json",
  "device": {
  "ids": "4f.23.38",
  "mf": "Insteon",
  "mdl": "DIMMABLE_LIGHTING (0x01): '2477D' (0x20) 'SwitchLinc Dimmer (Dual-Band)'",
  "sw": "69",
  "name": "dimmer",
  "via_device": "41.ee.e6"
}
}
```
