### PR TITLE
add group 2 to fanlinc responders group

### DIFF
--- a/insteon_mqtt/device/FanLinc.py
+++ b/insteon_mqtt/device/FanLinc.py
@@ -82,6 +82,9 @@ class FanLinc(Dimmer):
         # This is necessary to override the dimmer group_map of 0x01
         self.group_map = {}
 
+        # List of responder group numbers
+        self.responder_groups = [0x01, 0x02]
+
     #-----------------------------------------------------------------------
     def addRefreshData(self, seq, force=False):
         """Add commands to refresh any internal data required.


### PR DESCRIPTION
## Proposed change
I spent a small amount of time looking into the error I reported in #398 and found the `responder_groups`  list doesn't appear to be updated correctly for fan lincs.

This adds group 2 into the list of responder groups for fanlinc devices

## Additional information
I'm not familiar enough with the code to know if this is an appropriate change; however, it seemed like it would help move me past the exception I'm running into.

- This PR is related to issue: #398

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary

Do you have examples you can point me to that demonstrate how to test this type of change?
