### PR TITLE
Save DB Delta to File on Refresh Complete

### DIFF
--- a/insteon_mqtt/handler/DeviceRefresh.py
+++ b/insteon_mqtt/handler/DeviceRefresh.py
@@ -111,6 +111,7 @@ class DeviceRefresh(Base):
                     def on_done(success, message, data):
                         if success:
                             self.device.db.delta = msg.cmd1
+                            self.device.db.save()
                             LOG.ui("%s database download complete\n%s",
                                    self.addr, self.device.db)
                         self.on_done(success, message, data)


### PR DESCRIPTION
## Proposed change
We were only saving to the variable and not pushing to the file which could cause a false `out-of-date` response after a restart.

This calls save after a successful refresh a simple one-liner.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
