### PR TITLE
Add Unit Tests to Discovery Platform

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -204,8 +204,12 @@ mqtt:
   # Any additional variables that a specific device may offer are documented
   # in the comments below under that device class.
   #
-  # TO DISABLE THE DISCOVERY SERVICE: Comment out the line below by placing a
-  # hash character # at the start of the line.
+  # TO ENABLE THE DISCOVERY PLATFORM: Set the following to true
+  enable_discovery: false
+
+  # This defines the base topic for publishing discovery messages, likely
+  # does not need to be changed unless you changed your setting in
+  # HomeAssistant
   discovery_topic_base: 'homeassistant'
 
   # The mqtt topic to monitor for HomeAssistant status.  This likely doesn't

--- a/insteon_mqtt/mqtt/Modem.py
+++ b/insteon_mqtt/mqtt/Modem.py
@@ -105,6 +105,7 @@ class Modem(topic.SceneTopic, topic.DiscoveryTopic):
                 # scene does not have a name
                 data['scene_name'] = ""
             data['scene'] = scene
-            self.entries[0].publish(self.mqtt, data, retain=False)
+            self.disc_templates[0].publish(self.mqtt, data.copy(),
+                                           retain=False)
 
     #-----------------------------------------------------------------------

--- a/insteon_mqtt/mqtt/Modem.py
+++ b/insteon_mqtt/mqtt/Modem.py
@@ -50,6 +50,11 @@ class Modem(topic.SceneTopic, topic.DiscoveryTopic):
 
         self.load_scene_data(data, qos)
 
+        # Strip out the scene_topic, it is used in a different manner in the
+        # modem and is generated below in publish_discovery()
+        if 'scene_topic' in self.rendered_topic_map:
+            del self.rendered_topic_map['scene_topic']
+
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
         """Subscribe to any MQTT topics the object needs.

--- a/insteon_mqtt/mqtt/Mqtt.py
+++ b/insteon_mqtt/mqtt/Mqtt.py
@@ -98,7 +98,7 @@ class Mqtt:
         - broker:    (str) The broker host to connect to.
         - port:      (int) Thr broker port to connect to.
         - username:  (str) Optional user name to log in with.
-        - passord:   (str) Optional password to log in with.
+        - password:  (str) Optional password to log in with.
 
         - qos:         (int) QOS level to use for sent messages (Default 1).
         - retain:      (bool) Retain sent messages (Default True)

--- a/insteon_mqtt/mqtt/Mqtt.py
+++ b/insteon_mqtt/mqtt/Mqtt.py
@@ -68,6 +68,9 @@ class Mqtt:
         # The command topic template (MstTemplate) to use.
         self._cmd_topic = None
 
+        # Enable discovery service
+        self.discovery_enabled = False
+
         # The HomeAssistant status topic to use.
         self._ha_status_topic = None
 
@@ -124,9 +127,13 @@ class Mqtt:
             self.device_info_template = data['device_info_template']
 
         # Check to see that discovery_topic_base is set in config
-        self.discovery_topic_base = data.get('discovery_topic_base', None)
-        if self.discovery_topic_base is None:
-            LOG.debug("Discovery disabled, discovery_topic_base not defined.")
+        self.discovery_topic_base = data.get('discovery_topic_base',
+                                             "homeassistant")
+
+        # Check if discovery enabled
+        self.discovery_enabled = data.get('enable_discovery', False)
+        if not self.discovery_enabled:
+            LOG.debug("Discovery disabled via config setting.")
 
         # MQTT message parameters.
         self.qos = data.get('qos', self.qos)
@@ -391,7 +398,7 @@ class Mqtt:
         Args:
           device: the device to send the publish discovery command
         """
-        if self.discovery_topic_base is not None:
+        if self.discovery_enabled:
             if (hasattr(device, 'publish_discovery') and
                     callable(device.publish_discovery)):
                 device.publish_discovery()

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -162,10 +162,12 @@ class DiscoveryTopic(BaseTopic):
             data['modem_addr'] = self.device.modem.addr.hex
 
         # Finally, render the device_info_template
-        device_info_template = jinja2.Template(self.mqtt.device_info_template)
         try:
+            device_info_template = jinja2.Template(
+                self.mqtt.device_info_template
+            )
             data['device_info_template'] = device_info_template.render(data)
-        except jinja2.exceptions.UndefinedError as exc:
+        except jinja2.exceptions.TemplateError as exc:
             LOG.error("Error rendering device_info_template: %s", exc)
             LOG.error("Template was: \n%s",
                       self.mqtt.device_info_template.strip())
@@ -210,13 +212,13 @@ class DiscoveryTopic(BaseTopic):
         Returns:
           unique_id (str) or None if there was an error.
         """
-        config_template = jinja2.Template(config)
         data = self.discovery_template_data()
         ret = None
         # First render template
         try:
+            config_template = jinja2.Template(config)
             config_rendered = config_template.render(data)
-        except jinja2.exceptions.UndefinedError as exc:
+        except jinja2.exceptions.TemplateError as exc:
             LOG.error("Error rendering config template: %s", exc)
             LOG.error("Template was: \n%s",
                       config.strip())

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -34,7 +34,7 @@ class DiscoveryTopic(BaseTopic):
 
         # This is a list of all of the discovery entries published by this
         # device
-        self.entries = []
+        self.disc_templates = []
 
     #-----------------------------------------------------------------------
     def load_discovery_data(self, config, qos=None):
@@ -89,8 +89,10 @@ class DiscoveryTopic(BaseTopic):
                                                     self.device.addr.hex,
                                                     unique_id)
             topic = entity.get('topic', default_topic)
-            self.entries.append(MsgTemplate(topic=topic, payload=payload,
-                                            qos=qos, retain=False))
+            self.disc_templates.append(MsgTemplate(topic=topic,
+                                                   payload=payload,
+                                                   qos=qos,
+                                                   retain=False))
 
     #-----------------------------------------------------------------------
     def discovery_template_data(self, **kwargs):
@@ -193,7 +195,7 @@ class DiscoveryTopic(BaseTopic):
 
         data = self.discovery_template_data(**kwargs)
 
-        for entry in self.entries:
+        for entry in self.disc_templates:
             entry.publish(self.mqtt, data, retain=False)
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_BatterySensor.py
+++ b/tests/mqtt/test_BatterySensor.py
@@ -93,6 +93,20 @@ class Test_BatterySensor:
             topic='%s/battery' % topic, payload='on', qos=0, retain=True)
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"battery_sensor": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "battery_sensor"
+        assert mdev.rendered_topic_map == {
+            'state_topic': 'insteon/01.02.03/state',
+            'low_battery_topic': 'insteon/01.02.03/battery',
+            'heartbeat_topic': 'insteon/01.02.03/heartbeat',
+        }
+        assert len(mdev.extra_topic_nums) == 0
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_Dimmer.py
+++ b/tests/mqtt/test_Dimmer.py
@@ -121,6 +121,22 @@ class Test_Dimmer:
         assert len(link.client.pub) == 0
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"dimmer": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "dimmer"
+        assert mdev.rendered_topic_map == {
+            'manual_state_topic': None,
+            'on_off_topic': 'insteon/01.02.03/set',
+            'scene_topic': 'insteon/01.02.03/scene',
+            'state_topic': 'insteon/01.02.03/state',
+            'level_topic': 'insteon/01.02.03/level'
+        }
+        assert len(mdev.extra_topic_nums) == 0
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_EZIO4O.py
+++ b/tests/mqtt/test_EZIO4O.py
@@ -170,6 +170,25 @@ class Test_EZIO4O:
         link.client.clear()
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"ezio4o": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "ezio4o"
+        assert mdev.rendered_topic_map == {
+            'on_off_topic_1': 'insteon/01.02.03/set/1',
+            'on_off_topic_2': 'insteon/01.02.03/set/2',
+            'on_off_topic_3': 'insteon/01.02.03/set/3',
+            'on_off_topic_4': 'insteon/01.02.03/set/4',
+            'state_topic_1': 'insteon/01.02.03/state/1',
+            'state_topic_2': 'insteon/01.02.03/state/2',
+            'state_topic_3': 'insteon/01.02.03/state/3',
+            'state_topic_4': 'insteon/01.02.03/state/4'
+        }
+        assert len(mdev.extra_topic_nums) == 4
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(["mdev", "dev", "link"])
 

--- a/tests/mqtt/test_FanLinc.py
+++ b/tests/mqtt/test_FanLinc.py
@@ -161,6 +161,36 @@ class Test_FanLinc:
             payload='off', qos=0, retain=True)
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        # Fan doesn't have default values for fan_speed_topic or
+        # fan_speed_set_topic
+        mdev.load_config({
+            "fan_linc": {
+                "fan_speed_set_topic": "insteon/{{address}}/fan/speed/set",
+                "fan_speed_topic": "insteon/{{address}}/fan/speed/state"
+            },
+            "dimmer": {
+                "junk": "junk",
+            }
+        })
+        assert mdev.default_discovery_cls == "fan_linc"
+        assert mdev.rendered_topic_map == {
+            'manual_state_topic': None,
+            'on_off_topic': 'insteon/01.02.03/set',
+            'scene_topic': 'insteon/01.02.03/scene',
+            'state_topic': 'insteon/01.02.03/state',
+            'level_topic': 'insteon/01.02.03/level',
+            'fan_on_off_topic': 'insteon/01.02.03/fan/set',
+            'fan_speed_set_topic': 'insteon/01.02.03/fan/speed/set',
+            'fan_speed_topic': 'insteon/01.02.03/fan/speed/state',
+            'fan_state_topic': 'insteon/01.02.03/fan/state'
+        }
+        assert len(mdev.extra_topic_nums) == 0
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_IOLincMqtt.py
+++ b/tests/mqtt/test_IOLincMqtt.py
@@ -135,6 +135,22 @@ class Test_IOLinc:
         link.client.clear()
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"io_linc": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "io_linc"
+        assert mdev.rendered_topic_map == {
+            'on_off_topic': 'insteon/01.02.03/set',
+            'relay_state_topic': 'insteon/01.02.03/relay',
+            'sensor_state_topic': 'insteon/01.02.03/sensor',
+            'state_topic': 'insteon/01.02.03/state'
+        }
+        assert len(mdev.extra_topic_nums) == 0
+
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_KeypadLinc.py
+++ b/tests/mqtt/test_KeypadLinc.py
@@ -166,6 +166,47 @@ class Test_KeypadLinc:
         assert len(link.client.pub) == 0
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"keypad_linc": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "keypad_linc"
+        assert mdev.rendered_topic_map == {
+            'dimmer_level_topic': 'insteon/01.02.03/level',
+            'dimmer_state_topic': 'insteon/01.02.03/state/',
+            'btn_on_off_topic_1': 'insteon/01.02.03/set/1',
+            'btn_on_off_topic_2': 'insteon/01.02.03/set/2',
+            'btn_on_off_topic_3': 'insteon/01.02.03/set/3',
+            'btn_on_off_topic_4': 'insteon/01.02.03/set/4',
+            'btn_on_off_topic_5': 'insteon/01.02.03/set/5',
+            'btn_on_off_topic_6': 'insteon/01.02.03/set/6',
+            'btn_on_off_topic_7': 'insteon/01.02.03/set/7',
+            'btn_on_off_topic_8': 'insteon/01.02.03/set/8',
+            'btn_on_off_topic_9': 'insteon/01.02.03/set/9',
+            'btn_scene_topic_1': 'insteon/01.02.03/scene/1',
+            'btn_scene_topic_2': 'insteon/01.02.03/scene/2',
+            'btn_scene_topic_3': 'insteon/01.02.03/scene/3',
+            'btn_scene_topic_4': 'insteon/01.02.03/scene/4',
+            'btn_scene_topic_5': 'insteon/01.02.03/scene/5',
+            'btn_scene_topic_6': 'insteon/01.02.03/scene/6',
+            'btn_scene_topic_7': 'insteon/01.02.03/scene/7',
+            'btn_scene_topic_8': 'insteon/01.02.03/scene/8',
+            'btn_scene_topic_9': 'insteon/01.02.03/scene/9',
+            'btn_state_topic_1': 'insteon/01.02.03/state/1',
+            'btn_state_topic_2': 'insteon/01.02.03/state/2',
+            'btn_state_topic_3': 'insteon/01.02.03/state/3',
+            'btn_state_topic_4': 'insteon/01.02.03/state/4',
+            'btn_state_topic_5': 'insteon/01.02.03/state/5',
+            'btn_state_topic_6': 'insteon/01.02.03/state/6',
+            'btn_state_topic_7': 'insteon/01.02.03/state/7',
+            'btn_state_topic_8': 'insteon/01.02.03/state/8',
+            'btn_state_topic_9': 'insteon/01.02.03/state/9',
+            'manual_state_topic': None
+        }
+        assert len(mdev.extra_topic_nums) == 9
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_KeypadLinc_sw.py
+++ b/tests/mqtt/test_KeypadLinc_sw.py
@@ -118,6 +118,45 @@ class Test_KeypadLinc_sw:
         assert len(link.client.pub) == 0
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"keypad_linc": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "keypad_linc"
+        assert mdev.rendered_topic_map == {
+            'btn_on_off_topic_1': 'insteon/01.02.03/set/1',
+            'btn_on_off_topic_2': 'insteon/01.02.03/set/2',
+            'btn_on_off_topic_3': 'insteon/01.02.03/set/3',
+            'btn_on_off_topic_4': 'insteon/01.02.03/set/4',
+            'btn_on_off_topic_5': 'insteon/01.02.03/set/5',
+            'btn_on_off_topic_6': 'insteon/01.02.03/set/6',
+            'btn_on_off_topic_7': 'insteon/01.02.03/set/7',
+            'btn_on_off_topic_8': 'insteon/01.02.03/set/8',
+            'btn_on_off_topic_9': 'insteon/01.02.03/set/9',
+            'btn_scene_topic_1': 'insteon/01.02.03/scene/1',
+            'btn_scene_topic_2': 'insteon/01.02.03/scene/2',
+            'btn_scene_topic_3': 'insteon/01.02.03/scene/3',
+            'btn_scene_topic_4': 'insteon/01.02.03/scene/4',
+            'btn_scene_topic_5': 'insteon/01.02.03/scene/5',
+            'btn_scene_topic_6': 'insteon/01.02.03/scene/6',
+            'btn_scene_topic_7': 'insteon/01.02.03/scene/7',
+            'btn_scene_topic_8': 'insteon/01.02.03/scene/8',
+            'btn_scene_topic_9': 'insteon/01.02.03/scene/9',
+            'btn_state_topic_1': 'insteon/01.02.03/state/1',
+            'btn_state_topic_2': 'insteon/01.02.03/state/2',
+            'btn_state_topic_3': 'insteon/01.02.03/state/3',
+            'btn_state_topic_4': 'insteon/01.02.03/state/4',
+            'btn_state_topic_5': 'insteon/01.02.03/state/5',
+            'btn_state_topic_6': 'insteon/01.02.03/state/6',
+            'btn_state_topic_7': 'insteon/01.02.03/state/7',
+            'btn_state_topic_8': 'insteon/01.02.03/state/8',
+            'btn_state_topic_9': 'insteon/01.02.03/state/9',
+            'manual_state_topic': None
+        }
+        assert len(mdev.extra_topic_nums) == 9
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_Leak.py
+++ b/tests/mqtt/test_Leak.py
@@ -110,6 +110,22 @@ class Test_Leak:
         pytest.approx(t0, hb, 5)
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"leak": {"junk": "junk"},
+                          "battery_sensor" : {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "leak"
+        assert mdev.rendered_topic_map == {
+            'wet_dry_topic': 'insteon/01.02.03/wet',
+            'heartbeat_topic': 'insteon/01.02.03/heartbeat',
+            'low_battery_topic': 'insteon/01.02.03/battery'
+        }
+        assert len(mdev.extra_topic_nums) == 0
+
+
+    #-----------------------------------------------------------------------
     def test_refresh_data(self, setup):
         # handle refresh will pass the level and not an is_on
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])

--- a/tests/mqtt/test_Modem.py
+++ b/tests/mqtt/test_Modem.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+from unittest import mock
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -93,6 +94,90 @@ class Test_Modem:
 
         # test error payload
         link.publish(topic, b'asdf', qos, False)
+
+    #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, link = setup.getAll(['mdev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        # Modem with no scenes should have no discovery topics
+        mdev.load_config({"modem": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "modem"
+        assert mdev.rendered_topic_map == {}
+        assert len(mdev.extra_topic_nums) == 0
+
+    #-----------------------------------------------------------------------
+    def test_discovery_publish(self, setup):
+        mdev, link = setup.getAll(['mdev', 'link'])
+
+        # First generate our discovery template
+        unique_id = "{{address}}_{{scene}}"
+        topic = "homeassistant/switch/%s/%s/config" % (
+            setup.addr.hex,
+            unique_id
+        )
+        payload = """
+          {
+            "uniq_id": "{{address}}_{{scene}}",
+            "name": "{%- if scene_name != "" -%}
+                       {{scene_name}}
+                     {%- else -%}
+                       Modem Scene {{scene}}
+                     {%- endif -%}",
+            "cmd_t": "{{scene_topic}}",
+            "device": {{device_info_template}},
+            "payload_on": "{\"cmd\": \"on\", \"group\": \"{{scene}}\"}",
+            "payload_off": "{\"cmd\": \"off\", \"group\": \"{{scene}}\"}"
+          }
+        """
+        mdev.disc_templates.append(IM.mqtt.MsgTemplate(topic=topic,
+                                                       payload=payload,
+                                                       qos=1,
+                                                       retain=False))
+
+        # Second add some fake groups
+        mdev.device.db.groups[1] = ['junk']
+        mdev.device.db.groups[2] = ['junk']
+        mdev.device.db.groups[0x10] = ['junk']
+
+        # Third add a name to one of the fake groups
+        mdev.device.scene_map['test_name'] = 0x10
+
+        # Fourth, mock the publish call on MsgTemplate
+        mdev.disc_templates[0].publish = mock.Mock()
+        mocked = mdev.disc_templates[0].publish
+
+        # Finally call publish_discovery() and test results
+        mdev.publish_discovery()
+        assert mocked.call_count == 2
+
+        # The expected template data
+        data = {
+            'address': '20.30.40',
+            'dev_cat': 0,
+            'dev_cat_name': 'Unknown',
+            'device_info_template': '',
+            'engine': 'Unknown',
+            'firmware': 0,
+            'model_description': 'Unknown',
+            'model_number': 'Unknown',
+            'modem_addr': '20.30.40',
+            'name': 'modem',
+            'name_user_case': 'Modem',
+            'scene': 0,
+            'scene_name': '',
+            'sub_cat': 0
+        }
+
+
+        # One call should be group 2 with no name
+        data['scene'] = 2
+        mocked.assert_any_call(mdev.mqtt, data, retain=False)
+
+        # Other call should be group 16 with name of 'test_name'
+        data['scene'] = 16
+        data['scene_name'] = 'test_name'
+        mocked.assert_any_call(mdev.mqtt, data, retain=False)
 
 
 #===========================================================================

--- a/tests/mqtt/test_Motion.py
+++ b/tests/mqtt/test_Motion.py
@@ -112,6 +112,22 @@ class Test_Motion:
             topic='%s/battery' % topic, payload='on', qos=0, retain=True)
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"motion": {"junk": "junk"},
+                          "battery_sensor" : {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "motion"
+        assert mdev.rendered_topic_map == {
+            'dawn_dusk_topic': 'insteon/01.02.03/dawn',
+            'state_topic': 'insteon/01.02.03/state',
+            'heartbeat_topic': 'insteon/01.02.03/heartbeat',
+            'low_battery_topic': 'insteon/01.02.03/battery'
+        }
+        assert len(mdev.extra_topic_nums) == 0
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_Mqtt.py
+++ b/tests/mqtt/test_Mqtt.py
@@ -1,12 +1,12 @@
 #===========================================================================
 #
-# Tests for: insteont_mqtt/mqtt/Mqtt.py
+# Tests for: insteon_mqtt/mqtt/Mqtt.py
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
 import logging
-import pytest
 from unittest import mock
+import pytest
 import insteon_mqtt as IM
 import helpers as H
 

--- a/tests/mqtt/test_Mqtt.py
+++ b/tests/mqtt/test_Mqtt.py
@@ -1,0 +1,103 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/mqtt/Mqtt.py
+#
+# pylint: disable=redefined-outer-name
+#===========================================================================
+import logging
+import pytest
+from unittest import mock
+import insteon_mqtt as IM
+import helpers as H
+
+# Create our MQTT object to test as well as the linked Insteon object and a
+# mocked MQTT client to publish to.
+@pytest.fixture
+def setup(mock_paho_mqtt):
+    link = IM.network.Mqtt()
+    mqttModem = H.mqtt.MockModem()
+    mqtt = IM.mqtt.Mqtt(link, mqttModem)
+
+    return H.Data(mqtt=mqtt, mqttModem=mqttModem, link=link)
+
+@pytest.fixture
+def config():
+    # The minimum config required for MQTT
+    config = {"broker": "127.0.0.2",
+              "port": "12345",
+              "cmd_topic": "insteon/command"}
+    return config
+
+#===========================================================================
+class Test_Mqtt:
+    #-----------------------------------------------------------------------
+    def test_disabled_discovery(self, setup, caplog, config):
+        mqtt = setup.get('mqtt')
+
+        with caplog.at_level(logging.DEBUG):
+            # No config
+            mqtt.load_config(config)
+            assert 'Discovery disabled' in caplog.text
+
+            # Config is False
+            caplog.clear()
+            config['enable_discovery'] = False
+            mqtt.load_config(config)
+            assert 'Discovery disabled' in caplog.text
+
+            # Config is True
+            caplog.clear()
+            config['enable_discovery'] = True
+            mqtt.load_config(config)
+            assert 'Discovery disabled' not in caplog.text
+
+    #-----------------------------------------------------------------------
+    def test_handle_ha_status(self, setup, caplog):
+        mqtt = setup.get('mqtt')
+        mqtt.devices = {"test_dev": "test_dev_value"}
+
+        message = MockMqttMessage("fake_topic", "online")
+        with mock.patch.object(mqtt, '_publish_device_discovery') as mocked:
+            mqtt.handle_ha_status(None, None, message)
+            mocked.assert_called_once_with("test_dev_value")
+
+        message = MockMqttMessage("fake_topic", "offline")
+        with mock.patch.object(mqtt, '_publish_device_discovery') as mocked:
+            mqtt.handle_ha_status(None, None, message)
+            mocked.assert_not_called()
+
+        message = MockMqttMessage("fake_topic", "bad_thing")
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            mqtt.handle_ha_status(None, None, message)
+            assert 'Unexpected HomeAssistant status message' in caplog.text
+
+    #-----------------------------------------------------------------------
+    def test_publish(self, setup, caplog):
+        mqtt = setup.get('mqtt')
+
+        mqtt.discovery_enabled = False
+        device = MockDiscovery()
+        with mock.patch.object(device, 'publish_discovery') as mocked:
+            mqtt._publish_device_discovery(device)
+            mocked.assert_not_called()
+
+        mqtt.discovery_enabled = True
+        device = MockDiscovery()
+        with mock.patch.object(device, 'publish_discovery') as mocked:
+            mqtt._publish_device_discovery(device)
+            mocked.assert_called_once()
+
+class MockMqttMessage():
+    """MockMqttMessage, generates a mocked paho mqtt message"""
+    def __init__(self, topic, payload):
+        self.topic = topic
+        self.payload = payload.encode(encoding='UTF-8')
+
+class MockDiscovery():
+    """MockDiscovery, simulate a device with discovery"""
+    def __init__(self):
+        pass
+
+    def publish_discovery(self):
+        pass

--- a/tests/mqtt/test_Outlet.py
+++ b/tests/mqtt/test_Outlet.py
@@ -98,6 +98,21 @@ class Test_Outlet:
         link.client.clear()
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"outlet": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "outlet"
+        assert mdev.rendered_topic_map == {
+            'on_off_topic_1': 'insteon/01.02.03/set/1',
+            'on_off_topic_2': 'insteon/01.02.03/set/2',
+            'state_topic_1': 'insteon/01.02.03/state/1',
+            'state_topic_2': 'insteon/01.02.03/state/2'
+        }
+        assert len(mdev.extra_topic_nums) == 2
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_Remote.py
+++ b/tests/mqtt/test_Remote.py
@@ -106,6 +106,29 @@ class Test_Remote:
         assert len(link.client.pub) == 0
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"remote": {"junk": "junk"},
+                          "battery_sensor" : {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "remote"
+        assert mdev.rendered_topic_map == {
+            'heartbeat_topic': 'insteon/01.02.03/heartbeat',
+            'low_battery_topic': 'insteon/01.02.03/battery',
+            'manual_state_topic': None,
+            'state_topic_1': 'insteon/01.02.03/state/1',
+            'state_topic_2': 'insteon/01.02.03/state/2',
+            'state_topic_3': 'insteon/01.02.03/state/3',
+            'state_topic_4': 'insteon/01.02.03/state/4',
+            'state_topic_5': 'insteon/01.02.03/state/5',
+            'state_topic_6': 'insteon/01.02.03/state/6',
+            'state_topic_7': 'insteon/01.02.03/state/7',
+            'state_topic_8': 'insteon/01.02.03/state/8'
+        }
+        assert len(mdev.extra_topic_nums) == 8
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_SmokeBridge.py
+++ b/tests/mqtt/test_SmokeBridge.py
@@ -84,6 +84,21 @@ class Test_SmokeBridge:
         link.client.clear()
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"smoke_bridge": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "smoke_bridge"
+        assert mdev.rendered_topic_map == {
+            'battery_topic': 'insteon/01.02.03/battery',
+            'co_topic': 'insteon/01.02.03/co',
+            'error_topic': 'insteon/01.02.03/error',
+            'smoke_topic': 'insteon/01.02.03/smoke'
+        }
+        assert len(mdev.extra_topic_nums) == 0
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/test_Switch.py
+++ b/tests/mqtt/test_Switch.py
@@ -111,6 +111,21 @@ class Test_Switch:
         assert len(link.client.pub) == 0
 
     #-----------------------------------------------------------------------
+    def test_discovery(self, setup):
+        mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
+        topic = "insteon/%s" % setup.addr.hex
+
+        mdev.load_config({"switch": {"junk": "junk"}})
+        assert mdev.default_discovery_cls == "switch"
+        assert mdev.rendered_topic_map == {
+            'manual_state_topic': None,
+            'on_off_topic': 'insteon/01.02.03/set',
+            'scene_topic': 'insteon/01.02.03/scene',
+            'state_topic': 'insteon/01.02.03/state'
+        }
+        assert len(mdev.extra_topic_nums) == 0
+
+    #-----------------------------------------------------------------------
     def test_config(self, setup):
         mdev, dev, link = setup.getAll(['mdev', 'dev', 'link'])
 

--- a/tests/mqtt/topic/test_DiscoveryTopic.py
+++ b/tests/mqtt/topic/test_DiscoveryTopic.py
@@ -176,3 +176,23 @@ class Test_DiscoveryTopic:
         data = discovery.discovery_template_data()
         assert 'Error rendering device_info_template' in caplog.text
         caplog.clear()
+
+    #-----------------------------------------------------------------------
+    def test_publish(self, discovery, caplog):
+        discovery.entries.append(mock.Mock())
+        discovery.publish_discovery()
+        data = {'address': '11.22.33',
+                'name': '11.22.33',
+                'name_user_case': '11.22.33',
+                'engine': 'Unknown',
+                'model_number': 'Unknown',
+                'model_description': 'Unknown',
+                'dev_cat': 0,
+                'dev_cat_name': 'Unknown',
+                'sub_cat': 0,
+                'firmware': 0,
+                'modem_addr': '20.30.40',
+                'device_info_template': ''}
+        discovery.entries[0].publish.assert_called_once_with(discovery.mqtt,
+                                                             data,
+                                                             retain=False)

--- a/tests/mqtt/topic/test_DiscoveryTopic.py
+++ b/tests/mqtt/topic/test_DiscoveryTopic.py
@@ -1,0 +1,108 @@
+#===========================================================================
+#
+# Tests for: insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+#
+# pylint: disable=redefined-outer-name
+#===========================================================================
+import logging
+from unittest import mock
+import pytest
+import insteon_mqtt as IM
+import helpers as H
+
+# Create the base mqtt object
+@pytest.fixture
+def discovery(mock_paho_mqtt):
+    link = IM.network.Mqtt()
+    mqttModem = H.mqtt.MockModem()
+    mqtt = IM.mqtt.Mqtt(link, mqttModem)
+    # set the default topic base
+    mqtt.discovery_topic_base = "homeassistant"
+
+    device = MockDevice()
+    discovery = IM.mqtt.topic.DiscoveryTopic(mqtt, device)
+
+    return discovery
+
+#===========================================================================
+class Test_DiscoveryTopic:
+    #-----------------------------------------------------------------------
+    def test_load_discovery_data(self, discovery, caplog):
+        # This also fully tests _get_unique_id()
+
+        # test lack of discovery class
+        config = {}
+        discovery.load_discovery_data(config)
+        assert 'Unable to find discovery class' in caplog.text
+        caplog.clear()
+
+        # test lack of entities defined
+        config['fake_dev'] = {}
+        discovery.device.config_extra['discovery_class'] = 'fake_dev'
+        discovery.load_discovery_data(config)
+        assert 'No discovery_entities defined' in caplog.text
+        caplog.clear()
+
+        # test lack of component
+        config['fake_dev'] = {'discovery_entities': [{}]}
+        discovery.load_discovery_data(config)
+        assert 'No component specified in discovery entity' in caplog.text
+        caplog.clear()
+
+        # Override data at this point
+        discovery.discovery_template_data = mock.Mock(return_value={})
+
+        # test lack of unique id
+        config['fake_dev'] = {'discovery_entities': [{
+            "component": "switch",
+            "config": "{}"
+        }]}
+        discovery.load_discovery_data(config)
+        assert 'Error getting unique_id, skipping entry' in caplog.text
+        caplog.clear()
+
+        # test with unique_id
+        config['fake_dev'] = {'discovery_entities': [{
+            "component": "switch",
+            "config": '{"unique_id": "unique"}'
+        }]}
+        discovery.load_discovery_data(config)
+        expected_topic = "homeassistant/switch/11.22.33/unique/config"
+        assert discovery.entries[0].topic_str == expected_topic
+        discovery.entries = []
+
+        # test with uniq_id
+        config['fake_dev'] = {'discovery_entities': [{
+            "component": "switch",
+            "config": '{"uniq_id": "unique2"}'
+        }]}
+        discovery.load_discovery_data(config)
+        expected_topic = "homeassistant/switch/11.22.33/unique2/config"
+        assert discovery.entries[0].topic_str == expected_topic
+        discovery.entries = []
+
+        # test bad json
+        config['fake_dev'] = {'discovery_entities': [{
+            "component": "switch",
+            "config": "{'no_single': 'quotes'}"
+        }]}
+        discovery.load_discovery_data(config)
+        expected_topic = "homeassistant/switch/11.22.33/unique2/config"
+        assert 'Error parsing config as json' in caplog.text
+        caplog.clear()
+
+        # test bad template
+        config['fake_dev'] = {'discovery_entities': [{
+            "component": "switch",
+            "config": "{% if bad_format = 1 %}"
+        }]}
+        discovery.load_discovery_data(config)
+        expected_topic = "homeassistant/switch/11.22.33/unique2/config"
+        assert 'Error rendering config template' in caplog.text
+        caplog.clear()
+
+class MockDevice:
+    def __init__(self):
+        self.config_extra = {}
+        self.label = "Fake device"
+        self.addr = IM.Address("11.22.33")

--- a/tests/mqtt/topic/test_DiscoveryTopic.py
+++ b/tests/mqtt/topic/test_DiscoveryTopic.py
@@ -4,7 +4,6 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
-import logging
 from unittest import mock
 import pytest
 import insteon_mqtt as IM
@@ -71,8 +70,8 @@ class Test_DiscoveryTopic:
         }]}
         discovery.load_discovery_data(config)
         expected_topic = "homeassistant/switch/11.22.33/unique/config"
-        assert discovery.entries[0].topic_str == expected_topic
-        discovery.entries = []
+        assert discovery.disc_templates[0].topic_str == expected_topic
+        discovery.disc_templates = []
 
         # test with uniq_id
         config['fake_dev'] = {'discovery_entities': [{
@@ -81,8 +80,8 @@ class Test_DiscoveryTopic:
         }]}
         discovery.load_discovery_data(config)
         expected_topic = "homeassistant/switch/11.22.33/unique2/config"
-        assert discovery.entries[0].topic_str == expected_topic
-        discovery.entries = []
+        assert discovery.disc_templates[0].topic_str == expected_topic
+        discovery.disc_templates = []
 
         # test bad json
         config['fake_dev'] = {'discovery_entities': [{
@@ -179,7 +178,7 @@ class Test_DiscoveryTopic:
 
     #-----------------------------------------------------------------------
     def test_publish(self, discovery, caplog):
-        discovery.entries.append(mock.Mock())
+        discovery.disc_templates.append(mock.Mock())
         discovery.publish_discovery()
         data = {'address': '11.22.33',
                 'name': '11.22.33',
@@ -193,6 +192,8 @@ class Test_DiscoveryTopic:
                 'firmware': 0,
                 'modem_addr': '20.30.40',
                 'device_info_template': ''}
-        discovery.entries[0].publish.assert_called_once_with(discovery.mqtt,
-                                                             data,
-                                                             retain=False)
+        discovery.disc_templates[0].publish.assert_called_once_with(
+            discovery.mqtt,
+            data,
+            retain=False
+        )

--- a/tests/mqtt/topic/test_DiscoveryTopic.py
+++ b/tests/mqtt/topic/test_DiscoveryTopic.py
@@ -12,14 +12,17 @@ import helpers as H
 
 # Create the base mqtt object
 @pytest.fixture
-def discovery(mock_paho_mqtt):
+def discovery(mock_paho_mqtt, tmpdir):
     link = IM.network.Mqtt()
     mqttModem = H.mqtt.MockModem()
     mqtt = IM.mqtt.Mqtt(link, mqttModem)
     # set the default topic base
     mqtt.discovery_topic_base = "homeassistant"
 
-    device = MockDevice()
+    protocol = H.main.MockProtocol()
+    modem = H.main.MockModem(tmpdir)
+    addr = IM.Address(0x11, 0x22, 0x33)
+    device = IM.device.Switch(protocol, modem, addr)
     discovery = IM.mqtt.topic.DiscoveryTopic(mqtt, device)
 
     return discovery
@@ -101,8 +104,75 @@ class Test_DiscoveryTopic:
         assert 'Error rendering config template' in caplog.text
         caplog.clear()
 
-class MockDevice:
-    def __init__(self):
-        self.config_extra = {}
-        self.label = "Fake device"
-        self.addr = IM.Address("11.22.33")
+    #-----------------------------------------------------------------------
+    def test_template_data(self, discovery, caplog):
+        # Test default values
+        data = discovery.discovery_template_data()
+        assert data['address'] == "11.22.33"
+        assert data['name'] == "11.22.33"
+        assert data['name_user_case'] == "11.22.33"
+        assert data['engine'] == "Unknown"
+        assert data['model_number'] == 'Unknown'
+        assert data['model_description'] == 'Unknown'
+        assert data['dev_cat_name'] == 'Unknown'
+        assert data['dev_cat'] == 0
+        assert data['sub_cat'] == 0
+        assert data['firmware'] == 0
+        assert data['modem_addr'] == "20.30.40"
+        assert data['device_info_template'] == ""
+
+        # Test with actual values
+        discovery.device.name = "test device"
+        discovery.device.name_user_case = "Test Device"
+        discovery.device.db.engine = 2
+        discovery.device.db.desc = IM.catalog.find(0x02, 0x2a)
+        discovery.device.db.firmware = 0x45
+        data = discovery.discovery_template_data()
+        assert data['name'] == "test device"
+        assert data['name_user_case'] == "Test Device"
+        assert data['engine'] == "i2cs"
+        assert data['model_number'] == '2477S'
+        assert data['model_description'] == 'SwitchLinc Relay (Dual-Band)'
+        assert data['dev_cat_name'] == 'SWITCHED_LIGHTING'
+        assert data['dev_cat'] == 0x02
+        assert data['sub_cat'] == 0x2a
+        assert data['firmware'] == 0x45
+        assert data['modem_addr'] == "20.30.40"
+        assert data['device_info_template'] == ""
+
+        # test device info template
+        discovery.mqtt.device_info_template = """
+            {
+              "ids": "{{address}}",
+              "mf": "Insteon",
+              "mdl": "{%- if model_number != 'Unknown' -%}
+                        {{model_number}} - {{model_description}}
+                      {%- elif dev_cat_name != 'Unknown' -%}
+                        {{dev_cat_name}} - 0x{{'%0x' % sub_cat|int }}
+                      {%- elif dev_cat == 0 and sub_cat == 0 -%}
+                        No Info
+                      {%- else -%}
+                        0x{{'%0x' % dev_cat|int }} - 0x{{'%0x' % sub_cat|int }}
+                      {%- endif -%}",
+              "sw": "0x{{'%0x' % firmware|int }} - {{engine}}",
+              "name": "{{name_user_case}}",
+              "via_device": "{{modem_addr}}"
+            }
+        """
+        data = discovery.discovery_template_data()
+        assert data['device_info_template'] == """
+            {
+              "ids": "11.22.33",
+              "mf": "Insteon",
+              "mdl": "2477S - SwitchLinc Relay (Dual-Band)",
+              "sw": "0x45 - i2cs",
+              "name": "Test Device",
+              "via_device": "20.30.40"
+            }
+        """
+
+        # test bad device info template
+        discovery.mqtt.device_info_template = " {% if bad = 1 %}"
+        data = discovery.discovery_template_data()
+        assert 'Error rendering device_info_template' in caplog.text
+        caplog.clear()

--- a/tests/util/helpers/main.py
+++ b/tests/util/helpers/main.py
@@ -77,7 +77,8 @@ class MockDevice:
         self.protocol = protocol
         self.modem = modem
         self.addr = IM.Address(address)
-        self.name = name
+        self.name = name.lower()
+        self.name_user_case = name
 
     def send(self, msg, msg_handler, high_priority=False, after=None):
         self.protocol.send(msg, msg_handler, high_priority, after)

--- a/tests/util/helpers/main.py
+++ b/tests/util/helpers/main.py
@@ -77,7 +77,7 @@ class MockDevice:
         self.protocol = protocol
         self.modem = modem
         self.addr = IM.Address(address)
-        self.name = name.lower()
+        self.name = name
         self.name_user_case = name
 
     def send(self, msg, msg_handler, high_priority=False, after=None):


### PR DESCRIPTION
## Proposed change
This adds unit tests to the base Mqtt and the DiscoveryTopic classes covering the discovery code.

~I have also added some unit tests to the individual device classes but I have a little ways to go on them.~ Done

## Additional information
- This PR is related to issue: #128

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary