### PR TITLE
Allow Domain Names for Broker and Hub; Remove IP Test

### DIFF
--- a/insteon_mqtt/config.py
+++ b/insteon_mqtt/config.py
@@ -347,16 +347,6 @@ class MetaErrorHandler(BasicErrorHandler):
 class IMValidator(Validator):
     """ Adds a few check_with functions to validate specific settings
     """
-    def _check_with_valid_ip(self, field, value):
-        """ Tests whether value is a valid ipv4 or ipv6 address
-
-        Uses the library ipaddress for accuracy
-        """
-        try:
-            ipaddress.ip_address(value)
-        except ValueError:
-            self._error(field, "Invalid IP Address")
-
     def _check_with_valid_insteon_addr(self, field, value):
         """ Tests whether value is a valid Insteon Address for Insteon MQTT
 

--- a/insteon_mqtt/schemas/config-schema.yaml
+++ b/insteon_mqtt/schemas/config-schema.yaml
@@ -58,7 +58,6 @@ insteon:
           two following definitions must be satisfied.
     hub_ip:
       type: string
-      check_with: valid_ip
     hub_port:
       type: integer
       min: 0
@@ -140,8 +139,6 @@ insteon:
 
 mqtt:
   type: dict
-  meta:
-    schema_error: unknown field
   allow_unknown:
     ## The only unknown keys are user defined discovery_class settings
     type: dict
@@ -164,7 +161,6 @@ mqtt:
   schema:
     broker:
       type: string
-      check_with: valid_ip
       required: True
     port:
       type: integer

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,6 +94,13 @@ class Test_config:
         assert val == ""
 
     #-----------------------------------------------------------------------
+    def test_dns(self):
+        file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                            'configs', 'use_dns.yaml')
+        val = IM.config.validate(file)
+        assert val == ""
+
+    #-----------------------------------------------------------------------
     def test_validate_addr(self):
         validator = IM.config.IMValidator()
         validator._error = mock.Mock()


### PR DESCRIPTION
## Proposed change
Allows for domain names to be used for the broker and hub addresses.

New tests added to catch this in the future.

## Additional information
- This PR fixes or closes issue: fixes #403

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.
