### PR TITLE
Run Docker Build on Local Docker Instance

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -2,6 +2,6 @@
 
 docker run --rm --privileged \
   -v ~/.docker:/root/.docker \
-  homeassistant/amd64-builder --all \
-  -r https://github.com/TD22057/insteon-mqtt \
-  -b master
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  homeassistant/amd64-builder \
+  --all -r https://github.com/TD22057/insteon-mqtt -b master


### PR DESCRIPTION
## Proposed change
Fixes the build process to work more reliably by building the docker images using the local docker instance instead of the docker-in-docker design used by HomeAssistant.


## Additional information
- This PR fixes or closes issue: fixes #375 