### PR TITLE
fix issue with hassio initial config setup

### DIFF
--- a/hassio/entrypoint.sh
+++ b/hassio/entrypoint.sh
@@ -6,7 +6,7 @@
 
 if [ ! -f /config/insteon-mqtt/config.yaml ]; then
     echo "Copying default config.yaml"
-    /bin/cp /opt/insteon-mqtt/config.yaml /config/insteon-mqtt/config.yaml
+    /bin/cp /config/insteon-mqtt/config.yaml.default /config/insteon-mqtt/config.yaml
     sed -i "s/storage: 'data'/storage: '\/config\/insteon-mqtt\/data'/" /config/insteon-mqtt/config.yaml
     sed -i "s/file: \/var\/log\/insteon_mqtt.log/file: \/config\/insteon-mqtt\/insteon_mqtt.log/" /config/insteon-mqtt/config.yaml
 fi


### PR DESCRIPTION
## Proposed change
This fixes the initial config setup on a new install (it current bails because `/opt/insteon-mqtt/config.yaml` does not exist)

## Checklist
- [x] The code change is tested and works locally.
