### PR TITLE
Add Discovery Support to All Devices

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1524,6 +1524,26 @@ mqtt:
     on_off_topic: 'insteon/{{address}}/set'
     on_off_payload: '{ "cmd" : "{{value.lower()}}" }'
 
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    discovery_entities:
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_relay",
+            "name": "{{name_user_case}}",
+            "cmd_t": "{{on_off_topic}}",
+            "stat_t": "{{relay_state_topic}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_sensor",
+            "name": "{{name_user_case}} sensor",
+            "stat_t": "{{sensor_state_topic}}",
+            "device": {{device_info_template}}
+          }
+
   #------------------------------------------------------------------------
   # On/off outlets
   #------------------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -909,6 +909,45 @@ mqtt:
     error_topic: 'insteon/{{address}}/error'
     error_payload: '{{on_str.upper()}}'
 
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    discovery_entities:
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_smoke",
+            "name": "{{name_user_case}} smoke",
+            "stat_t": "{{smoke_topic}}",
+            "device_class": "smoke",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_battery",
+            "name": "{{name_user_case}} battery",
+            "stat_t": "{{battery_topic}}",
+            "device_class": "battery",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_co",
+            "name": "{{name_user_case}} co",
+            "stat_t": "{{co_topic}}",
+            "device_class": "gas",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_error",
+            "name": "{{name_user_case}} error",
+            "stat_t": "{{error_topic}}",
+            "device_class": "problem",
+            "device": {{device_info_template}}
+          }
+
   #------------------------------------------------------------------------
   # Thermostat
   #------------------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -337,6 +337,18 @@ mqtt:
                       {% endif %}
                     }'
 
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    discovery_entities:
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_switch",
+            "name": "{{name_user_case}}",
+            "cmd_t": "{{on_off_topic}}",
+            "stat_t": "{{state_topic}}",
+            "device": {{device_info_template}}
+          }
+
   #------------------------------------------------------------------------
   # Dimmers
   #------------------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1592,12 +1592,12 @@ mqtt:
 
     # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
     #
-    # The keypad_linc class includes additional topics for the various buttons,
+    # The outlet class includes additional topics for the two outlets,
     # these topics are:
     #   btn_state_topic_N
     #   btn_on_off_topic_N
     #
-    # Where N is in the range of [1-2] representing the button group numbers
+    # Where N is in the range of [1-2] representing the outlet group numbers
     # 1-2
     # The default setup below includes topics for both outlets. If you have a
     # single outlet model, you may want to review the instructions at:
@@ -1667,5 +1667,56 @@ mqtt:
     #          a variable from a json payload.
     on_off_topic: "insteon/{{address}}/set/{{button}}"
     on_off_payload: '{ "cmd" : "{{value.lower()}}" }'
+
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    #
+    # The ezio4 class includes additional topics for the various relays,
+    # these topics are:
+    #   btn_state_topic_N
+    #   btn_on_off_topic_N
+    #
+    # Where N is in the range of [1-4] representing the relay group numbers
+    # 1-4
+    # The default setup below includes topics for all relays. You may want to
+    # review the instructions at:
+    # https://github.com/TD22057/insteon-mqtt/blob/master/docs/discovery.md
+    # for details about how to define a custom class for your devices.
+    discovery_entities:
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_1",
+            "name": "{{name_user_case}} relay 1",
+            "cmd_t": "{{on_off_topic_1}}",
+            "stat_t": "{{state_topic_1}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_2",
+            "name": "{{name_user_case}} relay 2",
+            "cmd_t": "{{on_off_topic_2}}",
+            "stat_t": "{{state_topic_2}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_3",
+            "name": "{{name_user_case}} relay 3",
+            "cmd_t": "{{on_off_topic_3}}",
+            "stat_t": "{{state_topic_3}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_4",
+            "name": "{{name_user_case}} relay 4",
+            "cmd_t": "{{on_off_topic_4}}",
+            "stat_t": "{{state_topic_4}}",
+            "device": {{device_info_template}}
+          }
 
 #----------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -714,6 +714,27 @@ mqtt:
     wet_dry_topic: 'insteon/{{address}}/wet'
     wet_dry_payload: '{{is_wet_str.upper()}}'
 
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    discovery_entities:
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_wet",
+            "name": "{{name_user_case}} leak",
+            "stat_t": "{{state_topic}}",
+            "device_class": "moisture",
+            "device": {{device_info_template}}
+          }
+      - component: 'sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_heartbeat",
+            "name": "{{name_user_case}} heartbeat",
+            "stat_t": "{{heartbeat_topic}}",
+            "device_class": "timestamp",
+            "device": {{device_info_template}}
+          }
+
   #------------------------------------------------------------------------
   # Mini remotes
   #------------------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -237,7 +237,7 @@ mqtt:
               {%- endif -%}",
       "sw": "0x{{'%0x' % firmware|int }} - {{engine}}",
       "name": "{{name_user_case}}",
-      "via_device": "{{modem_addr}}",
+      "via_device": "{{modem_addr}}"
     }
 
   # Trigger modem virtual scenes.  Modem scenes are where the modem is a

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1530,7 +1530,7 @@ mqtt:
         config: |-
           {
             "uniq_id": "{{address}}_relay",
-            "name": "{{name_user_case}}",
+            "name": "{{name_user_case}} relay",
             "cmd_t": "{{on_off_topic}}",
             "stat_t": "{{relay_state_topic}}",
             "device": {{device_info_template}}
@@ -1589,6 +1589,39 @@ mqtt:
     #          a variable from a json payload.
     on_off_topic: 'insteon/{{address}}/set/{{button}}'
     on_off_payload: '{ "cmd" : "{{value.lower()}}" }'
+
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    #
+    # The keypad_linc class includes additional topics for the various buttons,
+    # these topics are:
+    #   btn_state_topic_N
+    #   btn_on_off_topic_N
+    #
+    # Where N is in the range of [1-2] representing the button group numbers
+    # 1-2
+    # The default setup below includes topics for both outlets. If you have a
+    # single outlet model, you may want to review the instructions at:
+    # https://github.com/TD22057/insteon-mqtt/blob/master/docs/discovery.md
+    # for details about how to define a custom class for your devices.
+    discovery_entities:
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_1",
+            "name": "{{name_user_case}} top",
+            "cmd_t": "{{on_off_topic_1}}",
+            "stat_t": "{{state_topic_1}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_2",
+            "name": "{{name_user_case}} bottom",
+            "cmd_t": "{{on_off_topic_2}}",
+            "stat_t": "{{state_topic_2}}",
+            "device": {{device_info_template}}
+          }
 
   #------------------------------------------------------------------------
   # EZIO4O 4 relay output module

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -768,6 +768,103 @@ mqtt:
     #manual_state_topic: 'insteon/{{address}}/manual_state'
     #manual_state_payload: '{{manual_str.upper()}}'
 
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    #
+    # The remote class includes additional topics for the state of the various
+    # buttons, these state topics are:
+    #   state_topic_N
+    #
+    # Where N is in the range of [1-8] representing the button group numbers
+    # 1-8
+    # The default setup below includes state topics for all 8 buttons.  If you
+    # have a single button or a 4 button remote, you may want to review the
+    # instructions at:
+    # https://github.com/TD22057/insteon-mqtt/blob/master/docs/discovery.md
+    # for details about how to define a custom class for your devices.
+    discovery_entities:
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_1",
+            "name": "{{name_user_case}} btn 1",
+            "stat_t": "{{state_topic_1}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_2",
+            "name": "{{name_user_case}} btn 2",
+            "stat_t": "{{state_topic_2}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_3",
+            "name": "{{name_user_case}} btn 3",
+            "stat_t": "{{state_topic_3}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_4",
+            "name": "{{name_user_case}} btn 4",
+            "stat_t": "{{state_topic_4}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_5",
+            "name": "{{name_user_case}} btn 5",
+            "stat_t": "{{state_topic_5}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_6",
+            "name": "{{name_user_case}} btn 6",
+            "stat_t": "{{state_topic_6}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_7",
+            "name": "{{name_user_case}} btn 7",
+            "stat_t": "{{state_topic_7}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_8",
+            "name": "{{name_user_case}} btn 8",
+            "stat_t": "{{state_topic_8}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_battery",
+            "name": "{{name_user_case}} battery",
+            "stat_t": "{{low_battery_topic}}",
+            "device_class": "battery",
+            "device": {{device_info_template}}
+          }
+      - component: 'sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_heartbeat",
+            "name": "{{name_user_case}} heartbeat",
+            "stat_t": "{{heartbeat_topic}}",
+            "device_class": "timestamp",
+            "device": {{device_info_template}}
+          }
+
   #------------------------------------------------------------------------
   # Smoke Bridge
   #------------------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -575,6 +575,45 @@ mqtt:
     dawn_dusk_topic: 'insteon/{{address}}/dawn'
     dawn_dusk_payload: '{{is_dawn_str.upper()}}'
 
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    discovery_entities:
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_motion",
+            "name": "{{name_user_case}} motion",
+            "stat_t": "{{state_topic}}",
+            "device_class": "motion",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_battery",
+            "name": "{{name_user_case}} battery",
+            "stat_t": "{{low_battery_topic}}",
+            "device_class": "battery",
+            "device": {{device_info_template}}
+          }
+      - component: 'sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_heartbeat",
+            "name": "{{name_user_case}} heartbeat",
+            "stat_t": "{{heartbeat_topic}}",
+            "device_class": "timestamp",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_dusk",
+            "name": "{{name_user_case}} dusk",
+            "stat_t": "{{dawn_dusk_topic}}",
+            "device_class": "light",
+            "device": {{device_info_template}}
+          }
+
   #------------------------------------------------------------------------
   # Hidden Door Sensors
   #------------------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -622,12 +622,12 @@ mqtt:
   # inputs from battery_sensor and add battery voltage which is configured
   # here.
   #
-  # To register the hidden door sensor in Home Assistant use MQTT binary
+  # To register the battery voltage sensor in Home Assistant use MQTT
   # sensor with a configuration like:
-  #   binary_sensor:
+  #   sensor:
   #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc//battery_voltage'
-  #TODO       device_class: 'light'
+  #       state_topic: 'insteon/aa.bb.cc/battery_voltage'
+  #       device_class: 'voltage'
   hidden_door:
     # Output topic and payload.  This message is sent
     # whenever the device is polled and a new voltage, low battery voltage
@@ -639,6 +639,45 @@ mqtt:
 
     battery_voltage_topic: 'insteon/{{address}}/battery_voltage'
     battery_voltage_payload: '{"voltage" : {{batt_volt}}}'
+
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    discovery_entities:
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_door",
+            "name": "{{name_user_case}} door",
+            "stat_t": "{{state_topic}}",
+            "device_class": "door",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_battery",
+            "name": "{{name_user_case}} battery",
+            "stat_t": "{{low_battery_topic}}",
+            "device_class": "battery",
+            "device": {{device_info_template}}
+          }
+      - component: 'sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_heartbeat",
+            "name": "{{name_user_case}} heartbeat",
+            "stat_t": "{{heartbeat_topic}}",
+            "device_class": "timestamp",
+            "device": {{device_info_template}}
+          }
+      - component: 'sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_voltage",
+            "name": "{{name_user_case}} voltage",
+            "stat_t": "{{battery_voltage_topic}}",
+            "device_class": "voltage",
+            "device": {{device_info_template}}
+          }
 
   #------------------------------------------------------------------------
   # Leak sensors

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1042,6 +1042,36 @@ mqtt:
     cool_sp_command_topic: 'insteon/{{address}}/cool_sp_command'
     cool_sp_payload: '{ "temp_f" : {{value}} }'
 
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    discovery_entities:
+      - component: 'climate'
+        config: |-
+          {
+            "uniq_id": "{{address}}_thermo",
+            "name": "{{name_user_case}} thermo",
+            "act_t": "{{status_state_topic}}",
+            "curr_temp_t": "{{ambient_temp_topic}}",
+            "curr_temp_tpl": "{% raw %}{{value_json.temp_f}}{% endraw %}",
+            "device": {{device_info_template}},
+            "fan_mode_cmd_t": "{{fan_command_topic}}",
+            "fan_mode_stat_t": "{{fan_state_topic}}",
+            "fan_modes": ["auto", "on"],
+            "hold_stat_t": "{{hold_state_topic}}",
+            "mode_cmd_t": "{{mode_command_topic}}",
+            "mode_stat_t": "{{mode_state_topic}}",
+            "modes": ["off", "cool", "heat", "auto"],
+            "precision": 1.0,
+            "temp_hi_cmd_t": "{{cool_sp_command_topic}}",
+            "temp_hi_stat_t": "{{cool_sp_state_topic}}",
+            "temp_hi_stat_tpl": "{% raw %}{{value_json.temp_f}}{% endraw %}",
+            "temp_lo_cmd_t": "{{heat_sp_command_topic}}",
+            "temp_lo_stat_t": "{{heat_sp_state_topic}}",
+            "temp_lo_stat_tpl": "{% raw %}{{value_json.temp_f}}{% endraw %}",
+            "temperature_unit": "F"
+          }
+
+
+
   #------------------------------------------------------------------------
   # Fan Linc
   #------------------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -274,6 +274,40 @@ mqtt:
                       "group" : {{json.group}}
                     }'
 
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    #
+    # The modem has 253 possible scenes from scene 2-254.  The modem ONLY
+    # ACCEPTS A SINGLE entity template.  This template will be used for each of
+    # the scenes.
+    #
+    # This is the only place where you can set the template for the modem, it
+    # does NOT use the `discovery_class` extra configuration setting.
+    #
+    # Special variables:
+    #  {{scene}} - will be replaced with the scene number of the scene.
+    #  {{scene_name}} - will be replaced with the name of the scene as defined
+    #                   in a scenes.yaml file if used.
+    #  {{scene_topic}} - will be replaced by the scene topic for this scene.
+    #
+    # Only scenes that appear in the GroupMap list when printing the modem db
+    # will be included.  These are the only scenes for which the modem is
+    # listed as a controller.  Run `refresh modem` if the entities list
+    # appears incomplete to you.
+    discovery_entities:
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_{{scene}}",
+            "name": "{%- if scene_name != "" -%}
+                       {{scene_name}}
+                     {%- else -%}
+                       Modem Scene {{scene}}
+                     {%- endif -%}",
+            "cmd_t": "{{scene_topic}}",
+            "device": {{device_info_template}},
+            "payload_on": "{\"cmd\": \"on\", \"group\": \"{{scene}}\"}",
+            "payload_off": "{\"cmd\": \"off\", \"group\": \"{{scene}}\"}"
+          }
 
   # IMPORTANT: all devices must have the pair() command run one time to make
   # sure that the all the necessary controller/responder links are defined

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -467,7 +467,10 @@ mqtt:
 
   #------------------------------------------------------------------------
   # Battery powered sensors
-  #    door sensors, hidden door sensors, window sensors
+  #    door sensors, window sensors
+  #
+  #    Other devices (motion, leak, hidden_door, and remote) inherit the
+  #    topics defined here and then add a few more.
   #------------------------------------------------------------------------
 
   # In Home Assistant use MQTT binary sensor with a configuration like:
@@ -510,6 +513,39 @@ mqtt:
     # the leak sensor is known to provide this data
     heartbeat_topic: 'insteon/{{address}}/heartbeat'
     heartbeat_payload: '{{heartbeat_time}}'
+
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    # this only applies to devices defined as battery_sensor.  Devices that
+    # extend this class (motion, hidden_door, leak, and remote) all have their
+    # own discovery_entities
+    discovery_entities:
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_door",
+            "name": "{{name_user_case}} door",
+            "stat_t": "{{state_topic}}",
+            "device_class": "door",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_battery",
+            "name": "{{name_user_case}} battery",
+            "stat_t": "{{low_battery_topic}}",
+            "device_class": "battery",
+            "device": {{device_info_template}}
+          }
+      - component: 'sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_heartbeat",
+            "name": "{{name_user_case}} heartbeat",
+            "stat_t": "{{heartbeat_topic}}",
+            "device_class": "timestamp",
+            "device": {{device_info_template}}
+          }
 
   #------------------------------------------------------------------------
   # Motion sensors

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1338,6 +1338,117 @@ mqtt:
                           {% endif %}
                         }'
 
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    #
+    # This class includes an additional variable `is_dimmable` which is set
+    # to True if btn 1 on the device is dimmable otherwise it returns False
+    #
+    # The keypad_linc class includes additional topics for the various buttons,
+    # these topics are:
+    #   btn_state_topic_N
+    #   btn_on_off_topic_N
+    #   btn_scene_topic_N
+    #
+    # Where N is in the range of [1-9] representing the button group numbers
+    # 1-9
+    # The default setup below includes topics for all 8 buttons plus the
+    # the detached load setup.  If you have a six button keypad_linc, you may
+    # want to review the instructions at:
+    # https://github.com/TD22057/insteon-mqtt/blob/master/docs/discovery.md
+    # for details about how to define a custom class for your devices.
+    discovery_entities:
+      - component: 'light'
+        config: |-
+          {
+            "uniq_id": "{{address}}_1",
+            "name": "{{name_user_case}} btn 1",
+            "device": {{device_info_template}},
+            "brightness": {{is_dimmable|lower()}},
+            "cmd_t": "{%- if is_dimmable -%}
+                        {{dimmer_level_topic}}
+                      {%- else -%}
+                        {{btn_on_off_topic_1}}
+                      {%- endif -%}",
+            "schema": "json",
+            "stat_t": "{%- if is_dimmable -%}
+                        {{dimmer_state_topic}}
+                      {%- else -%}
+                        {{btn_state_topic_1}}
+                      {%- endif -%}"
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_2",
+            "name": "{{name_user_case}} btn 2",
+            "device": {{device_info_template}},
+            "cmd_t": "{{btn_on_off_topic_2}}",
+            "stat_t": "{{btn_on_off_topic_2}}",
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_3",
+            "name": "{{name_user_case}} btn 3",
+            "device": {{device_info_template}},
+            "cmd_t": "{{btn_on_off_topic_3}}",
+            "stat_t": "{{btn_on_off_topic_3}}",
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_4",
+            "name": "{{name_user_case}} btn 4",
+            "device": {{device_info_template}},
+            "cmd_t": "{{btn_on_off_topic_4}}",
+            "stat_t": "{{btn_on_off_topic_4}}",
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_5",
+            "name": "{{name_user_case}} btn 5",
+            "device": {{device_info_template}},
+            "cmd_t": "{{btn_on_off_topic_5}}",
+            "stat_t": "{{btn_on_off_topic_5}}",
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_6",
+            "name": "{{name_user_case}} btn 6",
+            "device": {{device_info_template}},
+            "cmd_t": "{{btn_on_off_topic_6}}",
+            "stat_t": "{{btn_on_off_topic_6}}",
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_7",
+            "name": "{{name_user_case}} btn 7",
+            "device": {{device_info_template}},
+            "cmd_t": "{{btn_on_off_topic_7}}",
+            "stat_t": "{{btn_on_off_topic_7}}",
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_8",
+            "name": "{{name_user_case}} btn 8",
+            "device": {{device_info_template}},
+            "cmd_t": "{{btn_on_off_topic_8}}",
+            "stat_t": "{{btn_on_off_topic_8}}",
+          }
+      - component: 'switch'
+        config: |-
+          {
+            "uniq_id": "{{address}}_9",
+            "name": "{{name_user_case}} btn 9",
+            "device": {{device_info_template}},
+            "cmd_t": "{{btn_on_off_topic_9}}",
+            "stat_t": "{{btn_on_off_topic_9}}",
+          }
+
   #------------------------------------------------------------------------
   # IO Linc relay controllers
   #------------------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1070,8 +1070,6 @@ mqtt:
             "temperature_unit": "F"
           }
 
-
-
   #------------------------------------------------------------------------
   # Fan Linc
   #------------------------------------------------------------------------
@@ -1115,6 +1113,9 @@ mqtt:
   #       {% else %}
   #         0
   #       {% endif %}
+  #     preset_mode_state_topic: "insteon/aa.bb.cc/fan/speed/state"
+  #     preset_mode_command_topic: "insteon/aa.bb.cc/fan/speed/set"
+  #     preset_modes: ["off", "low", "medium", "high"]
 
   fan_linc:
     # Output fan state change topic and payload.  This message is sent
@@ -1166,6 +1167,35 @@ mqtt:
     #          a variable from a json payload.
     fan_speed_set_topic: 'insteon/{{address}}/fan/speed/set'
     fan_speed_set_payload: '{ "cmd" : "{{value.lower()}}" }'
+
+    # Discovery Entities - Used as part of HomeAssistant MQTT Discovery
+    discovery_entities:
+      - component: 'fan'
+        config: |-
+          {
+            "uniq_id": "{{address}}_fan",
+            "name": "{{name_user_case}} thermo",
+            "device": {{device_info_template}},
+            "cmd_t": "{{fan_on_off_topic}}",
+            "pct_cmd_t": "{{fan_speed_set_topic}}",
+            "pct_cmd_tpl": "{% raw %}{% if value < 10 %}off{% elif value < 40 %}low{% elif value < 75 %}medium{% else %}high{% endif %}{% endraw %}",
+            "pct_stat_t": "{{fan_speed_topic}}",
+            "pct_val_tpl": "{% raw %}{% if value == 'low' %}33{% elif value == 'medium' %}67{% elif value == 'high' %}100{% else %}0{% endif %}{% endraw %}",
+            "pr_mode_stat_t": "{{fan_speed_topic}}",
+            "pr_mode_cmd_t": "{{fan_speed_set_topic}}",
+            "pr_modes": ["off", "low", "medium", "high"]
+          }
+      - component: 'light'
+        config: |-
+          {
+            "uniq_id": "{{address}}_light",
+            "name": "{{name_user_case}}",
+            "cmd_t": "{{level_topic}}",
+            "stat_t": "{{state_topic}}",
+            "brightness": true,
+            "schema": "json",
+            "device": {{device_info_template}}
+          }
 
   #------------------------------------------------------------------------
   # Keypad Linc

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -138,6 +138,8 @@ they can however be represented by `\n`
 2. __Trailing Commas__ - JSON cannot include trailing commas.  The last item
 in a list or the last key:value pair in an object __cannot__ be followed by a
 comma.
+3. __Single Quotes__ - JSON requires doubles quotes, you __cannot__ use single
+quotes to define a string.  You can escape double quotes with `\"`
 
 #### Passing Jinja Templates as Values
 HomeAssistant uses jinja templates as well, and in a number of cases entities

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -109,6 +109,28 @@ Additional variables may be offered by specific devices classes.  Those
 variables are defined in the `config-example.yaml` file under the relevant
 `mqtt` device keys.
 
+#### Passing Jinja Templates as Values
+HomeAssistant uses jinja templates as well, and in a number of cases entities
+have configuration settings that contain a template.  If you attempt to enter a
+template as a value, it will be rendered by InsteonMQTT, which in this case
+would likely result with an empty value.
+
+To pass an unrendered template on to HomeAssistant __you must escape the
+template__.  The template can be escaped using the `{% raw %} {{escaped_stuff}} {% endraw %}`
+format.  For example:
+
+```yaml
+mqtt:
+  climate:
+    discovery_entities:
+      - component: "climate"
+        config: |-
+          {
+          .... # other settings
+          "temp_lo_stat_tpl": "{% raw %}{{value_json.temp_f}}{% endraw %}",
+          }
+```
+
 #### Example `discovery_entities` templates
 
 ```yaml

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -189,3 +189,50 @@ as:
   }
 }
 ```
+
+## Sample Templates for Custom Discovery Classes
+
+### Single Button Remote
+
+The default remote configuration exposes entities for all eight
+buttons.  However, if you have a single button remote, you likely
+only want to see an entity for that single button.  The following
+sample configuration settings will enable that:
+
+```yaml
+insteon:
+  device:
+    mini_remote1::
+      - dd.ee.ff: my_remote
+        discovery_class: remote_1  # < note no dash at start of line
+
+mqtt:
+  remote_1:  # < Note the class name
+    discovery_entities:
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_btn",
+            "name": "{{name_user_case}} btn",
+            "stat_t": "{{state_topic_1}}",
+            "device": {{device_info_template}}
+          }
+      - component: 'binary_sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_battery",
+            "name": "{{name_user_case}} battery",
+            "stat_t": "{{low_battery_topic}}",
+            "device_class": "battery",
+            "device": {{device_info_template}}
+          }
+      - component: 'sensor'
+        config: |-
+          {
+            "uniq_id": "{{address}}_heartbeat",
+            "name": "{{name_user_case}} heartbeat",
+            "stat_t": "{{heartbeat_topic}}",
+            "device_class": "timestamp",
+            "device": {{device_info_template}}
+          }
+```

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -164,7 +164,7 @@ mqtt:
               {%- endif -%}",
       "sw": "0x{{'%0x' % firmware|int }} - {{engine}}",
       "name": "{{name_user_case}}",
-      "via_device": "{{modem_addr}}",
+      "via_device": "{{modem_addr}}"
     }
 ```
 
@@ -185,7 +185,7 @@ as:
     "mdl": "2477D - SwitchLinc Dimmer (Dual-Band)",
     "sw": "0x45 - i2cs",
     "name": "my dimmer",
-    "via_device": "41.ee.e6",
+    "via_device": "41.ee.e6"
   }
 }
 ```

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -64,7 +64,7 @@ Each entry `discovery_entities` is an associative array with the __required__
 keys `component` and `config`.
 - `component` - (String) One of the supported HomeAssistant MQTT components,
 eg. `binary_sensor`, `light`, `switch`
-- `config` - (jinja template) The template must produce a json string that is
+- `config` - (jinja template) The template must produce a __json__ string that is
 acceptable to HomeAssistant.  The contents of what is required in this json
 string are defined by the
 [HomeAssistant Discovery Platform](https://www.home-assistant.io/docs/mqtt/discovery/).
@@ -75,6 +75,10 @@ recommended__ that you use the the device address as part of this unique id.
 The recommended format is `{{address}}_suffix` where the suffix is something
 that plainly describes the nature of this enity.  Devices with only a single
 entity do not need a suffix, but it is still good practice to use one.
+
+> The `config` json template __must generate valid json_.  This is a good json
+[validator](https://jsonformatter.curiousconcept.com/).  __Notably__ json strings
+cannot contain raw newline characters, they can however be represented by `\n`
 
 The `config` template has a number of variables available to it.  For all
 devices this includes at minimum the following, devices may also add

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -110,6 +110,13 @@ class Modem:
         # to each device.
         self.protocol.signal_received.connect(self.handle_received)
 
+        # For compatibility with devices, this is empty.  The Modem does not
+        # use config_extra settings.
+        self.config_extra = {}
+
+        # A prettier name for the modem
+        self.name_user_case = "Modem"
+
     #-----------------------------------------------------------------------
     def clear_db_config(self):
         """Clears and initializes the device config database

--- a/insteon_mqtt/mqtt/BatterySensor.py
+++ b/insteon_mqtt/mqtt/BatterySensor.py
@@ -45,7 +45,7 @@ class BatterySensor(topic.StateTopic, topic.DiscoveryTopic):
         device.signal_heartbeat.connect(self._insteon_heartbeat)
 
         # This defines the default discovery_class for these devices
-        self.class_name = "battery_sensor"
+        self.default_discovery_cls = "battery_sensor"
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/BatterySensor.py
+++ b/insteon_mqtt/mqtt/BatterySensor.py
@@ -71,6 +71,13 @@ class BatterySensor(topic.StateTopic, topic.DiscoveryTopic):
         self.msg_heartbeat.load_config(data, 'heartbeat_topic',
                                        'heartbeat_payload', qos)
 
+        # Add our unique topics to the discovery topic map
+        topics = {}
+        var_data = self.base_template_data()
+        topics['low_battery_topic'] = self.msg_battery.render_topic(var_data)
+        topics['heartbeat_topic'] = self.msg_heartbeat.render_topic(var_data)
+        self.rendered_topic_map.update(topics)
+
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
         """Subscribe to any MQTT topics the object needs.
@@ -124,18 +131,6 @@ class BatterySensor(topic.StateTopic, topic.DiscoveryTopic):
             data["is_heartbeat_str"] = "on" if is_heartbeat else "off"
             data["heartbeat_time"] = time.time() if is_heartbeat else 0
 
-        return data
-
-    #-----------------------------------------------------------------------
-    def discovery_template_data(self, **kwargs):
-        """This extends the template data variables defined in the base class
-
-        Adds in low_battery_topic and heartbeat_topic topics.
-        """
-        # Set up the variables that can be used in the templates.
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
-        data['low_battery_topic'] = self.msg_battery.render_topic(data)
-        data['heartbeat_topic'] = self.msg_heartbeat.render_topic(data)
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -36,7 +36,7 @@ class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
                                        '"brightness" : {{level_255}} }')
 
         # This defines the default discovery_class for these devices
-        self.class_name = "dimmer"
+        self.default_discovery_cls = "dimmer"
 
         # Input level command template.
         self.msg_level = MsgTemplate(
@@ -56,7 +56,7 @@ class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
         # The discovery topic needs the full config
         self.load_discovery_data(config, qos)
 
-        data = config.get(self.class_name, None)
+        data = config.get("dimmer", None)
         if not data:
             return
 

--- a/insteon_mqtt/mqtt/Dimmer.py
+++ b/insteon_mqtt/mqtt/Dimmer.py
@@ -69,6 +69,11 @@ class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
         # Update the MQTT topics and payloads from the config file.
         self.msg_level.load_config(data, 'level_topic', 'level_payload', qos)
 
+        # Add our unique topics to the discovery topic map
+        self.rendered_topic_map['level_topic'] = self.msg_level.render_topic(
+            self.base_template_data()
+        )
+
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
         """Subscribe to any MQTT topics the object needs.
@@ -101,17 +106,6 @@ class Dimmer(topic.StateTopic, topic.SceneTopic, topic.ManualTopic,
         link.unsubscribe(topic_str)
 
         self.scene_unsubscribe(link)
-
-    #-----------------------------------------------------------------------
-    def discovery_template_data(self, **kwargs):
-        """This extends the template data variables defined in the base class
-
-        Adds in level_topic for dimmers.
-        """
-        # Set up the variables that can be used in the templates.
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
-        data['level_topic'] = self.msg_level.render_topic(data)
-        return data
 
     #-----------------------------------------------------------------------
     def _input_set_level(self, client, data, message):

--- a/insteon_mqtt/mqtt/EZIO4O.py
+++ b/insteon_mqtt/mqtt/EZIO4O.py
@@ -9,7 +9,7 @@ from . import topic
 LOG = log.get_logger()
 
 
-class EZIO4O(topic.StateTopic, topic.SetTopic):
+class EZIO4O(topic.StateTopic, topic.SetTopic, topic.DiscoveryTopic):
     """MQTT interface to Smartenit EZIO4O 4 relay output device.
 
     This class connects to a device.EZIO4O object and converts it's
@@ -32,6 +32,12 @@ class EZIO4O(topic.StateTopic, topic.SetTopic):
                          state_topic='insteon/{{address}}/state/{{button}}',
                          set_topic="insteon/{{address}}/set/{{button}}")
 
+        # This defines the default discovery_class for these devices
+        self.default_discovery_cls = "ezio4o"
+
+        # Set the groups for discovery topic generation
+        self.extra_topic_nums = range(1, 5)
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -41,6 +47,9 @@ class EZIO4O(topic.StateTopic, topic.SetTopic):
                  config is stored in config['ezio4o'].
           qos (int):  The default quality of service level to use.
         """
+        # The discovery topic needs the full config
+        self.load_discovery_data(config, qos)
+
         data = config.get("ezio4o", None)
         if not data:
             return

--- a/insteon_mqtt/mqtt/FanLinc.py
+++ b/insteon_mqtt/mqtt/FanLinc.py
@@ -39,7 +39,7 @@ class FanLinc(Dimmer):
         super().__init__(mqtt, device)
 
         # This defines the default discovery_class for these devices
-        self.class_name = "fan_linc"
+        self.default_discovery_cls = "fan_linc"
 
         # Output fan state change reporting template.
         self.msg_fan_state = MsgTemplate(

--- a/insteon_mqtt/mqtt/FanLinc.py
+++ b/insteon_mqtt/mqtt/FanLinc.py
@@ -87,6 +87,19 @@ class FanLinc(Dimmer):
         self.msg_fan_speed.load_config(data, 'fan_speed_set_topic',
                                        'fan_speed_set_payload', qos)
 
+        # Add our unique topics to the discovery topic map
+        topics = {}
+        var_data = self.base_template_data()
+        topics['fan_state_topic'] = self.msg_fan_state.render_topic(var_data)
+        topics['fan_on_off_topic'] = self.msg_fan_on_off.render_topic(var_data)
+        topics['fan_speed_topic'] = self.msg_fan_speed_state.render_topic(
+            var_data
+        )
+        topics['fan_speed_set_topic'] = self.msg_fan_speed.render_topic(
+            var_data
+        )
+        self.rendered_topic_map.update(topics)
+
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
         """Subscribe to any MQTT topics the object needs.
@@ -165,20 +178,6 @@ class FanLinc(Dimmer):
             data["level_str"] = level.name.lower()
             data["reason"] = reason if reason is not None else ""
 
-        return data
-
-    #-----------------------------------------------------------------------
-    def discovery_template_data(self, **kwargs):
-        """This extends the template data variables defined in the base class
-
-        Adds fan special topics.
-        """
-        # Set up the variables that can be used in the templates.
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
-        data['fan_state_topic'] = self.msg_fan_state.render_topic(data)
-        data['fan_on_off_topic'] = self.msg_fan_on_off.render_topic(data)
-        data['fan_speed_topic'] = self.msg_fan_speed_state.render_topic(data)
-        data['fan_speed_set_topic'] = self.msg_fan_speed.render_topic(data)
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/FanLinc.py
+++ b/insteon_mqtt/mqtt/FanLinc.py
@@ -38,6 +38,9 @@ class FanLinc(Dimmer):
         # Initialize the dimmer.
         super().__init__(mqtt, device)
 
+        # This defines the default discovery_class for these devices
+        self.class_name = "fan_linc"
+
         # Output fan state change reporting template.
         self.msg_fan_state = MsgTemplate(
             topic='insteon/{{address}}/fan/state',
@@ -67,7 +70,7 @@ class FanLinc(Dimmer):
           qos (int):  The default quality of service level to use.
         """
         # Load the dimmer configuration from the dimmer area, not the fanlinc
-        # area.
+        # area.  This will also load discovery items.
         super().load_config(config, qos)
 
         # Now load the fan control configuration.
@@ -162,6 +165,20 @@ class FanLinc(Dimmer):
             data["level_str"] = level.name.lower()
             data["reason"] = reason if reason is not None else ""
 
+        return data
+
+    #-----------------------------------------------------------------------
+    def discovery_template_data(self, **kwargs):
+        """This extends the template data variables defined in the base class
+
+        Adds fan special topics.
+        """
+        # Set up the variables that can be used in the templates.
+        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
+        data['fan_state_topic'] = self.msg_fan_state.render_topic(data)
+        data['fan_on_off_topic'] = self.msg_fan_on_off.render_topic(data)
+        data['fan_speed_topic'] = self.msg_fan_speed_state.render_topic(data)
+        data['fan_speed_set_topic'] = self.msg_fan_speed.render_topic(data)
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/HiddenDoor.py
+++ b/insteon_mqtt/mqtt/HiddenDoor.py
@@ -39,6 +39,9 @@ class HiddenDoor(BatterySensor):
 
         device.signal_voltage.connect(self._insteon_voltage)
 
+        # This defines the default discovery_class for these devices
+        self.class_name = "hidden_door"
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -81,6 +84,19 @@ class HiddenDoor(BatterySensor):
             voltage = int(batt_volt)
             data["voltage"] = voltage
 
+        return data
+
+    #-----------------------------------------------------------------------
+    def discovery_template_data(self, **kwargs):
+        """This extends the template data variables defined in the base class
+
+        Adds in battery_voltage_topic topic.
+        """
+        # Set up the variables that can be used in the templates.
+        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
+        data['battery_voltage_topic'] = self.msg_battery_voltage.render_topic(
+            data
+        )
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/HiddenDoor.py
+++ b/insteon_mqtt/mqtt/HiddenDoor.py
@@ -61,6 +61,14 @@ class HiddenDoor(BatterySensor):
         self.msg_battery_voltage.load_config(data, 'battery_voltage_topic',
                                              'battery_voltage_payload', qos)
 
+        # Add our unique topics to the discovery topic map
+        topics = {}
+        bat_volt = self.msg_battery_voltage
+        topics['battery_voltage_topic'] = bat_volt.render_topic(
+            self.base_template_data()
+        )
+        self.rendered_topic_map.update(topics)
+
     #-----------------------------------------------------------------------
     def template_data_hidden_door(self, is_dawn=None, batt_volt=None,
                                   low_batt_volt=None, hb_interval=None):
@@ -84,19 +92,6 @@ class HiddenDoor(BatterySensor):
             voltage = int(batt_volt)
             data["voltage"] = voltage
 
-        return data
-
-    #-----------------------------------------------------------------------
-    def discovery_template_data(self, **kwargs):
-        """This extends the template data variables defined in the base class
-
-        Adds in battery_voltage_topic topic.
-        """
-        # Set up the variables that can be used in the templates.
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
-        data['battery_voltage_topic'] = self.msg_battery_voltage.render_topic(
-            data
-        )
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/HiddenDoor.py
+++ b/insteon_mqtt/mqtt/HiddenDoor.py
@@ -40,7 +40,7 @@ class HiddenDoor(BatterySensor):
         device.signal_voltage.connect(self._insteon_voltage)
 
         # This defines the default discovery_class for these devices
-        self.class_name = "hidden_door"
+        self.default_discovery_cls = "hidden_door"
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -109,10 +109,11 @@ class KeypadLinc(topic.SetTopic, topic.SceneTopic, topic.StateTopic,
                  including:
         """
         # Get the default variables
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
+        # pylint:disable=E1101
+        data = super().discovery_template_data(**kwargs)
         data['is_dimmable'] = False
         if isinstance(self.device, DimmerBase):
             data['is_dimmable'] = True
         return data
 
-        #-----------------------------------------------------------------------
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/KeypadLinc.py
+++ b/insteon_mqtt/mqtt/KeypadLinc.py
@@ -5,12 +5,13 @@
 #===========================================================================
 from .. import log
 from . import topic
+from ..device.base import DimmerBase
 
 LOG = log.get_logger()
 
 
 class KeypadLinc(topic.SetTopic, topic.SceneTopic, topic.StateTopic,
-                 topic.ManualTopic):
+                 topic.ManualTopic, topic.DiscoveryTopic):
     """MQTT interface to an Insteon KeypadLinc switch.
 
     This class connects to a device.KeypadLinc object and converts it's output
@@ -31,6 +32,12 @@ class KeypadLinc(topic.SetTopic, topic.SceneTopic, topic.StateTopic,
                          set_topic='insteon/{{address}}/set/{{button}}',
                          **kwargs)
 
+        # This defines the default discovery_class for these devices
+        self.default_discovery_cls = "keypad_linc"
+
+        # Set the groups for discovery topic generation
+        self.extra_topic_nums = range(1, 10)
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -40,6 +47,9 @@ class KeypadLinc(topic.SetTopic, topic.SceneTopic, topic.StateTopic,
                  config is stored in config['keypad_linc'].
           qos (int):  The default quality of service level to use.
         """
+        # The discovery topic needs the full config
+        self.load_discovery_data(config, qos)
+
         data = config.get("keypad_linc", None)
         if not data:
             return
@@ -86,3 +96,23 @@ class KeypadLinc(topic.SetTopic, topic.SceneTopic, topic.StateTopic,
         for group in range(1, 9):
             self.set_unsubscribe(link, group=group)
             self.scene_unsubscribe(link, group=group)
+
+    #-----------------------------------------------------------------------
+    def discovery_template_data(self, **kwargs):
+        """Create the Jinja templating data variables for discovery messages.
+
+        This extends the default dict with additional variables supported
+        by this device
+
+        Returns:
+          dict:  Returns a dict with the variables available for templating.
+                 including:
+        """
+        # Get the default variables
+        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
+        data['is_dimmable'] = False
+        if isinstance(self.device, DimmerBase):
+            data['is_dimmable'] = True
+        return data
+
+        #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/KeypadLincDimmer.py
+++ b/insteon_mqtt/mqtt/KeypadLincDimmer.py
@@ -54,6 +54,13 @@ class KeypadLincDimmer(KeypadLinc):
         self.msg_dimmer_level.load_config(data, 'dimmer_level_topic',
                                           'dimmer_level_payload', qos)
 
+        # Add our unique topics to the discovery topic map
+        topics = {}
+        topics['dimmer_level_topic'] = self.msg_dimmer_level.render_topic(
+            self.base_template_data()
+        )
+        self.rendered_topic_map.update(topics)
+
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos, start_group=1):
         """Subscribe to any MQTT topics the object needs.

--- a/insteon_mqtt/mqtt/Leak.py
+++ b/insteon_mqtt/mqtt/Leak.py
@@ -27,6 +27,9 @@ class Leak(BatterySensor):
                          state_topic='insteon/{{address}}/wet',
                          state_payload='{{is_wet_str.lower()}}')
 
+        # This defines the default discovery_class for these devices
+        self.class_name = "leak"
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -95,3 +98,17 @@ class Leak(BatterySensor):
         data["state"] = "wet" if is_wet else "dry"
 
         return data
+
+    #-----------------------------------------------------------------------
+    def discovery_template_data(self, **kwargs):
+        """This extends the template data variables defined in the base class
+
+        The wet_dry_topic is just the state topic
+        """
+        # Set up the variables that can be used in the templates.
+        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
+        if 'state_topic' in data:
+            data['wet_dry_topic'] = data.pop('state_topic')
+        return data
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Leak.py
+++ b/insteon_mqtt/mqtt/Leak.py
@@ -56,6 +56,12 @@ class Leak(BatterySensor):
             self.msg_heartbeat.load_config(data, 'heartbeat_topic',
                                            'heartbeat_payload', qos)
 
+        # Add our unique topics to the discovery topic map
+        # The state_topic uses a different name on the leak sensor
+        if 'state_topic' in self.rendered_topic_map:
+            rendered_topic = self.rendered_topic_map.pop('state_topic')
+            self.rendered_topic_map['wet_dry_topic'] = rendered_topic
+
     #-----------------------------------------------------------------------
     def state_template_data(self, **kwargs):
         """Create the Jinja templating data variables for on/off messages.
@@ -97,18 +103,6 @@ class Leak(BatterySensor):
         data["is_dry_str"] = "off" if is_wet else "on"
         data["state"] = "wet" if is_wet else "dry"
 
-        return data
-
-    #-----------------------------------------------------------------------
-    def discovery_template_data(self, **kwargs):
-        """This extends the template data variables defined in the base class
-
-        The wet_dry_topic is just the state topic
-        """
-        # Set up the variables that can be used in the templates.
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
-        if 'state_topic' in data:
-            data['wet_dry_topic'] = data.pop('state_topic')
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Leak.py
+++ b/insteon_mqtt/mqtt/Leak.py
@@ -28,7 +28,7 @@ class Leak(BatterySensor):
                          state_payload='{{is_wet_str.lower()}}')
 
         # This defines the default discovery_class for these devices
-        self.class_name = "leak"
+        self.default_discovery_cls = "leak"
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/Modem.py
+++ b/insteon_mqtt/mqtt/Modem.py
@@ -88,7 +88,7 @@ class Modem(topic.SceneTopic, topic.DiscoveryTopic):
         Args:
           kwargs (dict): The arguments to pass to discovery_template_data
         """
-        LOG.info("MQTT received discovery %s on: %s", self.device.label, kwargs)
+        LOG.info("MQTT discovery %s on: %s", self.device.label, kwargs)
 
         data = self.discovery_template_data(**kwargs)
 

--- a/insteon_mqtt/mqtt/Modem.py
+++ b/insteon_mqtt/mqtt/Modem.py
@@ -8,7 +8,7 @@ from . import topic
 LOG = log.get_logger()
 
 
-class Modem(topic.SceneTopic):
+class Modem(topic.SceneTopic, topic.DiscoveryTopic):
     """MQTT interface to an Insteon power line modem (PLM).
 
     This class connects to an insteon_mqtt.Modem object and allows input MQTT
@@ -26,6 +26,12 @@ class Modem(topic.SceneTopic):
                          scene_payload='{ "cmd" : "{{json.cmd.lower()}}",'
                                        '"group" : {{json.group}} }')
 
+        # This defines the default discovery_class for these devices
+        self.default_discovery_cls = "modem"
+
+        # Set the groups for discovery topic generation
+        # self.extra_topic_nums = range(2, 255)
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -35,6 +41,9 @@ class Modem(topic.SceneTopic):
                  config is stored in config['modem'].
           qos (int):  The default quality of service level to use.
         """
+        # The discovery topic needs the full config
+        self.load_discovery_data(config, qos)
+
         data = config.get("modem", None)
         if not data:
             return
@@ -62,5 +71,40 @@ class Modem(topic.SceneTopic):
           link (network.Mqtt):  The MQTT network client to use.
         """
         self.scene_unsubscribe(link)
+
+    #-----------------------------------------------------------------------
+    def publish_discovery(self, **kwargs):
+        """This Hijacks the method from DiscoveryTopic
+
+        This is necessary because the Modem is a singular device that requires
+        a little different handling to publish the available scenes.
+
+        This is triggered from the MQTT handler.
+
+        No kwargs are currently sent from the MQTT handler, it is a little
+        hard to imagine how any such arguments could be provided but left here
+        for potential use.
+
+        Args:
+          kwargs (dict): The arguments to pass to discovery_template_data
+        """
+        LOG.info("MQTT received discovery %s on: %s", self.device.label, kwargs)
+
+        data = self.discovery_template_data(**kwargs)
+
+        for scene in self.device.db.groups:
+            if scene < 2:
+                # Don't publish scenes 0/1, they are not real scenes
+                continue
+            # Try and load the scene name if it exists
+            scene_map = self.device.scene_map
+            try:
+                scene_index = list(scene_map.values()).index(scene)
+                data['scene_name'] = list(scene_map.keys())[scene_index]
+            except ValueError:
+                # scene does not have a name
+                data['scene_name'] = ""
+            data['scene'] = scene
+            self.entries[0].publish(self.mqtt, data, retain=False)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Motion.py
+++ b/insteon_mqtt/mqtt/Motion.py
@@ -37,7 +37,7 @@ class Motion(BatterySensor):
         device.signal_dawn.connect(self._insteon_dawn)
 
         # This defines the default discovery_class for these devices
-        self.class_name = "motion"
+        self.default_discovery_cls = "motion"
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/Motion.py
+++ b/insteon_mqtt/mqtt/Motion.py
@@ -67,6 +67,13 @@ class Motion(BatterySensor):
             self.msg_battery.load_config(data, 'low_battery_topic',
                                          'low_battery_payload', qos)
 
+        # Add our unique topics to the discovery topic map
+        topics = {}
+        topics['dawn_dusk_topic'] = self.msg_dawn.render_topic(
+            self.base_template_data()
+        )
+        self.rendered_topic_map.update(topics)
+
     #-----------------------------------------------------------------------
     def template_data_motion(self, is_dawn=None):
         """Create the Jinja templating data variables.
@@ -88,17 +95,6 @@ class Motion(BatterySensor):
             data["is_dusk_str"] = "off" if is_dawn else "on"
             data["state"] = "dawn" if is_dawn else "dusk"
 
-        return data
-
-    #-----------------------------------------------------------------------
-    def discovery_template_data(self, **kwargs):
-        """This extends the template data variables defined in the base class
-
-        Adds in dawn_dusk_topic topic.
-        """
-        # Set up the variables that can be used in the templates.
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
-        data['dawn_dusk_topic'] = self.msg_dawn.render_topic(data)
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Motion.py
+++ b/insteon_mqtt/mqtt/Motion.py
@@ -36,6 +36,9 @@ class Motion(BatterySensor):
 
         device.signal_dawn.connect(self._insteon_dawn)
 
+        # This defines the default discovery_class for these devices
+        self.class_name = "motion"
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -85,6 +88,17 @@ class Motion(BatterySensor):
             data["is_dusk_str"] = "off" if is_dawn else "on"
             data["state"] = "dawn" if is_dawn else "dusk"
 
+        return data
+
+    #-----------------------------------------------------------------------
+    def discovery_template_data(self, **kwargs):
+        """This extends the template data variables defined in the base class
+
+        Adds in dawn_dusk_topic topic.
+        """
+        # Set up the variables that can be used in the templates.
+        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
+        data['dawn_dusk_topic'] = self.msg_dawn.render_topic(data)
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Outlet.py
+++ b/insteon_mqtt/mqtt/Outlet.py
@@ -9,7 +9,7 @@ from . import topic
 LOG = log.get_logger()
 
 
-class Outlet(topic.SetTopic, topic.StateTopic):
+class Outlet(topic.SetTopic, topic.StateTopic, topic.DiscoveryTopic):
     """MQTT interface to an Insteon on/off outlet.
 
     This class connects to a device.Outlet object and converts it's
@@ -31,6 +31,12 @@ class Outlet(topic.SetTopic, topic.StateTopic):
                          state_topic='insteon/{{address}}/state/{{button}}',
                          set_topic='insteon/{{address}}/set/{{button}}')
 
+        # This defines the default discovery_class for these devices
+        self.default_discovery_cls = "outlet"
+
+        # Set the groups for discovery topic generation
+        self.extra_topic_nums = (1, 2)
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -40,6 +46,9 @@ class Outlet(topic.SetTopic, topic.StateTopic):
                  config is stored in config['outlet'].
           qos (int):  The default quality of service level to use.
         """
+        # The discovery topic needs the full config
+        self.load_discovery_data(config, qos)
+
         data = config.get("outlet", None)
         if not data:
             return

--- a/insteon_mqtt/mqtt/Remote.py
+++ b/insteon_mqtt/mqtt/Remote.py
@@ -72,15 +72,3 @@ class Remote(BatterySensor, topic.ManualTopic):
                                          'low_battery_payload', qos)
 
     #-----------------------------------------------------------------------
-    def discovery_template_data(self, **kwargs):
-        """This extends the template data variables defined in the base class
-
-        Adds the state_topics
-        """
-        # Set up the variables that can be used in the templates.
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
-        if 'state_topic' in data:
-            data['wet_dry_topic'] = data.pop('state_topic')
-        return data
-
-    #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Remote.py
+++ b/insteon_mqtt/mqtt/Remote.py
@@ -41,10 +41,10 @@ class Remote(BatterySensor, topic.ManualTopic):
         self.state_retain = False
 
         # This defines the default discovery_class for these devices
-        self.class_name = "remote"
+        self.default_discovery_cls = "remote"
 
         # Set the groups for discovery topic generation
-        self.group_topic_nums = range(1, 9)
+        self.group_state_list = range(1, 9)
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/Remote.py
+++ b/insteon_mqtt/mqtt/Remote.py
@@ -40,6 +40,12 @@ class Remote(BatterySensor, topic.ManualTopic):
         # retained message? - KRKeegan 2021-01-10
         self.state_retain = False
 
+        # This defines the default discovery_class for these devices
+        self.class_name = "remote"
+
+        # Set the groups for discovery topic generation
+        self.group_topic_nums = range(1, 9)
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -64,5 +70,17 @@ class Remote(BatterySensor, topic.ManualTopic):
         if "low_battery_topic" in data:
             self.msg_battery.load_config(data, 'low_battery_topic',
                                          'low_battery_payload', qos)
+
+    #-----------------------------------------------------------------------
+    def discovery_template_data(self, **kwargs):
+        """This extends the template data variables defined in the base class
+
+        Adds the state_topics
+        """
+        # Set up the variables that can be used in the templates.
+        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
+        if 'state_topic' in data:
+            data['wet_dry_topic'] = data.pop('state_topic')
+        return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Remote.py
+++ b/insteon_mqtt/mqtt/Remote.py
@@ -44,7 +44,7 @@ class Remote(BatterySensor, topic.ManualTopic):
         self.default_discovery_cls = "remote"
 
         # Set the groups for discovery topic generation
-        self.group_state_list = range(1, 9)
+        self.extra_topic_nums = range(1, 9)
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/SmokeBridge.py
+++ b/insteon_mqtt/mqtt/SmokeBridge.py
@@ -72,6 +72,15 @@ class SmokeBridge(topic.DiscoveryTopic):
                                      qos)
         self.msg_error.load_config(data, 'error_topic', 'error_payload', qos)
 
+        # Add our unique topics to the discovery topic map
+        topics = {}
+        var_data = self.base_template_data()
+        topics['smoke_topic'] = self.msg_smoke.render_topic(var_data)
+        topics['co_topic'] = self.msg_co.render_topic(var_data)
+        topics['battery_topic'] = self.msg_battery.render_topic(var_data)
+        topics['error_topic'] = self.msg_error.render_topic(var_data)
+        self.rendered_topic_map.update(topics)
+
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
         """Subscribe to any MQTT topics the object needs.
@@ -117,20 +126,6 @@ class SmokeBridge(topic.DiscoveryTopic):
             "type" : type.name.lower(),
             }
 
-        return data
-
-    #-----------------------------------------------------------------------
-    def discovery_template_data(self, **kwargs):
-        """This extends the template data variables defined in the base class
-
-        Adds special topics for the smoke bridge.
-        """
-        # Set up the variables that can be used in the templates.
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
-        data['smoke_topic'] = self.msg_smoke.render_topic(data)
-        data['co_topic'] = self.msg_co.render_topic(data)
-        data['battery_topic'] = self.msg_battery.render_topic(data)
-        data['error_topic'] = self.msg_error.render_topic(data)
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/SmokeBridge.py
+++ b/insteon_mqtt/mqtt/SmokeBridge.py
@@ -47,7 +47,7 @@ class SmokeBridge(topic.DiscoveryTopic):
         device.signal_on_off.connect(self._insteon_change)
 
         # This defines the default discovery_class for these devices
-        self.class_name = "smoke_bridge"
+        self.default_discovery_cls = "smoke_bridge"
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/Switch.py
+++ b/insteon_mqtt/mqtt/Switch.py
@@ -10,7 +10,7 @@ LOG = log.get_logger()
 
 
 class Switch(topic.SetTopic, topic.StateTopic, topic.SceneTopic,
-             topic.ManualTopic):
+             topic.ManualTopic, topic.DiscoveryTopic):
     """MQTT interface to an Insteon on/off switch.
 
     This class connects to a device.Switch object and converts it's
@@ -30,6 +30,9 @@ class Switch(topic.SetTopic, topic.StateTopic, topic.SceneTopic,
         # Setup the Topics
         super().__init__(mqtt, device)
 
+        # This defines the default discovery_class for these devices
+        self.class_name = "switch"
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -39,6 +42,9 @@ class Switch(topic.SetTopic, topic.StateTopic, topic.SceneTopic,
                  config is stored in config['switch'].
           qos (int):  The default quality of service level to use.
         """
+        # The discovery topic needs the full config
+        self.load_discovery_data(config, qos)
+
         data = config.get("switch", None)
         if not data:
             return

--- a/insteon_mqtt/mqtt/Switch.py
+++ b/insteon_mqtt/mqtt/Switch.py
@@ -31,7 +31,7 @@ class Switch(topic.SetTopic, topic.StateTopic, topic.SceneTopic,
         super().__init__(mqtt, device)
 
         # This defines the default discovery_class for these devices
-        self.class_name = "switch"
+        self.default_discovery_cls = "switch"
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/Thermostat.py
+++ b/insteon_mqtt/mqtt/Thermostat.py
@@ -131,6 +131,32 @@ class Thermostat(topic.DiscoveryTopic):
         self.cool_sp_command.load_config(data, 'cool_sp_command_topic',
                                          'cool_sp_command_payload', qos)
 
+        # Add our unique topics to the discovery topic map
+        topics = {}
+        var_data = self.base_template_data()
+        topics['ambient_temp_topic'] = self.ambient_temp.render_topic(var_data)
+        topics['fan_state_topic'] = self.fan_state.render_topic(var_data)
+        topics['mode_state_topic'] = self.mode_state.render_topic(var_data)
+        topics['cool_sp_state_topic'] = self.cool_sp_state.render_topic(
+            var_data
+        )
+        topics['heat_sp_state_topic'] = self.heat_sp_state.render_topic(
+            var_data
+        )
+        topics['humid_state_topic'] = self.humid_state.render_topic(var_data)
+        topics['status_state_topic'] = self.status_state.render_topic(var_data)
+        topics['hold_state_topic'] = self.hold_state.render_topic(var_data)
+        topics['energy_state_topic'] = self.energy_state.render_topic(var_data)
+        topics['mode_command_topic'] = self.mode_command.render_topic(var_data)
+        topics['fan_command_topic'] = self.fan_command.render_topic(var_data)
+        topics['heat_sp_command_topic'] = self.heat_sp_command.render_topic(
+            var_data
+        )
+        topics['cool_sp_command_topic'] = self.cool_sp_command.render_topic(
+            var_data
+        )
+        self.rendered_topic_map.update(topics)
+
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
         """Subscribe to any MQTT topics the object needs.
@@ -186,29 +212,6 @@ class Thermostat(topic.DiscoveryTopic):
                      else self.device.addr.hex
             }
 
-        return data
-
-    #-----------------------------------------------------------------------
-    def discovery_template_data(self, **kwargs):
-        """This extends the template data variables defined in the base class
-
-        Adds the many thermostat topics.
-        """
-        # Set up the variables that can be used in the templates.
-        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
-        data['ambient_temp_topic'] = self.ambient_temp.render_topic(data)
-        data['fan_state_topic'] = self.fan_state.render_topic(data)
-        data['mode_state_topic'] = self.mode_state.render_topic(data)
-        data['cool_sp_state_topic'] = self.cool_sp_state.render_topic(data)
-        data['heat_sp_state_topic'] = self.heat_sp_state.render_topic(data)
-        data['humid_state_topic'] = self.humid_state.render_topic(data)
-        data['status_state_topic'] = self.status_state.render_topic(data)
-        data['hold_state_topic'] = self.hold_state.render_topic(data)
-        data['energy_state_topic'] = self.energy_state.render_topic(data)
-        data['mode_command_topic'] = self.mode_command.render_topic(data)
-        data['fan_command_topic'] = self.fan_command.render_topic(data)
-        data['heat_sp_command_topic'] = self.heat_sp_command.render_topic(data)
-        data['cool_sp_command_topic'] = self.cool_sp_command.render_topic(data)
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Thermostat.py
+++ b/insteon_mqtt/mqtt/Thermostat.py
@@ -85,7 +85,7 @@ class Thermostat(topic.DiscoveryTopic):
         device.signal_energy_change.connect(self._insteon_energy_change)
 
         # This defines the default discovery_class for these devices
-        self.class_name = "thermostat"
+        self.default_discovery_cls = "thermostat"
 
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):

--- a/insteon_mqtt/mqtt/Thermostat.py
+++ b/insteon_mqtt/mqtt/Thermostat.py
@@ -4,12 +4,13 @@
 #
 #===========================================================================
 from .. import log
+from . import topic
 from .MsgTemplate import MsgTemplate
 
 LOG = log.get_logger()
 
 
-class Thermostat:
+class Thermostat(topic.DiscoveryTopic):
     """MQTT interface to an Insteon thermostat switch.
 
     This class connects to a device.Thermostat and converts it's output
@@ -23,8 +24,8 @@ class Thermostat:
           mqtt (mqtt.Mqtt):  The MQTT main interface.
           device (device.Thermostat):  The Insteon object to link to.
         """
-        self.mqtt = mqtt
-        self.device = device
+        # Setup the BaseTopic
+        super().__init__(mqtt, device)
 
         # Set up the default templates for the MQTT messages and payloads.
         # Templates for states
@@ -83,6 +84,9 @@ class Thermostat:
         device.signal_hold_change.connect(self._insteon_hold_change)
         device.signal_energy_change.connect(self._insteon_energy_change)
 
+        # This defines the default discovery_class for these devices
+        self.class_name = "thermostat"
+
     #-----------------------------------------------------------------------
     def load_config(self, config, qos=None):
         """Load values from a configuration data object.
@@ -92,6 +96,9 @@ class Thermostat:
                  config is stored in config['thermostat'].
           qos (int):  The default quality of service level to use.
         """
+        # The discovery topic needs the full config
+        self.load_discovery_data(config, qos)
+
         data = config.get("thermostat", None)
         if not data:
             return
@@ -135,17 +142,17 @@ class Thermostat:
           link (network.Mqtt):  The MQTT network client to use.
           qos (int):  The quality of service to use.
         """
-        topic = self.mode_command.render_topic(self.template_data())
-        link.subscribe(topic, qos, self._input_mode)
+        rendered_topic = self.mode_command.render_topic(self.template_data())
+        link.subscribe(rendered_topic, qos, self._input_mode)
 
-        topic = self.fan_command.render_topic(self.template_data())
-        link.subscribe(topic, qos, self._input_fan)
+        rendered_topic = self.fan_command.render_topic(self.template_data())
+        link.subscribe(rendered_topic, qos, self._input_fan)
 
-        topic = self.heat_sp_command.render_topic(self.template_data())
-        link.subscribe(topic, qos, self._input_heat_setpoint)
+        rendered_topic = self.heat_sp_command.render_topic(self.template_data())
+        link.subscribe(rendered_topic, qos, self._input_heat_setpoint)
 
-        topic = self.cool_sp_command.render_topic(self.template_data())
-        link.subscribe(topic, qos, self._input_cool_setpoint)
+        rendered_topic = self.cool_sp_command.render_topic(self.template_data())
+        link.subscribe(rendered_topic, qos, self._input_cool_setpoint)
 
     #-----------------------------------------------------------------------
     def unsubscribe(self, link):
@@ -154,17 +161,17 @@ class Thermostat:
         Args:
           link (network.Mqtt):  The MQTT network client to use.
         """
-        topic = self.mode_command.render_topic(self.template_data())
-        link.unsubscribe(topic)
+        rendered_topic = self.mode_command.render_topic(self.template_data())
+        link.unsubscribe(rendered_topic)
 
-        topic = self.fan_command.render_topic(self.template_data())
-        link.unsubscribe(topic)
+        rendered_topic = self.fan_command.render_topic(self.template_data())
+        link.unsubscribe(rendered_topic)
 
-        topic = self.heat_sp_command.render_topic(self.template_data())
-        link.unsubscribe(topic)
+        rendered_topic = self.heat_sp_command.render_topic(self.template_data())
+        link.unsubscribe(rendered_topic)
 
-        topic = self.cool_sp_command.render_topic(self.template_data())
-        link.unsubscribe(topic)
+        rendered_topic = self.cool_sp_command.render_topic(self.template_data())
+        link.unsubscribe(rendered_topic)
 
     #-----------------------------------------------------------------------
     def template_data(self):
@@ -179,6 +186,29 @@ class Thermostat:
                      else self.device.addr.hex
             }
 
+        return data
+
+    #-----------------------------------------------------------------------
+    def discovery_template_data(self, **kwargs):
+        """This extends the template data variables defined in the base class
+
+        Adds the many thermostat topics.
+        """
+        # Set up the variables that can be used in the templates.
+        data = super().discovery_template_data(**kwargs)  # pylint:disable=E1101
+        data['ambient_temp_topic'] = self.ambient_temp.render_topic(data)
+        data['fan_state_topic'] = self.fan_state.render_topic(data)
+        data['mode_state_topic'] = self.mode_state.render_topic(data)
+        data['cool_sp_state_topic'] = self.cool_sp_state.render_topic(data)
+        data['heat_sp_state_topic'] = self.heat_sp_state.render_topic(data)
+        data['humid_state_topic'] = self.humid_state.render_topic(data)
+        data['status_state_topic'] = self.status_state.render_topic(data)
+        data['hold_state_topic'] = self.hold_state.render_topic(data)
+        data['energy_state_topic'] = self.energy_state.render_topic(data)
+        data['mode_command_topic'] = self.mode_command.render_topic(data)
+        data['fan_command_topic'] = self.fan_command.render_topic(data)
+        data['heat_sp_command_topic'] = self.heat_sp_command.render_topic(data)
+        data['cool_sp_command_topic'] = self.cool_sp_command.render_topic(data)
         return data
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Thermostat.py
+++ b/insteon_mqtt/mqtt/Thermostat.py
@@ -168,16 +168,17 @@ class Thermostat(topic.DiscoveryTopic):
           link (network.Mqtt):  The MQTT network client to use.
           qos (int):  The quality of service to use.
         """
-        rendered_topic = self.mode_command.render_topic(self.template_data())
+        data = self.template_data()
+        rendered_topic = self.mode_command.render_topic(data)
         link.subscribe(rendered_topic, qos, self._input_mode)
 
-        rendered_topic = self.fan_command.render_topic(self.template_data())
+        rendered_topic = self.fan_command.render_topic(data)
         link.subscribe(rendered_topic, qos, self._input_fan)
 
-        rendered_topic = self.heat_sp_command.render_topic(self.template_data())
+        rendered_topic = self.heat_sp_command.render_topic(data)
         link.subscribe(rendered_topic, qos, self._input_heat_setpoint)
 
-        rendered_topic = self.cool_sp_command.render_topic(self.template_data())
+        rendered_topic = self.cool_sp_command.render_topic(data)
         link.subscribe(rendered_topic, qos, self._input_cool_setpoint)
 
     #-----------------------------------------------------------------------
@@ -187,16 +188,17 @@ class Thermostat(topic.DiscoveryTopic):
         Args:
           link (network.Mqtt):  The MQTT network client to use.
         """
-        rendered_topic = self.mode_command.render_topic(self.template_data())
+        data = self.template_data()
+        rendered_topic = self.mode_command.render_topic(data)
         link.unsubscribe(rendered_topic)
 
-        rendered_topic = self.fan_command.render_topic(self.template_data())
+        rendered_topic = self.fan_command.render_topic(data)
         link.unsubscribe(rendered_topic)
 
-        rendered_topic = self.heat_sp_command.render_topic(self.template_data())
+        rendered_topic = self.heat_sp_command.render_topic(data)
         link.unsubscribe(rendered_topic)
 
-        rendered_topic = self.cool_sp_command.render_topic(self.template_data())
+        rendered_topic = self.cool_sp_command.render_topic(data)
         link.unsubscribe(rendered_topic)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/topic/BaseTopic.py
+++ b/insteon_mqtt/mqtt/topic/BaseTopic.py
@@ -20,15 +20,20 @@ class BaseTopic:
         """
         self.mqtt = mqtt
         self.device = device
-        self.class_name = None  # This should be amended by each class
+
+        # This defines the default class name that is used when searching for
+        # discovery templates.
+        self.default_discovery_cls = None
+
         # Any topics added here are available in discovery templates using the
         # key as the variable name.  The key should be the yaml key for the
         # topic
-        self.topics = {}
+        self.rendered_topic_map = {}
 
-        # Set the list of state and command topics to generate for the
-        # discovery platform
-        self.group_topic_nums = []
+        # This should be a list of group numbers for which state and
+        # command topics will be generated such as state_topic_1, if empty
+        # only the default state topics and command topics will be generated
+        self.group_state_list = []
 
     #-----------------------------------------------------------------------
     def base_template_data(self, **kwargs):

--- a/insteon_mqtt/mqtt/topic/BaseTopic.py
+++ b/insteon_mqtt/mqtt/topic/BaseTopic.py
@@ -30,10 +30,10 @@ class BaseTopic:
         # topic
         self.rendered_topic_map = {}
 
-        # This should be a list of group numbers for which state and
-        # command topics will be generated such as state_topic_1, if empty
+        # This should be a list of group numbers for which state, set, and
+        # scene topics will be generated such as state_topic_1, if empty
         # only the default state topics and command topics will be generated
-        self.group_state_list = []
+        self.extra_topic_nums = []
 
     #-----------------------------------------------------------------------
     def base_template_data(self, **kwargs):

--- a/insteon_mqtt/mqtt/topic/BaseTopic.py
+++ b/insteon_mqtt/mqtt/topic/BaseTopic.py
@@ -26,6 +26,10 @@ class BaseTopic:
         # topic
         self.topics = {}
 
+        # Set the list of state and command topics to generate for the
+        # discovery platform
+        self.group_topic_nums = []
+
     #-----------------------------------------------------------------------
     def base_template_data(self, **kwargs):
         """Create the Jinja templating data variables for use in topics.

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -78,6 +78,10 @@ class DiscoveryTopic(BaseTopic):
             # Allowing topic to be settable in yaml, but I don't think users
             # should worry about this, there is no utility in changing it
             unique_id = self._get_unique_id(payload)
+            if unique_id is None:
+                LOG.error("%s - Error getting unique_id, skipping entry",
+                          self.device.label)
+                continue
             default_topic = "%s/%s/%s/%s/config" % (self.mqtt.discovery_topic_base,
                                                     component,
                                                     self.device.addr.hex,

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -56,7 +56,8 @@ class DiscoveryTopic(BaseTopic):
                       self.device.label, disc_class)
             return
 
-        # Loop all of the discovery entities and append them to self.rendered_topic_map
+        # Loop all of the discovery entities and append them to
+        # self.rendered_topic_map
         entities = class_config.get('discovery_entities', None)
         if entities is None or not isinstance(entities, list):
             LOG.error("%s - No discovery_entities defined, or not a list %s",
@@ -82,7 +83,8 @@ class DiscoveryTopic(BaseTopic):
                 LOG.error("%s - Error getting unique_id, skipping entry",
                           self.device.label)
                 continue
-            default_topic = "%s/%s/%s/%s/config" % (self.mqtt.discovery_topic_base,
+            topic_base = self.mqtt.discovery_topic_base
+            default_topic = "%s/%s/%s/%s/config" % (topic_base,
                                                     component,
                                                     self.device.addr.hex,
                                                     unique_id)
@@ -184,7 +186,8 @@ class DiscoveryTopic(BaseTopic):
         Args:
           kwargs (dict): The arguments to pass to discovery_template_data
         """
-        LOG.info("MQTT received discovery %s on: %s", self.device.label, kwargs)
+        LOG.info("MQTT received discovery %s on: %s",
+                 self.device.label, kwargs)
 
         data = self.discovery_template_data(**kwargs)
 

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -101,6 +101,11 @@ class DiscoveryTopic(BaseTopic):
         kwargs are pass from the publish_discovery method and are not used
         in this class.
 
+        This is run in load_discovery_data() to get the unique_id which is
+        before the topics are created, so the topic variables cannot be used as
+        part of the unique_id.  This is fine, but be prepared to gracefully
+        handle the absence of topics in any extension of this method.
+
         Returns:
           dict:  Returns a dict with the variables available for templating.
                  including:

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -49,14 +49,14 @@ class DiscoveryTopic(BaseTopic):
         """
         # Get the device specific discovery class
         disc_class = self.device.config_extra.get('discovery_class',
-                                                  self.class_name)
+                                                  self.default_discovery_cls)
         class_config = config.get(disc_class, None)
         if class_config is None:
             LOG.error("%s - Unable to find discovery class %s",
                       self.device.label, disc_class)
             return
 
-        # Loop all of the discovery entities and append them to self.topics
+        # Loop all of the discovery entities and append them to self.rendered_topic_map
         entities = class_config.get('discovery_entities', None)
         if entities is None or not isinstance(entities, list):
             LOG.error("%s - No discovery_entities defined, or not a list %s",
@@ -130,7 +130,7 @@ class DiscoveryTopic(BaseTopic):
         data = self.base_template_data(**kwargs)
 
         # Insert Topics from topic classes
-        data.update(self.topics)
+        data.update(self.rendered_topic_map)
 
         data['name_user_case'] = self.device.addr.hex
         if self.device.name_user_case:

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -137,7 +137,9 @@ class DiscoveryTopic(BaseTopic):
             data['name_user_case'] = self.device.name_user_case
 
         engine_map = {0: 'i1', 1: 'i2', 2: 'i2cs'}
-        data['engine'] = engine_map.get(self.device.db.engine, 'Unknown')
+        data['engine'] = 'Unknown'
+        if hasattr(self.device.db, 'engine'):
+            data['engine'] = engine_map.get(self.device.db.engine, 'Unknown')
         data['model_number'] = 'Unknown'
         data['model_description'] = 'Unknown'
         data['dev_cat'] = 0
@@ -153,7 +155,9 @@ class DiscoveryTopic(BaseTopic):
         data['firmware'] = 0
         if self.device.db.firmware is not None:
             data['firmware'] = self.device.db.firmware
-        data['modem_addr'] = self.device.modem.addr.hex
+        data['modem_addr'] = data['address']
+        if hasattr(self.device, 'modem'):
+            data['modem_addr'] = self.device.modem.addr.hex
 
         # Finally, render the device_info_template
         device_info_template = jinja2.Template(self.mqtt.device_info_template)
@@ -169,7 +173,7 @@ class DiscoveryTopic(BaseTopic):
 
     #-----------------------------------------------------------------------
     def publish_discovery(self, **kwargs):
-        """Device on/off callback.
+        """Publish the Discovery Message
 
         This is triggered from the MQTT handler.
 

--- a/insteon_mqtt/mqtt/topic/ManualTopic.py
+++ b/insteon_mqtt/mqtt/topic/ManualTopic.py
@@ -76,7 +76,7 @@ class ManualTopic(BaseTopic):
         self.msg_manual_state.load_config(data, topic, payload, qos)
 
         # Add ourselves to the list of topics
-        self.topics['manual_state_topic'] = self.msg_manual_state.render_topic(
+        self.rendered_topic_map['manual_state_topic'] = self.msg_manual_state.render_topic(
             self.base_template_data()
         )
 

--- a/insteon_mqtt/mqtt/topic/ManualTopic.py
+++ b/insteon_mqtt/mqtt/topic/ManualTopic.py
@@ -76,7 +76,7 @@ class ManualTopic(BaseTopic):
         self.msg_manual_state.load_config(data, topic, payload, qos)
 
         # Add ourselves to the list of topics
-        self.rendered_topic_map['manual_state_topic'] = self.msg_manual_state.render_topic(
+        self.rendered_topic_map[topic] = self.msg_manual_state.render_topic(
             self.base_template_data()
         )
 

--- a/insteon_mqtt/mqtt/topic/SceneTopic.py
+++ b/insteon_mqtt/mqtt/topic/SceneTopic.py
@@ -60,7 +60,7 @@ class SceneTopic(BaseTopic):
         self.msg_scene.load_config(data, topic, payload, qos)
 
         # Add ourselves to the list of topics
-        self.topics['on_off_topic'] = self.msg_scene.render_topic(
+        self.rendered_topic_map['on_off_topic'] = self.msg_scene.render_topic(
             self.base_template_data()
         )
 

--- a/insteon_mqtt/mqtt/topic/SceneTopic.py
+++ b/insteon_mqtt/mqtt/topic/SceneTopic.py
@@ -60,9 +60,21 @@ class SceneTopic(BaseTopic):
         self.msg_scene.load_config(data, topic, payload, qos)
 
         # Add ourselves to the list of topics
-        self.rendered_topic_map['on_off_topic'] = self.msg_scene.render_topic(
-            self.base_template_data()
-        )
+        if len(self.extra_topic_nums) > 0:
+            # This device has multiple scene topics for multiple buttons
+            data = self.base_template_data()
+            topics = {}
+            for btn in self.extra_topic_nums:
+                data['button'] = btn
+                topics[topic + "_" + str(btn)] = self.msg_scene.render_topic(
+                    data
+                )
+            self.rendered_topic_map.update(topics)
+        else:
+            # Add ourselves to the list of topics
+            self.rendered_topic_map[topic] = self.msg_scene.render_topic(
+                self.base_template_data()
+            )
 
     #-----------------------------------------------------------------------
     def scene_subscribe(self, link, qos, group=None):

--- a/insteon_mqtt/mqtt/topic/SetTopic.py
+++ b/insteon_mqtt/mqtt/topic/SetTopic.py
@@ -57,7 +57,7 @@ class SetTopic(BaseTopic):
         self.msg_set.load_config(data, topic, payload, qos)
 
         # Add ourselves to the list of topics
-        self.topics['on_off_topic'] = self.msg_set.render_topic(
+        self.rendered_topic_map['on_off_topic'] = self.msg_set.render_topic(
             self.base_template_data()
         )
 

--- a/insteon_mqtt/mqtt/topic/SetTopic.py
+++ b/insteon_mqtt/mqtt/topic/SetTopic.py
@@ -57,9 +57,21 @@ class SetTopic(BaseTopic):
         self.msg_set.load_config(data, topic, payload, qos)
 
         # Add ourselves to the list of topics
-        self.rendered_topic_map['on_off_topic'] = self.msg_set.render_topic(
-            self.base_template_data()
-        )
+        if len(self.extra_topic_nums) > 0:
+            # This device has multiple set topics for multiple buttons
+            data = self.base_template_data()
+            topics = {}
+            for btn in self.extra_topic_nums:
+                data['button'] = btn
+                topics[topic + "_" + str(btn)] = self.msg_set.render_topic(
+                    data
+                )
+            self.rendered_topic_map.update(topics)
+        else:
+            # Add ourselves to the list of topics
+            self.rendered_topic_map[topic] = self.msg_set.render_topic(
+                self.base_template_data()
+            )
 
     #-----------------------------------------------------------------------
     def set_subscribe(self, link, qos, group=None):

--- a/insteon_mqtt/mqtt/topic/StateTopic.py
+++ b/insteon_mqtt/mqtt/topic/StateTopic.py
@@ -92,21 +92,23 @@ class StateTopic(BaseTopic):
                 payload_1 = 'dimmer_state_payload'
             self.msg_state_1.load_config(data, topic_1, payload_1, qos)
             # Add ourselves to the list of topics
-            self.rendered_topic_map['dimmer_state_topic'] = self.msg_state_1.render_topic(
+            self.rendered_topic_map[topic_1] = self.msg_state_1.render_topic(
                 self.base_template_data()
             )
 
-        if len(self.group_state_list) > 0:
+        if len(self.extra_topic_nums) > 0:
             # This device has multiple state topics for multiple buttons
             data = self.base_template_data()
-            for btn in self.group_state_list:
+            topics = {}
+            for btn in self.extra_topic_nums:
                 data['button'] = btn
-                self.rendered_topic_map['state_topic_' + str(btn)] = self.msg_state.render_topic(
+                topics[topic + "_" + str(btn)] = self.msg_state.render_topic(
                     data
                 )
+            self.rendered_topic_map.update(topics)
         else:
             # Add ourselves to the list of topics
-            self.rendered_topic_map['state_topic'] = self.msg_state.render_topic(
+            self.rendered_topic_map[topic] = self.msg_state.render_topic(
                 self.base_template_data()
             )
 

--- a/insteon_mqtt/mqtt/topic/StateTopic.py
+++ b/insteon_mqtt/mqtt/topic/StateTopic.py
@@ -96,10 +96,19 @@ class StateTopic(BaseTopic):
                 self.base_template_data()
             )
 
-        # Add ourselves to the list of topics
-        self.topics['state_topic'] = self.msg_state.render_topic(
-            self.base_template_data()
-        )
+        if len(self.group_topic_nums) > 0:
+            # This device has multiple state topics for multiple buttons
+            data = self.base_template_data()
+            for btn in self.group_topic_nums:
+                data['button'] = btn
+                self.topics['state_topic_' + str(btn)] = self.msg_state.render_topic(
+                    data
+                )
+        else:
+            # Add ourselves to the list of topics
+            self.topics['state_topic'] = self.msg_state.render_topic(
+                self.base_template_data()
+            )
 
     #-----------------------------------------------------------------------
     def state_template_data(self, **kwargs):

--- a/insteon_mqtt/mqtt/topic/StateTopic.py
+++ b/insteon_mqtt/mqtt/topic/StateTopic.py
@@ -92,21 +92,21 @@ class StateTopic(BaseTopic):
                 payload_1 = 'dimmer_state_payload'
             self.msg_state_1.load_config(data, topic_1, payload_1, qos)
             # Add ourselves to the list of topics
-            self.topics['dimmer_state_topic'] = self.msg_state_1.render_topic(
+            self.rendered_topic_map['dimmer_state_topic'] = self.msg_state_1.render_topic(
                 self.base_template_data()
             )
 
-        if len(self.group_topic_nums) > 0:
+        if len(self.group_state_list) > 0:
             # This device has multiple state topics for multiple buttons
             data = self.base_template_data()
-            for btn in self.group_topic_nums:
+            for btn in self.group_state_list:
                 data['button'] = btn
-                self.topics['state_topic_' + str(btn)] = self.msg_state.render_topic(
+                self.rendered_topic_map['state_topic_' + str(btn)] = self.msg_state.render_topic(
                     data
                 )
         else:
             # Add ourselves to the list of topics
-            self.topics['state_topic'] = self.msg_state.render_topic(
+            self.rendered_topic_map['state_topic'] = self.msg_state.render_topic(
                 self.base_template_data()
             )
 


### PR DESCRIPTION
## Proposed change
This adds the discovery platform support to the devices.  ~I still need to finish the KPL, outlets, io_lincs, and ezio4.  But this is a lot of code, so I am pushing it early.  I will likely push support for the other 4 devices tomorrow.~ Done.

So far, this seems to be working reasonably well.  The biggest time suck is getting the ideal config template for HomeAssistant for each device.

The Remotes and KPL discovery entries are going to be verbose.  I struggled over the weekend thinking about ways in which the entities for each button could be duplicated from a single definition.  I was not able to come up with one that didn't make the code overly complex or the definition for the user overly awkward.

I also made some good updates to the documentation when I discover issues that users are likely to stumble into too.

## Additional information
- This PR is related to issue: #128 

## Checklist
- [ ] The code change is tested and works locally.
- [x] Local tests pass.
- [ ] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary
- [x] Documentation added/updated
