### PR TITLE
add files created by tests to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__
 .cache
 .coverage
 htmlcov
+
+# files created by tests
+data/
+01.02.03.json


### PR DESCRIPTION
## Proposed change
This just adds the file `01.02.03.json` and folder `data` created by the tests into the gitignore

## Checklist
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**

the only failing test is the config test that references `use_dns.yaml`