### PR TITLE
Add Join_All and Pair_All Commands; Remove Battery Option

### DIFF
--- a/docs/initializing.md
+++ b/docs/initializing.md
@@ -8,61 +8,89 @@ All of these functions are idempotent, they can be run multiple times without ca
 
 > __Note__ Battery devices (e.g. motion sensors, remotes, etc) are normally sleeping and will not respond to commands sent to them.  If the commands below are sent to a battery device, the command will be queued and will attempt to be run the next time the device is awake. For more details, see [battery devices](battery_devices.md)
 
-1. __Join__ - This is necessary to allow the modem to talk to the device.  This needs to be done first on any new device or device that has been factory reset.  If you are seeing the error `Senders ID not in responders db. Try running 'join' again.`  You need to run `join`.
+1. __Join__ This is necessary to allow the modem to talk to the device.  This needs to be done first on any new device or device that has been factory reset.  If you are seeing the error `Senders ID not in responders db. Try running 'join' again.`
+   - To join a __single device__ run `join`.
 
-  _Command Line_
-  ```
-  insteon-mqtt config.yaml join aa.bb.cc
-  ```
-  _MQTT_
-  ```
-  Topic: /insteon/command/aa.bb.cc
-  Payload: { "cmd" : "join" }
-  ```
+    _Command Line_
+    ```
+    insteon-mqtt config.yaml join aa.bb.cc
+    ```
+    _MQTT_
+    ```
+    Topic: /insteon/command/aa.bb.cc
+    Payload: { "cmd" : "join" }
+    ```
+
+   - To join __all__ devices run `join_all`.  This may be necesary when first setting up a network.
+
+     _Command Line_
+     ```
+     insteon-mqtt config.yaml join-all
+     ```
+     _MQTT_
+     ```
+     Topic: /insteon/command/modem
+     Payload: { "cmd" : "join_all" }
+     ```
 
 2. __Pair__ - This adds links to the device so that the device knows to notify the modem of state changes.  If you do not see any activity in Insteon-MQTT when you manually activate a device, you should try running `pair` again.
 
-  _Command Line_
-  ```
-  insteon-mqtt config.yaml pair aa.bb.cc
-  ```
-  _MQTT_
-  ```
-  Topic: /insteon/command/aa.bb.cc
-  Payload: { "cmd" : "pair" }
-  ```
+   - To pair a __single device__ run `pair`.
 
-3. __Refresh__ - This downloads the 1) device link database, if necessary; 2) model information, if necessary; 3) the current state (e.g. on/off); and 4) other relevant details from the device.
+    _Command Line_
+    ```
+    insteon-mqtt config.yaml pair aa.bb.cc
+    ```
+    _MQTT_
+    ```
+    Topic: /insteon/command/aa.bb.cc
+    Payload: { "cmd" : "pair" }
+    ```
+
+   - To pair __all__ devices run `pair_all`.  This may be necesary when first setting up a network.
+
+      _Command Line_
+      ```
+      insteon-mqtt config.yaml pair-all
+      ```
+      _MQTT_
+      ```
+      Topic: /insteon/command/modem
+      Payload: { "cmd" : "pair_all" }
+      ```
+
+3. __Refresh__ - This downloads the 1) device link database, if necessary; 2) model information, if necessary; 3) the current state (e.g. on/off); and 4) other relevant details from the device.  It may take a few seconds per device to complete all of these steps.
   - `force` - this flag will cause the link database of to be refreshed even if it appears that our cached data is current.
 
   >If the device state is updated as a result of a `refresh` command the [reason](reason.md) string will be set to 'refresh'
 
-  _Command Line_
-  ```
-  insteon-mqtt config.yaml refresh aa.bb.cc [--force]
-  ```
-
-  _MQTT_
-   ```
-   Topic: /insteon/command/aa.bb.cc
-   Payload: { "cmd" : "refresh", ["force" : true/false] }
-   ```
-
  > If you manually add links to the device (e.g. by using some other device such as an ISY, or by using the set buttons on the device) you will need to run `refresh` again so that Insteon-MQTT can learn about these links.
 
-4. __Refresh-All__ - This is the same as the `refresh` command but it will be run on all devices configured in your `config.yaml` file. It is useful when first setting up a new network. This may take a while and __battery devices__ (motion sensors, remotes, etc) __will be refreshed the next time they wake up, if possible__.
-  - `force` - this flag will cause the link database of to be refreshed even if it appears that our cached data is current.
+   - To refresh a __single device__ run `refresh`.
 
-  _Command Line_
-   ```
-   insteon-mqtt config.yaml refresh-all [--force]
-   ```
+    _Command Line_
+    ```
+    insteon-mqtt config.yaml refresh aa.bb.cc [--force]
+    ```
 
-  _MQTT_
-   ```
-   Topic: /insteon/command/modem
-   Payload: { "cmd" : "refresh_all", ["force" : true/false] }
-   ```
+    _MQTT_
+     ```
+     Topic: /insteon/command/aa.bb.cc
+     Payload: { "cmd" : "refresh", ["force" : true/false] }
+     ```
+
+   - To refresh __all__ devices run `refresh_all`.  This may be necesary when first setting up a network.  __This may take a while to complete__
+
+    _Command Line_
+     ```
+     insteon-mqtt config.yaml refresh-all [--force]
+     ```
+
+    _MQTT_
+     ```
+     Topic: /insteon/command/modem
+     Payload: { "cmd" : "refresh_all", ["force" : true/false] }
+     ```
 
 ## Scene Commands
 

--- a/docs/initializing.md
+++ b/docs/initializing.md
@@ -50,19 +50,18 @@ All of these functions are idempotent, they can be run multiple times without ca
 
  > If you manually add links to the device (e.g. by using some other device such as an ISY, or by using the set buttons on the device) you will need to run `refresh` again so that Insteon-MQTT can learn about these links.
 
-4. __Refresh-All__ - This is the same as the `refresh` command but it will be run on all devices configured in your `config.yaml` file. It is useful when first setting up a new network. This may take a while and __battery devices__ (motion sensors, remotes, etc) __will be skipped__ by default.
+4. __Refresh-All__ - This is the same as the `refresh` command but it will be run on all devices configured in your `config.yaml` file. It is useful when first setting up a new network. This may take a while and __battery devices__ (motion sensors, remotes, etc) __will be refreshed the next time they wake up, if possible__.
   - `force` - this flag will cause the link database of to be refreshed even if it appears that our cached data is current.
-  - `battery` - this flag will cause battery devices to be refreshed. If a battery device is not awake, the message will be queued.
 
   _Command Line_
    ```
-   insteon-mqtt config.yaml refresh-all [--force] [--battery]
+   insteon-mqtt config.yaml refresh-all [--force]
    ```
 
   _MQTT_
    ```
    Topic: /insteon/command/modem
-   Payload: { "cmd" : "refresh_all", ["battery" : true/false, "force" : true/false] }
+   Payload: { "cmd" : "refresh_all", ["force" : true/false] }
    ```
 
 ## Scene Commands

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -97,6 +97,11 @@ Supported: devices
 
 See [initialization](initializing.md) for a discussion of `join`.
 
+### Join all devices
+
+Supported: modem
+
+See [initialization](initializing.md) for a discussion of `join-all`.
 
 ### Pair a Device to the Modem
 
@@ -104,6 +109,11 @@ Supported: devices
 
 See [initialization](initializing.md) for a discussion of `pair`.
 
+### Pair all devices
+
+Supported: modem
+
+See [initialization](initializing.md) for a discussion of `pair-all`.
 
 ### Sync Device Links
 

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -214,11 +214,10 @@ data.
 Supported: modem
 
 This will cause a get_engine command to be sent to each device (i.e. devices
-defined in the config file).  If the battery flag is false or not present,
-battery operated devices will be skipped. The command payload is:
+defined in the config file).  The command payload is:
 
   ```
-  { "cmd" : "get_engine_all", ["battery": true/false]}
+  { "cmd" : "get_engine_all"}
   ```
 
 ### Add the device as a controller of another device.
@@ -725,8 +724,8 @@ speed payload template must convert the input message into the format
    ```
 
 Here is a sample configuration.  HomeAssistant starting in version 2021.4.0
-dropped support for the off/low/medium/high fan speeds.  See 
-[config-example.yaml](https://github.com/TD22057/insteon-mqtt/blob/master/config-example.yaml) 
+dropped support for the off/low/medium/high fan speeds.  See
+[config-example.yaml](https://github.com/TD22057/insteon-mqtt/blob/master/config-example.yaml)
 in the mqtt -> fan section for an example HomeAssistant config that works
 with InsteonMQTT.
 

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -83,6 +83,8 @@ class Modem:
             'refresh' : self.refresh,
             'refresh_all' : self.refresh_all,
             'get_engine_all' : self.get_engine_all,
+            'join_all' : self.join_all,
+            'pair_all' : self.pair_all,
             'get_model' : self.get_model,
             'linking' : self.linking,
             'scene' : self.scene,
@@ -429,8 +431,6 @@ class Modem:
         activity is expected on the network.
 
         Args:
-          battery (bool): If true, will scan battery devices as well, by
-                default they are skipped.
           force (bool):  Force flag passed to devices.  If True, devices
                 will refresh their Insteon db's even if they think the db
                 is up to date.
@@ -462,8 +462,6 @@ class Modem:
         this.
 
         Args:
-          battery (bool):  If True, will run on battery devices as well,
-                           defaults to skipping them.
           on_done:  Finished callback.  This is called when the command has
                     completed.  Signature is: on_done(success, msg, data)
         """
@@ -475,6 +473,52 @@ class Modem:
         # Reload all the device databases.
         for device in self.devices.values():
             seq.add(device.get_engine)
+
+        # Start the command sequence.
+        seq.run()
+
+    #-----------------------------------------------------------------------
+    def join_all(self, on_done=None):
+        """Call Join on all Devices
+
+        This calls join on all the devices.  This can take a little time.  It
+        is helpful when first setting up a network or replacing a PLM.
+
+        Args:
+          on_done:  Finished callback.  This is called when the command has
+                    completed.  Signature is: on_done(success, msg, data)
+        """
+        # Set the error stop to false so a failed join doesn't stop the
+        # sequence from trying to join other devices.
+        seq = CommandSeq(self, "Join all complete", on_done,
+                         error_stop=False, name="JoinAll")
+
+        # Join all the device databases.
+        for device in self.devices.values():
+            seq.add(device.join)
+
+        # Start the command sequence.
+        seq.run()
+
+    #-----------------------------------------------------------------------
+    def pair_all(self, on_done=None):
+        """Call Pair on all Devices
+
+        This calls pair on all the devices.  This can take a little time.  It
+        is helpful when first setting up a network or replacing a PLM.
+
+        Args:
+          on_done:  Finished callback.  This is called when the command has
+                    completed.  Signature is: on_done(success, msg, data)
+        """
+        # Set the error stop to false so a failed pair doesn't stop the
+        # sequence from trying to pair other devices.
+        seq = CommandSeq(self, "Pair all complete", on_done,
+                         error_stop=False, name="PairAll")
+
+        # Pair all the device databases.
+        for device in self.devices.values():
+            seq.add(device.pair)
 
         # Start the command sequence.
         seq.run()

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -420,7 +420,7 @@ class Modem:
         return device
 
     #-----------------------------------------------------------------------
-    def refresh_all(self, battery=False, force=False, on_done=None):
+    def refresh_all(self, force=False, on_done=None):
         """Refresh all the all link databases.
 
         This forces a refresh of the modem and device databases.  This can
@@ -447,18 +447,13 @@ class Modem:
 
         # Reload all the device databases.
         for device in self.devices.values():
-            if not battery and isinstance(device, (DevClass.BatterySensor,
-                                                   DevClass.Leak,
-                                                   DevClass.Remote)):
-                LOG.ui("Refresh all, skipping battery device %s", device.label)
-                continue
             seq.add(device.refresh, force)
 
         # Start the command sequence.
         seq.run()
 
     #-----------------------------------------------------------------------
-    def get_engine_all(self, battery=False, on_done=None):
+    def get_engine_all(self, on_done=None):
         """Run Get Engine on all the devices, except Modem
 
         Devices are assumed to be i2cs, which all new devices are.  If you
@@ -479,12 +474,6 @@ class Modem:
 
         # Reload all the device databases.
         for device in self.devices.values():
-            if not battery and isinstance(device, (DevClass.BatterySensor,
-                                                   DevClass.Leak,
-                                                   DevClass.Remote)):
-                LOG.ui("Get engine all, skipping battery device %s",
-                       device.label)
-                continue
             seq.add(device.get_engine)
 
         # Start the command sequence.
@@ -1155,18 +1144,8 @@ class Modem:
           { 'cmd' : 'COMMAND', ...args }
 
         where COMMAND is the command name and any additional arguments to the
-        command are other dictionary keywords.  Valid commands are:
-
-          getdb:  No arguments.  Download the PLM modem all link database
-                  and save it to file.
-
-          reload_all: No arguments.  Reloads the modem database and tells
-                      every device to reload it's database as well.
-
-          factory_reset: No arguments.  Full factory reset of the modem.
-
-          set_btn: Optional time_out argument (in seconds).  Simulates pressing
-                   the modem set button to put the modem in linking mode.
+        command are other dictionary keywords.  Valid commands are defined in
+        self.cmd_map.
 
         Args:
           kwargs:  Command dictionary containing the arguments.

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -42,9 +42,6 @@ def parse_args(args):
                         "in the configuration.")
     sp.add_argument("-f", "--force", action="store_true",
                     help="Force the modem/device database to be downloaded.")
-    sp.add_argument("--battery", action="store_true",
-                    help="Refresh battery devices too, by default they are "
-                    "skipped.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=modem.refresh_all)
@@ -79,9 +76,6 @@ def parse_args(args):
     # modem.get_engine_all command
     sp = sub.add_parser("get-engine-all", help="Call get-engine on the "
                         "devices in the configuration.")
-    sp.add_argument("--battery", action="store_true",
-                    help="Run get-engine on battery devices too, by default "
-                         "they are skipped.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=modem.get_engine_all)

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -81,6 +81,22 @@ def parse_args(args):
     sp.set_defaults(func=modem.get_engine_all)
 
     #---------------------------------------
+    # modem.join_all command
+    sp = sub.add_parser("join-all", help="Call join all on the devices "
+                        "in the configuration.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=modem.join_all)
+
+    #---------------------------------------
+    # modem.pair_all command
+    sp = sub.add_parser("pair-all", help="Call pair all on the devices "
+                        "in the configuration.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=modem.pair_all)
+
+    #---------------------------------------
     # modem.factory_reset command
     sp = sub.add_parser("factory-reset", help="Perform a remote factory "
                         "reset.  Currently only supported on the modem.")

--- a/insteon_mqtt/cmd_line/modem.py
+++ b/insteon_mqtt/cmd_line/modem.py
@@ -11,7 +11,6 @@ def refresh_all(args, config):
     topic = "%s/modem" % (args.topic)
     payload = {
         "cmd" : "refresh_all",
-        "battery" : args.battery,
         "force" : args.force,
         }
 
@@ -49,7 +48,6 @@ def get_engine_all(args, config):
     topic = "%s/modem" % (args.topic)
     payload = {
         "cmd" : "get_engine_all",
-        "battery" : args.battery,
         }
 
     reply = util.send(config, topic, payload, args.quiet)

--- a/insteon_mqtt/cmd_line/modem.py
+++ b/insteon_mqtt/cmd_line/modem.py
@@ -53,6 +53,25 @@ def get_engine_all(args, config):
     reply = util.send(config, topic, payload, args.quiet)
     return reply["status"]
 
+#===========================================================================
+def join_all(args, config):
+    topic = "%s/modem" % (args.topic)
+    payload = {
+        "cmd" : "join_all",
+        }
+
+    reply = util.send(config, topic, payload, args.quiet)
+    return reply["status"]
+
+#===========================================================================
+def pair_all(args, config):
+    topic = "%s/modem" % (args.topic)
+    payload = {
+        "cmd" : "pair_all",
+        }
+
+    reply = util.send(config, topic, payload, args.quiet)
+    return reply["status"]
 
 #===========================================================================
 def factory_reset(args, config):

--- a/tests/cmd_line/test_modem.py
+++ b/tests/cmd_line/test_modem.py
@@ -18,7 +18,6 @@ class Test_modem:
         assert call[1] == topic
         assert call[2]["cmd"] == cmd
         assert call[2]["force"] == args.force
-        assert call[2]["battery"] == args.battery
         assert call[3] == args.quiet
 
     #-----------------------------------------------------------------------
@@ -26,7 +25,7 @@ class Test_modem:
         mocker.patch('insteon_mqtt.cmd_line.util.send')
         IM.cmd_line.util.send.return_value = {"status" : 10}
 
-        args = Data(topic="cmd_topic", force=False, quiet=True, battery=True)
+        args = Data(topic="cmd_topic", force=False, quiet=True)
         config = Data(a=1, b=2)
 
         r = IM.cmd_line.modem.refresh_all(args, config)


### PR DESCRIPTION
## Feature Removed
The "skip battery devices" option was removed from the `refresh_all` and `get_engine_all` commands as it is no longer necessary.  Messages sent to battery devices are automatically queued for the next time they wake up.  Removing this simplifies things for users.

## Proposed change
Adds `join_all` and `pair_all` commands.  Self explanatory.

## Additional information
- This PR fixes or closes issue: closes #380

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Code documentation was added where necessary
- [x] Documentation added/updated
