### PR TITLE
Add Timestamp as a Templating Variable

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -244,7 +244,8 @@ mqtt:
     # Output state change topic and template.  This message is sent whenever
     # the device state changes for any reason.  Available variables for
     # templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
     #   on_str = 'off'/'on'
@@ -307,7 +308,8 @@ mqtt:
     # Output state change topic and payload.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
     #   on_str = 'off'/'on'
@@ -337,7 +339,8 @@ mqtt:
     #   { "cmd" : "on"/"off", ["mode" : 'normal'/'fast'/'instant'],
     #             ["fast" : 1/0], ["instant" : 1/0], ["reason" : "..."] }
     # Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
     #   json = the input payload converted to json.  Use json.VAR to extract
@@ -359,7 +362,8 @@ mqtt:
     # where:
     #   LEVEL = 0->255 dimmer level
     # Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
     #   json = the input payload converted to json.  Use json.VAR to extract
@@ -407,7 +411,8 @@ mqtt:
     # Output state change topic and payload.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
     #   on_str = 'off'/'on'
@@ -417,7 +422,8 @@ mqtt:
     # Output low battery topic and payload.  This message is sent
     # whenever the device detects a low battery. Available variables
     # for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   is_low = 0/1
     #   is_low_str = 'off'/'on'
@@ -426,7 +432,8 @@ mqtt:
 
     # Output heartbeat topic and payload.  This message is sent
     # every 24 hours. Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   is_heartbeat = 0/1
     #   heartbeat_time = UNIX time float of the last heartbeat
@@ -453,7 +460,8 @@ mqtt:
     # Output dawn/dusk change topic and payload.  This message is sent
     # whenever the device light sensor detects dawn or dusk changes.
     # Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   is_dawn = 0/1
     #   is_dawn_str = 'off'/'on'
@@ -482,7 +490,8 @@ mqtt:
     # whenever the device is polled and a new voltage, low battery voltage
     # or heart beat interval is obtained from the device.
     # Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   batt_volt = raw insteon voltage level
 
@@ -514,7 +523,8 @@ mqtt:
     # Output wet/dry change topic and payload.  This message is sent
     # whenever the device changes state to wet or dry.
     # Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   is_wet = 0/1
     #   is_wet_str = 'off'/'on'
@@ -536,7 +546,8 @@ mqtt:
   remote:
     # Output state change topic and template.  This message is sent
     # whenever a button is pressed.  Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   button = 1...n  (button number 1-8 depending on configuration)
     #   on = 0/1
@@ -584,7 +595,8 @@ mqtt:
     # Output state change topic and payload.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
     #   on_str = 'off'/'on'
@@ -628,7 +640,8 @@ mqtt:
   thermostat:
     # Output state change topic and payload.  Available variables for
     # templating in all cases are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     # The following specific variables only apply to the topics listed
     # directly below
@@ -671,7 +684,8 @@ mqtt:
 
     # Command Topics
     # Available variables for templating all of these commands are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
     #   json = the input payload converted to json.  Use json.VAR to extract
@@ -743,7 +757,8 @@ mqtt:
     # Output fan state change topic and payload.  This message is sent
     # whenever the fan state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
     #   on_str = 'off'/'on'
@@ -759,7 +774,8 @@ mqtt:
     # through the template must match the following:
     #   { "cmd" : "on"/"off", ["reason" : "..."] }
     # Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
     #   json = the input payload converted to json.  Use json.VAR to extract
@@ -782,7 +798,8 @@ mqtt:
     #   SPEED = 0/1/2/3 (for off, low, medium, high)
     #      or = "off"/"low"/"medium"/"high"
     # Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
     #   json = the input payload converted to json.  Use json.VAR to extract
@@ -832,7 +849,8 @@ mqtt:
     # On/off switch state change topic and template.  This message is sent
     # whenever one of the on/off buttons is pressed.  It will not be sent for
     # button 1 if it's a dimmer.  Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   button = 1-8
     #   on = 0/1
@@ -847,7 +865,8 @@ mqtt:
     # Dimmer output state change topic and payload for button 1.  This
     # message is sent whenever the device dimmer state changes for any
     # reason.  Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
     #   on_str = 'off'/'on'
@@ -898,7 +917,8 @@ mqtt:
     # where:
     #   LEVEL = 0->255 dimmer level
     # Available variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
     #   json = the input payload converted to json.  Use json.VAR to extract
@@ -964,7 +984,8 @@ mqtt:
     # Output state change topic and template.  This message is sent whenever
     # the device sensor or device relay state changes.  Available variables for
     # templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   sensor_on = 0/1
     #   relay_on = 0/1
@@ -976,7 +997,8 @@ mqtt:
     # Output relay state change topic and template.  This message is sent
     # whenever the device relay state changes.  Available variables for
     # templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   relay_on = 0/1
     #   relay_on_str = 'off'/'on'
@@ -986,7 +1008,8 @@ mqtt:
     # Output sensor state change topic and template.  This message is sent
     # whenever the device sensor state changes.  Available variables for
     # templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   sensor_on = 0/1
     #   sensor_on = 'off'/'on'
@@ -1026,7 +1049,8 @@ mqtt:
     # Output state change topic and template.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   button = 1 (top outlet) or 2 (bottom outlet)
     #   on = 0/1
@@ -1071,7 +1095,8 @@ mqtt:
     # Output state change topic and template.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa.bb.cc'
+    #   address = 'aa\.bb\.cc'
+    #   timestamp = the current timestamp
     #   name = 'device name'
     #   button = 1 to 4 (relay number)
     #   on = 0/1

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -244,7 +244,7 @@ mqtt:
     # Output state change topic and template.  This message is sent whenever
     # the device state changes for any reason.  Available variables for
     # templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
@@ -308,7 +308,7 @@ mqtt:
     # Output state change topic and payload.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
@@ -339,7 +339,7 @@ mqtt:
     #   { "cmd" : "on"/"off", ["mode" : 'normal'/'fast'/'instant'],
     #             ["fast" : 1/0], ["instant" : 1/0], ["reason" : "..."] }
     # Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
@@ -362,7 +362,7 @@ mqtt:
     # where:
     #   LEVEL = 0->255 dimmer level
     # Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
@@ -411,7 +411,7 @@ mqtt:
     # Output state change topic and payload.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
@@ -422,7 +422,7 @@ mqtt:
     # Output low battery topic and payload.  This message is sent
     # whenever the device detects a low battery. Available variables
     # for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   is_low = 0/1
@@ -432,7 +432,7 @@ mqtt:
 
     # Output heartbeat topic and payload.  This message is sent
     # every 24 hours. Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   is_heartbeat = 0/1
@@ -460,7 +460,7 @@ mqtt:
     # Output dawn/dusk change topic and payload.  This message is sent
     # whenever the device light sensor detects dawn or dusk changes.
     # Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   is_dawn = 0/1
@@ -490,7 +490,7 @@ mqtt:
     # whenever the device is polled and a new voltage, low battery voltage
     # or heart beat interval is obtained from the device.
     # Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   batt_volt = raw insteon voltage level
@@ -523,7 +523,7 @@ mqtt:
     # Output wet/dry change topic and payload.  This message is sent
     # whenever the device changes state to wet or dry.
     # Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   is_wet = 0/1
@@ -546,7 +546,7 @@ mqtt:
   remote:
     # Output state change topic and template.  This message is sent
     # whenever a button is pressed.  Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   button = 1...n  (button number 1-8 depending on configuration)
@@ -595,7 +595,7 @@ mqtt:
     # Output state change topic and payload.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
@@ -640,7 +640,7 @@ mqtt:
   thermostat:
     # Output state change topic and payload.  Available variables for
     # templating in all cases are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     # The following specific variables only apply to the topics listed
@@ -684,7 +684,7 @@ mqtt:
 
     # Command Topics
     # Available variables for templating all of these commands are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
@@ -739,7 +739,7 @@ mqtt:
   #       {% elif value < 75 %}
   #         medium
   #       {% else %}
-  #         high 
+  #         high
   #       {% endif %}
   #     percentage_state_topic: 'insteon/aa.bb.cc/fan/speed/state'
   #     percentage_value_template: >
@@ -757,7 +757,7 @@ mqtt:
     # Output fan state change topic and payload.  This message is sent
     # whenever the fan state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
@@ -774,7 +774,7 @@ mqtt:
     # through the template must match the following:
     #   { "cmd" : "on"/"off", ["reason" : "..."] }
     # Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
@@ -798,7 +798,7 @@ mqtt:
     #   SPEED = 0/1/2/3 (for off, low, medium, high)
     #      or = "off"/"low"/"medium"/"high"
     # Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
@@ -849,7 +849,7 @@ mqtt:
     # On/off switch state change topic and template.  This message is sent
     # whenever one of the on/off buttons is pressed.  It will not be sent for
     # button 1 if it's a dimmer.  Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   button = 1-8
@@ -865,7 +865,7 @@ mqtt:
     # Dimmer output state change topic and payload for button 1.  This
     # message is sent whenever the device dimmer state changes for any
     # reason.  Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   on = 0/1
@@ -917,7 +917,7 @@ mqtt:
     # where:
     #   LEVEL = 0->255 dimmer level
     # Available variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   value = the input payload
@@ -984,7 +984,7 @@ mqtt:
     # Output state change topic and template.  This message is sent whenever
     # the device sensor or device relay state changes.  Available variables for
     # templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   sensor_on = 0/1
@@ -997,7 +997,7 @@ mqtt:
     # Output relay state change topic and template.  This message is sent
     # whenever the device relay state changes.  Available variables for
     # templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   relay_on = 0/1
@@ -1008,7 +1008,7 @@ mqtt:
     # Output sensor state change topic and template.  This message is sent
     # whenever the device sensor state changes.  Available variables for
     # templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   sensor_on = 0/1
@@ -1049,7 +1049,7 @@ mqtt:
     # Output state change topic and template.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   button = 1 (top outlet) or 2 (bottom outlet)
@@ -1095,7 +1095,7 @@ mqtt:
     # Output state change topic and template.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
-    #   address = 'aa\.bb\.cc'
+    #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp
     #   name = 'device name'
     #   button = 1 to 4 (relay number)

--- a/insteon_mqtt/mqtt/topic/BaseTopic.py
+++ b/insteon_mqtt/mqtt/topic/BaseTopic.py
@@ -3,6 +3,7 @@
 # MQTT Base Topic
 #
 #===========================================================================
+import time
 from ... import log
 
 LOG = log.get_logger()
@@ -26,7 +27,7 @@ class BaseTopic:
         """Create the Jinja templating data variables for use in topics.
 
         As the base template, this provides the immutable values such as
-        address and name.
+        address, name, and timestamp.
 
         Args:
           button (int):  The button (group) ID (1-8) of the Insteon button
@@ -36,7 +37,8 @@ class BaseTopic:
           dict:  Returns a dict with the variables available for templating.
         """
         data = {"address" : self.device.addr.hex,
-                "name" : self.device.addr.hex}
+                "name" : self.device.addr.hex,
+                "timestamp": int(time.time())}
         if self.device.name:
             data['name'] = self.device.name
         if 'button' in kwargs and kwargs['button'] is not None:

--- a/tests/mqtt/test_BatterySensor.py
+++ b/tests/mqtt/test_BatterySensor.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -56,12 +57,15 @@ class Test_BatterySensor:
 
         data = mdev.template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.template_data(is_on=True, is_low=False)
         right = {"address" : addr.hex, "name" : name,
                  "on" : 1, "on_str" : "on",
                  "is_low" : 0, "is_low_str" : "off"}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_Dimmer.py
+++ b/tests/mqtt/test_Dimmer.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -68,6 +69,8 @@ class Test_Dimmer:
 
         data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(level=0x55, mode=IM.on_off.Mode.FAST,
@@ -78,6 +81,7 @@ class Test_Dimmer:
                  "level_255" : 85, "level_100" : 33,
                  "mode" : "fast", "fast" : 1, "instant" : 0,
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(level=0x00)
@@ -85,12 +89,14 @@ class Test_Dimmer:
                  "on" : 0, "on_str" : "off", "reason" : "",
                  "level_255" : 0, "level_100" : 0,
                  "mode" : "normal", "fast" : 0, "instant" : 0}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(manual=IM.on_off.Manual.UP,
                                         reason="foo")
         right = {"address" : addr.hex, "name" : name, "reason" : "foo",
                  "manual_str" : "up", "manual" : 1, "manual_openhab" : 2}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_EZIO4O.py
+++ b/tests/mqtt/test_EZIO4O.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -81,6 +82,8 @@ class Test_EZIO4O:
 
         data = mdev.base_template_data()
         right = {"address": addr.hex, "name": name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(
@@ -97,6 +100,7 @@ class Test_EZIO4O:
             "fast": 1,
             "instant": 0,
         }
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(is_on=False, button=2)
@@ -111,6 +115,7 @@ class Test_EZIO4O:
             "fast": 0,
             "instant": 0,
         }
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(is_on=False, button=3)
@@ -125,6 +130,7 @@ class Test_EZIO4O:
             "fast": 0,
             "instant": 0,
         }
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(is_on=False, button=4)
@@ -139,6 +145,7 @@ class Test_EZIO4O:
             "fast": 0,
             "instant": 0,
         }
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_FanLinc.py
+++ b/tests/mqtt/test_FanLinc.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -72,6 +73,8 @@ class Test_FanLinc:
 
         data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(level=0x55, mode=IM.on_off.Mode.FAST,
@@ -82,6 +85,7 @@ class Test_FanLinc:
                  "level_255" : 85, "level_100" : 33,
                  "mode" : "fast", "fast" : 1, "instant" : 0,
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(level=0x00)
@@ -89,11 +93,13 @@ class Test_FanLinc:
                  "on" : 0, "on_str" : "off", "reason" : "",
                  "level_255" : 0, "level_100" : 0,
                  "mode" : "normal", "fast" : 0, "instant" : 0}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(manual=IM.on_off.Manual.UP)
         right = {"address" : addr.hex, "name" : name, "reason" : "",
                  "manual_str" : "up", "manual" : 1, "manual_openhab" : 2}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------
@@ -102,30 +108,36 @@ class Test_FanLinc:
 
         data = mdev.fan_template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.fan_template_data(level=dev.Speed.OFF, reason="hello")
         right = {"address" : addr.hex, "name" : name,
                  "on" : 0, "on_str" : "off", "reason" : "hello",
                  "level" : 0, "level_str" : 'off'}
+        del data['timestamp']
         assert data == right
 
         data = mdev.fan_template_data(level=dev.Speed.LOW)
         right = {"address" : addr.hex, "name" : name,
                  "on" : 1, "on_str" : "on", "reason" : "",
                  "level" : 1, "level_str" : 'low'}
+        del data['timestamp']
         assert data == right
 
         data = mdev.fan_template_data(level=dev.Speed.MEDIUM)
         right = {"address" : addr.hex, "name" : name,
                  "on" : 1, "on_str" : "on", "reason" : "",
                  "level" : 2, "level_str" : 'medium'}
+        del data['timestamp']
         assert data == right
 
         data = mdev.fan_template_data(level=dev.Speed.HIGH, reason="foo")
         right = {"address" : addr.hex, "name" : name,
                  "on" : 1, "on_str" : "on", "reason" : "foo",
                  "level" : 3, "level_str" : 'high'}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_IOLincMqtt.py
+++ b/tests/mqtt/test_IOLincMqtt.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -61,6 +62,8 @@ class Test_IOLinc:
 
         data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=1, is_on=True)
@@ -69,6 +72,7 @@ class Test_IOLinc:
                  "fast": 0, "instant": 0, "mode": "normal", "on": 1,
                  "on_str": "on", "reason": "", "relay_on": 0,
                  "relay_on_str" : "off"}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=2, is_on=True)
@@ -77,6 +81,7 @@ class Test_IOLinc:
                  "fast": 0, "instant": 0, "mode": "normal", "on": 1,
                  "on_str": "on", "reason": "", "relay_on": 1,
                  "relay_on_str" : "on"}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=1, is_on=False)
@@ -85,6 +90,7 @@ class Test_IOLinc:
                  "fast": 0, "instant": 0, "mode": "normal", "on": 0,
                  "on_str": "off", "reason": "", "relay_on": 0,
                  "relay_on_str" : "off"}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=2, is_on=False)
@@ -93,6 +99,7 @@ class Test_IOLinc:
                  "fast": 0, "instant": 0, "mode": "normal", "on": 0,
                  "on_str": "off", "reason": "", "relay_on": 0,
                  "relay_on_str" : "off"}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_KeypadLinc.py
+++ b/tests/mqtt/test_KeypadLinc.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -107,6 +108,8 @@ class Test_KeypadLinc:
 
         data = mdev.base_template_data(button=5)
         right = {"address" : addr.hex, "name" : name, "button" : 5}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=3, level=255, reason="something",
@@ -117,6 +120,7 @@ class Test_KeypadLinc:
                  "level_255" : 255, "level_100" : 100,
                  "mode" : "fast", "fast" : 1, "instant" : 0,
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=1, level=128,
@@ -125,6 +129,7 @@ class Test_KeypadLinc:
                  "on" : 1, "on_str" : "on", "reason" : "",
                  "level_255" : 128, "level_100" : 50,
                  "mode" : "instant", "fast" : 0, "instant" : 1}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=2, level=0, reason="foo")
@@ -132,6 +137,7 @@ class Test_KeypadLinc:
                  "on" : 0, "on_str" : "off", "reason" : "foo",
                  "level_255" : 0, "level_100" : 0,
                  "mode" : "normal", "fast" : 0, "instant" : 0}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=2, manual=IM.on_off.Manual.UP,
@@ -139,6 +145,7 @@ class Test_KeypadLinc:
         right = {"address" : addr.hex, "name" : name, "button" : 2,
                  "reason" : "HELLO", "manual_str" : "up", "manual" : 1,
                  "manual_openhab" : 2}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_KeypadLinc_sw.py
+++ b/tests/mqtt/test_KeypadLinc_sw.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -69,6 +70,8 @@ class Test_KeypadLinc_sw:
 
         data = mdev.base_template_data(button=5)
         right = {"address" : addr.hex, "name" : name, "button" : 5}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=3, level=1,
@@ -79,6 +82,7 @@ class Test_KeypadLinc_sw:
                  "level_255" : 1, "level_100" : 0,
                  "mode" : "fast", "fast" : 1, "instant" : 0,
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=1, level=0)
@@ -86,12 +90,14 @@ class Test_KeypadLinc_sw:
                  "on" : 0, "on_str" : "off", "reason" : "",
                  "level_255" : 0, "level_100" : 0,
                  "mode" : "normal", "fast" : 0, "instant" : 0}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=2, manual=IM.on_off.Manual.UP)
         right = {"address" : addr.hex, "name" : name, "button" : 2,
                  "reason" : "", "manual_str" : "up", "manual" : 1,
                  "manual_openhab" : 2}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_Leak.py
+++ b/tests/mqtt/test_Leak.py
@@ -57,6 +57,8 @@ class Test_Leak:
 
         data = mdev.template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         t0 = time.time()
@@ -64,6 +66,7 @@ class Test_Leak:
         right = {"address" : addr.hex, "name" : name,
                  "is_heartbeat" : 1, "is_heartbeat_str" : "on"}
         hb = data.pop('heartbeat_time')
+        del data['timestamp']
         assert data == right
         pytest.approx(t0, hb, 5)
 
@@ -73,6 +76,7 @@ class Test_Leak:
                  "is_dry" : 1, "is_dry_str" : "on", "button": 2,
                  "fast": 0, "instant": 0, "mode": 'normal', "on": 0,
                  "on_str": 'off', "reason": ''}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_Modem.py
+++ b/tests/mqtt/test_Modem.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -58,6 +59,8 @@ class Test_Modem:
 
         data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_Motion.py
+++ b/tests/mqtt/test_Motion.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -56,16 +57,20 @@ class Test_Motion:
 
         data = mdev.template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.template_data(is_on=True, is_low=False)
         right = {"address" : addr.hex, "name" : name,
                  "on" : 1, "on_str" : "on",
                  "is_low" : 0, "is_low_str" : "off"}
+        del data['timestamp']
         assert data == right
 
         data = mdev.template_data_motion()
         right = {"address" : addr.hex, "name" : name}
+        del data['timestamp']
         assert data == right
 
         data = mdev.template_data_motion(is_dawn=True)
@@ -73,6 +78,7 @@ class Test_Motion:
                  "is_dawn" : 1, "is_dawn_str" : "on",
                  "is_dusk" : 0, "is_dusk_str" : "off",
                  "state": "dawn"}
+        del data['timestamp']
         assert data == right
 
         data = mdev.template_data_motion(is_dawn=False)
@@ -80,6 +86,7 @@ class Test_Motion:
                  "is_dawn" : 0, "is_dawn_str" : "off",
                  "is_dusk" : 1, "is_dusk_str" : "on",
                  "state": "dusk"}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_Outlet.py
+++ b/tests/mqtt/test_Outlet.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -64,6 +65,8 @@ class Test_Outlet:
 
         data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(is_on=True, button=1, reason="something",
@@ -71,12 +74,14 @@ class Test_Outlet:
         right = {"address" : addr.hex, "name" : name, "button" : 1,
                  "on" : 1, "on_str" : "on", "reason" : "something",
                  "mode" : "fast", "fast" : 1, "instant" : 0}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(is_on=False, button=2)
         right = {"address" : addr.hex, "name" : name, "button" : 2,
                  "on" : 0, "on_str" : "off", "reason" : "",
                  "mode" : "normal", "fast" : 0, "instant" : 0}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_Remote.py
+++ b/tests/mqtt/test_Remote.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -57,6 +58,8 @@ class Test_Remote:
 
         data = mdev.base_template_data(button=3)
         right = {"address" : addr.hex, "name" : name, "button" : 3}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=4, is_on=True,
@@ -67,6 +70,7 @@ class Test_Remote:
                  "mode" : "fast", "fast" : 1, "instant" : 0,
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1,
                  "reason": ''}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=4, is_on=False)
@@ -74,12 +78,14 @@ class Test_Remote:
                  "on" : 0, "on_str" : "off",
                  "mode" : "normal", "fast" : 0, "instant" : 0,
                  "reason": ''}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(button=5, manual=IM.on_off.Manual.UP)
         right = {"address" : addr.hex, "name" : name, "button" : 5,
                  "manual_str" : "up", "manual" : 1, "manual_openhab" : 2,
                  "reason": ''}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------

--- a/tests/mqtt/test_Switch.py
+++ b/tests/mqtt/test_Switch.py
@@ -4,6 +4,7 @@
 #
 # pylint: disable=redefined-outer-name
 #===========================================================================
+import time
 import pytest
 import insteon_mqtt as IM
 import helpers as H
@@ -64,6 +65,8 @@ class Test_Switch:
 
         data = mdev.base_template_data()
         right = {"address" : addr.hex, "name" : name}
+        assert data['timestamp'] - time.time() <= 1
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(is_on=True, mode=IM.on_off.Mode.FAST,
@@ -73,18 +76,21 @@ class Test_Switch:
                  "on" : 1, "on_str" : "on", "reason" : "something",
                  "mode" : "fast", "fast" : 1, "instant" : 0,
                  "manual_str" : "stop", "manual" : 0, "manual_openhab" : 1}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(is_on=False)
         right = {"address" : addr.hex, "name" : name, "reason" : "",
                  "on" : 0, "on_str" : "off",
                  "mode" : "normal", "fast" : 0, "instant" : 0}
+        del data['timestamp']
         assert data == right
 
         data = mdev.state_template_data(manual=IM.on_off.Manual.UP,
                                         reason="foo")
         right = {"address" : addr.hex, "name" : name, "reason" : "foo",
                  "manual_str" : "up", "manual" : 1, "manual_openhab" : 2}
+        del data['timestamp']
         assert data == right
 
     #-----------------------------------------------------------------------


### PR DESCRIPTION
## Proposed change
This adds the templating variable `{{timestamp}}` to all templates.  It outputs the current timestamp.

## Additional information
I am using this as an attribute in addition to `reason` in automation conditions.  It is helpful in preventing automations from triggering on a restart of HA or the MQTT Broker when using the retain flag.

A simple check in HA is to test if the timestamp of the state change is within the last 5 seconds (could certainly be shorter). If it is not, then this message is likely being redelivered because of the retain flag, and I can avoid re-triggering an automation.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Code documentation was added where necessary
- [x] Documentation (in config-sample.yaml) added/updated
