### PR TITLE
Discovery Tweaks After Initial Usage

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1212,7 +1212,7 @@ mqtt:
         config: |-
           {
             "uniq_id": "{{address}}_fan",
-            "name": "{{name_user_case}} thermo",
+            "name": "{{name_user_case}} fan",
             "device": {{device_info_template}},
             "cmd_t": "{{fan_on_off_topic}}",
             "pct_cmd_t": "{{fan_speed_set_topic}}",

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1421,7 +1421,7 @@ mqtt:
             "name": "{{name_user_case}} btn 2",
             "device": {{device_info_template}},
             "cmd_t": "{{btn_on_off_topic_2}}",
-            "stat_t": "{{btn_on_off_topic_2}}",
+            "stat_t": "{{btn_on_off_topic_2}}"
           }
       - component: 'switch'
         config: |-
@@ -1430,7 +1430,7 @@ mqtt:
             "name": "{{name_user_case}} btn 3",
             "device": {{device_info_template}},
             "cmd_t": "{{btn_on_off_topic_3}}",
-            "stat_t": "{{btn_on_off_topic_3}}",
+            "stat_t": "{{btn_on_off_topic_3}}"
           }
       - component: 'switch'
         config: |-
@@ -1439,7 +1439,7 @@ mqtt:
             "name": "{{name_user_case}} btn 4",
             "device": {{device_info_template}},
             "cmd_t": "{{btn_on_off_topic_4}}",
-            "stat_t": "{{btn_on_off_topic_4}}",
+            "stat_t": "{{btn_on_off_topic_4}}"
           }
       - component: 'switch'
         config: |-
@@ -1448,7 +1448,7 @@ mqtt:
             "name": "{{name_user_case}} btn 5",
             "device": {{device_info_template}},
             "cmd_t": "{{btn_on_off_topic_5}}",
-            "stat_t": "{{btn_on_off_topic_5}}",
+            "stat_t": "{{btn_on_off_topic_5}}"
           }
       - component: 'switch'
         config: |-
@@ -1457,7 +1457,7 @@ mqtt:
             "name": "{{name_user_case}} btn 6",
             "device": {{device_info_template}},
             "cmd_t": "{{btn_on_off_topic_6}}",
-            "stat_t": "{{btn_on_off_topic_6}}",
+            "stat_t": "{{btn_on_off_topic_6}}"
           }
       - component: 'switch'
         config: |-
@@ -1466,7 +1466,7 @@ mqtt:
             "name": "{{name_user_case}} btn 7",
             "device": {{device_info_template}},
             "cmd_t": "{{btn_on_off_topic_7}}",
-            "stat_t": "{{btn_on_off_topic_7}}",
+            "stat_t": "{{btn_on_off_topic_7}}"
           }
       - component: 'switch'
         config: |-
@@ -1475,7 +1475,7 @@ mqtt:
             "name": "{{name_user_case}} btn 8",
             "device": {{device_info_template}},
             "cmd_t": "{{btn_on_off_topic_8}}",
-            "stat_t": "{{btn_on_off_topic_8}}",
+            "stat_t": "{{btn_on_off_topic_8}}"
           }
       - component: 'switch'
         config: |-
@@ -1484,7 +1484,7 @@ mqtt:
             "name": "{{name_user_case}} btn 9",
             "device": {{device_info_template}},
             "cmd_t": "{{btn_on_off_topic_9}}",
-            "stat_t": "{{btn_on_off_topic_9}}",
+            "stat_t": "{{btn_on_off_topic_9}}"
           }
 
   #------------------------------------------------------------------------

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -291,7 +291,7 @@ mqtt:
     #  {{scene}} - will be replaced with the scene number of the scene.
     #  {{scene_name}} - will be replaced with the name of the scene as defined
     #                   in a scenes.yaml file if used.
-    #  {{scene_topic}} - will be replaced by the scene topic for this scene.
+    #  {{scene_topic}} - is the modem scene topic
     #
     # Only scenes that appear in the GroupMap list when printing the modem db
     # will be included.  These are the only scenes for which the modem is

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -759,7 +759,7 @@ mqtt:
           {
             "uniq_id": "{{address}}_wet",
             "name": "{{name_user_case}} leak",
-            "stat_t": "{{state_topic}}",
+            "stat_t": "{{wet_dry_topic}}",
             "device_class": "moisture",
             "device": {{device_info_template}}
           }

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -274,7 +274,7 @@ mqtt:
     #   json = the input payload converted to json.  Use json.VAR to extract
     #          a variable from a json payload.
     scene_topic: 'insteon/modem/scene'
-    scene_payload: '{ "cmd" : "{{json.cmd.lower()}}",
+    scene_payload: '{ "cmd" : "{{json.state.lower()}}",
                       "group" : {{json.group}}
                     }'
 
@@ -483,7 +483,7 @@ mqtt:
     # in the same way clicking the button would.  The inputs are the same as
     # those for the on_off topic and payload.
     scene_topic: 'insteon/{{address}}/scene'
-    scene_payload: '{ "cmd" : "{{json.cmd.lower()}}"
+    scene_payload: '{ "cmd" : "{{json.state.lower()}}"
                       {% if json.brightness is defined %}
                           , "level" : {{json.brightness}}
                       {% endif %}
@@ -631,15 +631,6 @@ mqtt:
             "name": "{{name_user_case}} battery",
             "stat_t": "{{low_battery_topic}}",
             "device_class": "battery",
-            "device": {{device_info_template}}
-          }
-      - component: 'sensor'
-        config: |-
-          {
-            "uniq_id": "{{address}}_heartbeat",
-            "name": "{{name_user_case}} heartbeat",
-            "stat_t": "{{heartbeat_topic}}",
-            "device_class": "timestamp",
             "device": {{device_info_template}}
           }
       - component: 'binary_sensor'
@@ -893,15 +884,6 @@ mqtt:
             "device_class": "battery",
             "device": {{device_info_template}}
           }
-      - component: 'sensor'
-        config: |-
-          {
-            "uniq_id": "{{address}}_heartbeat",
-            "name": "{{name_user_case}} heartbeat",
-            "stat_t": "{{heartbeat_topic}}",
-            "device_class": "timestamp",
-            "device": {{device_info_template}}
-          }
 
   #------------------------------------------------------------------------
   # Smoke Bridge
@@ -1028,10 +1010,10 @@ mqtt:
     #   fan_mode = "on", "off"
     #   is_fan_on = 0/1
     fan_state_topic: 'insteon/{{address}}/fan_state'
-    fan_state_payload: '{{fan_mode.upper()}}'
+    fan_state_payload: '{{fan_mode.lower()}}'
     #   mode = 'off', 'auto', 'heat', 'cool', 'program'
     mode_state_topic: 'insteon/{{address}}/mode_state'
-    mode_state_payload: '{{mode.upper()}}'
+    mode_state_payload: '{{mode.lower()}}'
     #   humid = humidity percentage
     humid_state_topic: 'insteon/{{address}}/humid_state'
     humid_state_payload: '{{humid}}'
@@ -1039,7 +1021,7 @@ mqtt:
     #   is_heating = 0/1
     #   is_cooling = 0/1
     status_state_topic: 'insteon/{{address}}/status_state'
-    status_state_payload: '{{status.upper()}}'
+    status_state_payload: '{{status.lower()}}'
     # Caution, there is no push update for the hold or energy state.  ie, if
     # you press hold on the physical device, you will not get any notice of
     # this unless you run get_status().  There is also no way to programatically
@@ -1047,12 +1029,12 @@ mqtt:
     #   hold_str = 'off', 'temp'
     #   is_hold = 0/1
     hold_state_topic: 'insteon/{{address}}/hold_state'
-    hold_state_payload: '{{hold_str.upper()}}'
+    hold_state_payload: '{{hold_str.lower()}}'
     # See caution in hold state above
     #   energy_str = 'off', 'on'
     #   is_energy = 0/1
     energy_state_topic: 'insteon/{{address}}/energ_state'
-    energy_state_payload: '{{energy_str.upper()}}'
+    energy_state_payload: '{{energy_str.lower()}}'
 
     # Command Topics
     # Available variables for templating all of these commands are:
@@ -1527,7 +1509,7 @@ mqtt:
     #   sensor_on_str = 'off'/'on'
     #   relay_on_str = 'off'/'on'
     state_topic: 'insteon/{{address}}/state'
-    state_payload: '{ "sensor" : "{{sensor_on_str.upper()}}", "relay" : {{relay_on_str.upper()}} }'
+    state_payload: '{ "sensor" : "{{sensor_on_str.lower()}}", "relay" : {{relay_on_str.lower()}} }'
 
     # Output relay state change topic and template.  This message is sent
     # whenever the device relay state changes.  Available variables for
@@ -1537,7 +1519,7 @@ mqtt:
     #   relay_on = 0/1
     #   relay_on_str = 'off'/'on'
     relay_state_topic: 'insteon/{{address}}/relay'
-    relay_state_payload: '{{relay_on_str.upper()}}'
+    relay_state_payload: '{{relay_on_str.lower()}}'
 
     # Output sensor state change topic and template.  This message is sent
     # whenever the device sensor state changes.  Available variables for
@@ -1547,7 +1529,7 @@ mqtt:
     #   sensor_on = 0/1
     #   sensor_on = 'off'/'on'
     sensor_state_topic: 'insteon/{{address}}/sensor'
-    sensor_state_payload: '{{sensor_on_str.upper()}}'
+    sensor_state_payload: '{{sensor_on_str.lower()}}'
 
     # Input on/off command.  This forces the relay on/off and ignores the
     # momentary-A,B,C setting.  Use this to force the relay to respond.

--- a/insteon_mqtt/mqtt/Modem.py
+++ b/insteon_mqtt/mqtt/Modem.py
@@ -5,7 +5,7 @@
 #===========================================================================
 from .. import log
 from . import topic
-from . import MsgTemplate
+from .MsgTemplate import MsgTemplate
 LOG = log.get_logger()
 
 

--- a/insteon_mqtt/mqtt/Modem.py
+++ b/insteon_mqtt/mqtt/Modem.py
@@ -50,11 +50,6 @@ class Modem(topic.SceneTopic, topic.DiscoveryTopic):
 
         self.load_scene_data(data, qos)
 
-        # Strip out the scene_topic, it is used in a different manner in the
-        # modem and is generated below in publish_discovery()
-        if 'scene_topic' in self.rendered_topic_map:
-            del self.rendered_topic_map['scene_topic']
-
     #-----------------------------------------------------------------------
     def subscribe(self, link, qos):
         """Subscribe to any MQTT topics the object needs.

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -47,6 +47,10 @@ class DiscoveryTopic(BaseTopic):
           config (dict):  The mqtt section of the config dict.
           qos (int):  The default quality of service level to use.
         """
+        # Skip is discovery not enabled
+        if not self.mqtt.discovery_enabled:
+            return
+
         # Get the device specific discovery class
         disc_class = self.device.config_extra.get('discovery_class',
                                                   self.default_discovery_cls)

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -137,6 +137,9 @@ class DiscoveryTopic(BaseTopic):
         # Set up the variables that can be used in the templates.
         data = self.base_template_data(**kwargs)
 
+        # Remove periods from address
+        data['address'] = data['address'].replace(".", "_")
+
         # Insert Topics from topic classes
         data.update(self.rendered_topic_map)
 

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -90,7 +90,7 @@ class DiscoveryTopic(BaseTopic):
             topic_base = self.mqtt.discovery_topic_base
             default_topic = "%s/%s/%s/%s/config" % (topic_base,
                                                     component,
-                                                    self.device.addr.hex,
+                                                    self.device.addr.hex.replace(".", "_"),
                                                     unique_id)
             topic = entity.get('topic', default_topic)
             self.disc_templates.append(MsgTemplate(topic=topic,

--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -3,6 +3,7 @@
 # MQTT Discovery Topic
 #
 #===========================================================================
+import re
 import json
 import jinja2
 from ... import log
@@ -80,20 +81,25 @@ class DiscoveryTopic(BaseTopic):
                           self.device.label, entity)
                 continue
 
-            # Allowing topic to be settable in yaml, but I don't think users
-            # should worry about this, there is no utility in changing it
+            # Get Unique ID from payload to use in topic
             unique_id = self._get_unique_id(payload)
             if unique_id is None:
                 LOG.error("%s - Error getting unique_id, skipping entry",
                           self.device.label)
                 continue
+
+            # HA's implementation of discovery only allows a very limited
+            # range of characters in the node_id and object_id fields.
+            # See line #30 of /homeassistant/components/mqtt/discovery.py
+            # Replace any not-allowed character with underscore
             topic_base = self.mqtt.discovery_topic_base
+            address_safe = re.sub(r'[^a-zA-Z0-9_-]', '_', self.device.addr.hex)
+            unique_id_safe = re.sub(r'[^a-zA-Z0-9_-]', '_', unique_id)
             default_topic = "%s/%s/%s/%s/config" % (topic_base,
                                                     component,
-                                                    self.device.addr.hex.replace(".", "_"),
-                                                    unique_id)
-            topic = entity.get('topic', default_topic)
-            self.disc_templates.append(MsgTemplate(topic=topic,
+                                                    address_safe,
+                                                    unique_id_safe)
+            self.disc_templates.append(MsgTemplate(topic=default_topic,
                                                    payload=payload,
                                                    qos=qos,
                                                    retain=False))
@@ -136,9 +142,6 @@ class DiscoveryTopic(BaseTopic):
         """
         # Set up the variables that can be used in the templates.
         data = self.base_template_data(**kwargs)
-
-        # Remove periods from address
-        data['address'] = data['address'].replace(".", "_")
 
         # Insert Topics from topic classes
         data.update(self.rendered_topic_map)

--- a/tests/mqtt/test_Modem.py
+++ b/tests/mqtt/test_Modem.py
@@ -103,7 +103,9 @@ class Test_Modem:
         # Modem with no scenes should have no discovery topics
         mdev.load_config({"modem": {"junk": "junk"}})
         assert mdev.default_discovery_cls == "modem"
-        assert mdev.rendered_topic_map == {}
+        assert mdev.rendered_topic_map == {
+            'scene_topic': 'insteon/modem/scene'
+        }
         assert len(mdev.extra_topic_nums) == 0
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/topic/test_DiscoveryTopic.py
+++ b/tests/mqtt/topic/test_DiscoveryTopic.py
@@ -70,7 +70,7 @@ class Test_DiscoveryTopic:
             "config": '{"unique_id": "unique"}'
         }]}
         discovery.load_discovery_data(config)
-        expected_topic = "homeassistant/switch/11.22.33/unique/config"
+        expected_topic = "homeassistant/switch/11_22_33/unique/config"
         assert discovery.disc_templates[0].topic_str == expected_topic
         discovery.disc_templates = []
 
@@ -80,7 +80,7 @@ class Test_DiscoveryTopic:
             "config": '{"uniq_id": "unique2"}'
         }]}
         discovery.load_discovery_data(config)
-        expected_topic = "homeassistant/switch/11.22.33/unique2/config"
+        expected_topic = "homeassistant/switch/11_22_33/unique2/config"
         assert discovery.disc_templates[0].topic_str == expected_topic
         discovery.disc_templates = []
 
@@ -90,7 +90,7 @@ class Test_DiscoveryTopic:
             "config": "{'no_single': 'quotes'}"
         }]}
         discovery.load_discovery_data(config)
-        expected_topic = "homeassistant/switch/11.22.33/unique2/config"
+        expected_topic = "homeassistant/switch/11_22_33/unique2/config"
         assert 'Error parsing config as json' in caplog.text
         caplog.clear()
 
@@ -100,7 +100,7 @@ class Test_DiscoveryTopic:
             "config": "{% if bad_format = 1 %}"
         }]}
         discovery.load_discovery_data(config)
-        expected_topic = "homeassistant/switch/11.22.33/unique2/config"
+        expected_topic = "homeassistant/switch/11_22_33/unique2/config"
         assert 'Error rendering config template' in caplog.text
         caplog.clear()
 

--- a/tests/mqtt/topic/test_DiscoveryTopic.py
+++ b/tests/mqtt/topic/test_DiscoveryTopic.py
@@ -31,6 +31,7 @@ class Test_DiscoveryTopic:
     #-----------------------------------------------------------------------
     def test_load_discovery_data(self, discovery, caplog):
         # This also fully tests _get_unique_id()
+        discovery.mqtt.discovery_enabled = True
 
         # test lack of discovery class
         config = {}


### PR DESCRIPTION
## Proposed change
These are a few small fixes to the Discovery platform that I found while setting it up.
1. HomeAssistant does not allow periods in the node_id or the object_id in the topic.  They only allow a small set of characters.  This does not carry through to things in the payload.  Solved this by changing any out of bounds characters to underscore.
2. The logic in loading the modem discovery topics was flawed.  This fixes it.
3. Some other small fixes to the suggested config.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary