### PR TITLE
allow configuring the resume dim operating flag

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -380,6 +380,9 @@ Switch, KeypadLinc, and Dimmer all support the flags:
 
    - ramp_rate: float in the range of 0.5 to 540 seconds which sets the default ramp
      rate that will be used when the button is pressed
+   - resume_dim: bool indicating if the device's on level should be determined from
+     the configured on_level flag, or based on the last on level (currently this will
+     only effect manually pressing the button and not commands send through insteon-mqtt)
 
 IOLinc supports the flags:
 

--- a/insteon_mqtt/device/base/DimmerBase.py
+++ b/insteon_mqtt/device/base/DimmerBase.py
@@ -109,7 +109,7 @@ class DimmerBase(ManualCtrl, ResponderBase, Base):
         minutes.
 
         Args:
-          rate (float): Ramp rate in in the range [0.1, 540] seconds
+          ramp_rate (float): Ramp rate in in the range [0.1, 540] seconds
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """
@@ -155,7 +155,7 @@ class DimmerBase(ManualCtrl, ResponderBase, Base):
         brightness if needed.
 
         Args:
-          enabled (bool): resume dim is enabled
+          resume_dim (bool): resume dim is enabled
           on_done: Finished callback.  This is called when the command has
                    completed.  Signature is: on_done(success, msg, data)
         """

--- a/insteon_mqtt/device/base/DimmerBase.py
+++ b/insteon_mqtt/device/base/DimmerBase.py
@@ -167,12 +167,14 @@ class DimmerBase(ManualCtrl, ResponderBase, Base):
         # 0x05 - Disables resume dim
         if resume_dim:
             LOG.info("Device %s enabling resume dim", self.label)
-            cmd2=0x04
+            cmd2 = 0x04
         else:
             LOG.info("Device %s disabling resume dim", self.label)
-            cmd2=0x05
+            cmd2 = 0x05
 
-        msg = Msg.OutExtended.direct(self.addr, Msg.CmdType.SET_OPERATING_FLAGS, cmd2, bytes([0x00] * 14))
+        cmd1 = Msg.CmdType.SET_OPERATING_FLAGS
+        msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2,
+                                      bytes([0x00] * 14))
 
         # Use the standard command handler which will notify us when the
         # command is ACK'ed.

--- a/insteon_mqtt/device/base/DimmerBase.py
+++ b/insteon_mqtt/device/base/DimmerBase.py
@@ -172,7 +172,7 @@ class DimmerBase(ManualCtrl, ResponderBase, Base):
             LOG.info("Device %s disabling resume dim", self.label)
             cmd2=0x05
 
-        msg = Msg.OutStandard.direct(self.addr, Msg.CmdType.SET_OPERATING_FLAGS, cmd2)
+        msg = Msg.OutExtended.direct(self.addr, Msg.CmdType.SET_OPERATING_FLAGS, cmd2, bytes([0x00] * 14))
 
         # Use the standard command handler which will notify us when the
         # command is ACK'ed.

--- a/tests/device/test_DimmerDev.py
+++ b/tests/device/test_DimmerDev.py
@@ -73,6 +73,16 @@ class Test_Base_Config():
             else:
                 mocked.assert_not_called()
 
+    def test_set_resume_dim(self, test_device):
+        # set_resume_dim(self, resume_dim, on_done=None)
+        for params in ([True, 0x04], [False, 0x05]):
+            test_device.set_resume_dim(resume_dim=params[0])
+            assert len(test_device.protocol.sent) == 1
+            assert test_device.protocol.sent[0].msg.cmd1 == 0x20
+            assert test_device.protocol.sent[0].msg.cmd2 == params[1]
+            assert test_device.protocol.sent[0].msg.data == bytes([0x00] * 14)
+            test_device.protocol.clear()
+
     def test_set_on_level(self, test_device):
         # set_on_level(self, level, on_done=None)
         def level_bytes(level):


### PR DESCRIPTION
## Proposed change
This exposes the ability to configure the "Resume Dim" operating flag. It configures the device to use the previous on level instead of the value of the `on_level` flag as the default level for a normal on command.

## Additional Information
I'm unfamiliar with the code base, so still going through and making sure I've updated documentation where appropriate. I'm also unsure how to add unit tests for a change like this.

The command values were pulled from http://cache.insteon.com/pdf/INSTEON_Command_Tables_20070925a.pdf

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated
