### PR TITLE
allow sending raw commands to devices

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -498,6 +498,47 @@ below the expected value
   { "cmd": "set_low_battery_voltage", "voltage": 7.0 }
     ```
 
+### Send a raw insteon command.
+
+Supported: devices
+
+Send a raw insteon command to devices. Any changes as a result of this
+command won't be kept in sync automatically, so use this at your risk.
+This command is intended to help developing and debugging insteon-mqtt,
+and is as low level as it gets. It supports standard and extended direct
+messages.
+
+#### Standard Direct message payload
+
+A standard message requires the cmd1 and cmd2 attributes - allowed values are
+`0x00` (0) -> `0xFF` (255).
+
+   ```
+   { "cmd": "raw_command", "cmd1": 31, "cmd2": 0 }
+   ```
+
+#### Extended Direct message payload
+
+To send an extended message, simply provide the data property (a list of numbers).
+It's value will be right padded with 0s and trimmed to 14 digits, then converted
+to bytes. The allowed values cmd1, cmd2, and elements within the data array are
+`0x00` (0) -> `0xFF` (255). The payload also allows specifying the crc type, with
+the allowed values of `D14`, `CRC`. If the type is not supplied the data array
+will be sent as is without calculating a CRC.
+
+   ```
+   { "cmd": "raw_command", "cmd1": 32, "cmd2": 4, data: [], crc_type: "D14" }
+   ```
+
+#### Insteon command tables
+
+You can find insteon command tables online; however, they are usually out
+dated. Most modern devices (since ~2012) run the i2cs engine, which is an
+extension on the i2 engine and updated certain commands to require the 
+D14 crc. If you try commands from an old command table and recieve a
+response that indicates an invalid checksum for a standard command, you
+can try it as an extended command with the D14 checksum.
+
 ---
 
 # State change commands

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -349,7 +349,7 @@ def set_low_battery_voltage(args, config):
 def send_raw_message(args, config):
     topic = "%s/%s" % (args.topic, args.address)
     payload = {
-        "cmd" : "raw_message",
+        "cmd" : "raw_command",
         "cmd1": args.cmd1,
         "cmd2": args.cmd2,
         "ext_resp": args.ext_resp

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -343,4 +343,27 @@ def set_low_battery_voltage(args, config):
 
     reply = util.send(config, topic, payload, args.quiet)
     return reply["status"]
+
+
+#===========================================================================
+def send_raw_message(args, config):
+    topic = "%s/%s" % (args.topic, args.address)
+    payload = {
+        "cmd" : "raw_message",
+        "cmd1": args.cmd1,
+        "cmd2": args.cmd2,
+        "ext_resp": args.ext_resp
+        }
+
+    if args.ext_req:
+        payload["data"] = [0] * 14
+
+    if args.data:
+        payload["data"] = (args.data + ([0] * 14))[:14]
+
+    if args.crc:
+        payload["crc_type"] = args.crc
+
+    reply = util.send(config, topic, payload, args.quiet)
+    return reply["status"]
 #===========================================================================

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -356,10 +356,10 @@ def send_raw_message(args, config):
         }
 
     if args.ext_req:
-        payload["data"] = [0] * 14
+        payload["data"] = []
 
     if args.data:
-        payload["data"] = (args.data + ([0] * 14))[:14]
+        payload["data"] = args.data[:14]
 
     if args.crc:
         payload["crc_type"] = args.crc

--- a/insteon_mqtt/cmd_line/device.py
+++ b/insteon_mqtt/cmd_line/device.py
@@ -346,7 +346,7 @@ def set_low_battery_voltage(args, config):
 
 
 #===========================================================================
-def send_raw_message(args, config):
+def send_raw_command(args, config):
     topic = "%s/%s" % (args.topic, args.address)
     payload = {
         "cmd" : "raw_command",

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -440,7 +440,7 @@ def parse_args(args):
     sp.add_argument("--crc", type=str, choices=["D14", "CRC"])
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
-    sp.set_defaults(func=device.send_raw_message)
+    sp.set_defaults(func=device.send_raw_command)
 
     return p.parse_args(args)
 

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -423,6 +423,25 @@ def parse_args(args):
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=device.set_low_battery_voltage)
 
+    auto_int = lambda x: int(x, 0)
+
+    #---------------------------------------
+    # device.raw_message
+    sp = sub.add_parser("raw-message", help="Sends a raw message to a configured device")
+    sp.add_argument("address", help="Device address or name.")
+    sp.add_argument("cmd1", type=auto_int, help="cmd1 byte")
+    sp.add_argument("cmd2", type=auto_int, help="cmd2 byte")
+    sp.add_argument("--ext-req", action="store_true", help="Send message "
+    "as an extended message")
+    sp.add_argument("--ext-resp", action="store_true", help="Receive response "
+    "as an extended message")
+    sp.add_argument("-d", "--data", type=auto_int, default=None, nargs="*", 
+    help="the extended message data")
+    sp.add_argument("--crc", type=str, choices=["D14", "CRC"])
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=device.send_raw_message)
+
     return p.parse_args(args)
 
 

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -427,19 +427,20 @@ def parse_args(args):
 
     #---------------------------------------
     # device.raw_message
-    sp = sub.add_parser("raw-command", help="Sends a raw message to a configured device")
+    sp = sub.add_parser("raw-command", help="Sends a raw message to a "
+                            "configured device")
     sp.add_argument("address", help="Device address or name.")
     sp.add_argument("cmd1", type=auto_int, help="cmd1 byte")
     sp.add_argument("cmd2", type=auto_int, help="cmd2 byte")
     sp.add_argument("--ext-req", action="store_true", help="Send message "
-    "as an extended message")
+                        "as an extended message")
     sp.add_argument("--ext-resp", action="store_true", help="Receive response "
-    "as an extended message")
-    sp.add_argument("-d", "--data", type=auto_int, default=None, nargs="*", 
-    help="the extended message data")
+                    "as an extended message")
+    sp.add_argument("-d", "--data", type=auto_int, default=None, nargs="*",
+                        help="the extended message data")
     sp.add_argument("--crc", type=str, choices=["D14", "CRC"])
     sp.add_argument("-q", "--quiet", action="store_true",
-                    help="Don't print any command results to the screen.")
+                        help="Don't print any command results to the screen.")
     sp.set_defaults(func=device.send_raw_command)
 
     return p.parse_args(args)

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -430,14 +430,17 @@ def parse_args(args):
     sp = sub.add_parser("raw-command", help="Sends a raw message to a "
                             "configured device")
     sp.add_argument("address", help="Device address or name.")
-    sp.add_argument("cmd1", type=auto_int, help="cmd1 byte")
-    sp.add_argument("cmd2", type=auto_int, help="cmd2 byte")
+    sp.add_argument("cmd1", type=auto_int, help="cmd1 byte (supports "
+                        "both hex and decimal)")
+    sp.add_argument("cmd2", type=auto_int, help="cmd2 byte (supports "
+                        "both hex and decimal)")
     sp.add_argument("--ext-req", action="store_true", help="Send message "
                         "as an extended message")
     sp.add_argument("--ext-resp", action="store_true", help="Receive response "
                     "as an extended message")
     sp.add_argument("-d", "--data", type=auto_int, default=None, nargs="*",
-                        help="the extended message data")
+                        help="the extended message data (supports both hex "
+                        "and decimal)")
     sp.add_argument("--crc", type=str, choices=["D14", "CRC"])
     sp.add_argument("-q", "--quiet", action="store_true",
                         help="Don't print any command results to the screen.")

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -427,7 +427,7 @@ def parse_args(args):
 
     #---------------------------------------
     # device.raw_message
-    sp = sub.add_parser("raw-message", help="Sends a raw message to a configured device")
+    sp = sub.add_parser("raw-command", help="Sends a raw message to a configured device")
     sp.add_argument("address", help="Device address or name.")
     sp.add_argument("cmd1", type=auto_int, help="cmd1 byte")
     sp.add_argument("cmd2", type=auto_int, help="cmd2 byte")

--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -505,7 +505,8 @@ class Base:
         if data is None:
             msg = Msg.OutStandard.direct(self.addr, cmd1, cmd2)
         else:
-            msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2, bytes(data), crc_type)
+            padded_and_trimmed_data = (data + ([0] * 14))[:14]
+            msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2, bytes(padded_and_trimmed_data), crc_type)
 
         if ext_resp:
             # Use the standard command handler which will notify us when the

--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -509,13 +509,13 @@ class Base:
             msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2, bytes(padded_and_trimmed_data), crc_type)
 
         if ext_resp:
-            # Use the standard command handler which will notify us when the
-            # command is ACK'ed.
-            msg_handler = handler.StandardCmd(msg, self.handle_std_raw_message, on_done)
-        else:
             # Use the extended response command handler which will notify us when the
             # command is ACK'ed.
-            msg_handler = handler.ExtendedCmdResponse(msg, self.handle_ext_raw_message, on_done)
+            msg_handler = handler.ExtendedCmdResponse(msg, self.handle_raw_command, on_done)
+        else:
+            # Use the standard command handler which will notify us when the
+            # command is ACK'ed.
+            msg_handler = handler.StandardCmd(msg, self.handle_raw_command, on_done)
 
         self.send(msg, msg_handler)
 
@@ -1175,12 +1175,7 @@ class Base:
         on_done(True, "Operation complete", msg.cmd2)
 
     #-----------------------------------------------------------------------
-    def handle_std_raw_message(self, msg, on_done):
-        LOG.ui("Device %s raw message response: %s", self.addr, msg)
-        on_done(True, "Raw Message complete", None)
-
-    #-----------------------------------------------------------------------
-    def handle_ext_raw_message(self, msg, on_done):
+    def handle_raw_command(self, msg, on_done):
         LOG.ui("Device %s raw message response: %s", self.addr, msg)
         on_done(True, "Raw Message complete", None)
 

--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -184,7 +184,8 @@ class Base:
             'get_engine' : self.get_engine,
             'get_model' : self.get_model,
             'sync': self.sync,
-            'import_scenes': self.import_scenes
+            'import_scenes': self.import_scenes,
+            'raw_message': self.raw_message
             }
 
         # Device database delta.  The delta tells us if the database is
@@ -493,6 +494,31 @@ class Base:
             seq.add(function, **kwargs)
 
         seq.run()
+    #-----------------------------------------------------------------------
+    # TODO: remove this? i'm adding it to make it easier for me to test commands
+    # or extend it to support extended commands?
+    def raw_message(self, cmd1, cmd2, data=None, crc_type=None, ext_resp=False, on_done=None):
+        """Send a raw message to this device
+
+        This can be used to send commands that aren't supported directly
+        by insteon-mqtt yet. This is as low level as it gets, use at your
+        own risk
+        """
+        if data is None:
+            msg = Msg.OutStandard.direct(self.addr, cmd1, cmd2)
+        else:
+            msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2, bytes(data), crc_type)
+
+        if ext_resp:
+            # Use the standard command handler which will notify us when the
+            # command is ACK'ed.
+            msg_handler = handler.StandardCmd(msg, self.handle_std_raw_message, on_done)
+        else:
+            # Use the extended response command handler which will notify us when the
+            # command is ACK'ed.
+            msg_handler = handler.ExtendedCmdResponse(msg, self.handle_ext_raw_message, on_done)
+
+        self.send(msg, msg_handler)
 
     #-----------------------------------------------------------------------
     def refresh(self, force=False, group=None, on_done=None):
@@ -1148,6 +1174,16 @@ class Base:
         LOG.ui("Device %s operating flags: %s", self.addr,
                "{:08b}".format(msg.cmd2))
         on_done(True, "Operation complete", msg.cmd2)
+
+    #-----------------------------------------------------------------------
+    def handle_std_raw_message(self, msg, on_done):
+        LOG.ui("Device %s raw message response: %s", self.addr, msg)
+        on_done(True, "Raw Message complete", None)
+
+    #-----------------------------------------------------------------------
+    def handle_ext_raw_message(self, msg, on_done):
+        LOG.ui("Device %s raw message response: %s", self.addr, msg)
+        on_done(True, "Raw Message complete", None)
 
     #-----------------------------------------------------------------------
     def handle_engine(self, msg, on_done):

--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -494,8 +494,10 @@ class Base:
             seq.add(function, **kwargs)
 
         seq.run()
+
     #-----------------------------------------------------------------------
-    def raw_command(self, cmd1, cmd2, data=None, crc_type=None, ext_resp=False, on_done=None):
+    def raw_command(self, cmd1, cmd2, data=None, crc_type=None, ext_resp=False,
+                    on_done=None):
         """Send a raw message to this device
 
         This can be used to send commands that aren't supported directly
@@ -506,16 +508,19 @@ class Base:
             msg = Msg.OutStandard.direct(self.addr, cmd1, cmd2)
         else:
             padded_and_trimmed_data = bytes(data + ([0] * 14))[:14]
-            msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2, padded_and_trimmed_data, crc_type)
+            msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2,
+                                            padded_and_trimmed_data, crc_type)
 
         if ext_resp:
-            # Use the extended response command handler which will notify us when the
-            # command is ACK'ed.
-            msg_handler = handler.ExtendedCmdResponse(msg, self.handle_raw_command, on_done)
+            # Use the extended response command handler which will notify us
+            # when the command is ACK'ed.
+            msg_handler = handler.ExtendedCmdResponse(
+                msg, self.handle_raw_command, on_done)
         else:
             # Use the standard command handler which will notify us when the
             # command is ACK'ed.
-            msg_handler = handler.StandardCmd(msg, self.handle_raw_command, on_done)
+            msg_handler = handler.StandardCmd(
+                msg, self.handle_raw_command, on_done)
 
         self.send(msg, msg_handler)
 

--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -505,8 +505,8 @@ class Base:
         if data is None:
             msg = Msg.OutStandard.direct(self.addr, cmd1, cmd2)
         else:
-            padded_and_trimmed_data = (data + ([0] * 14))[:14]
-            msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2, bytes(padded_and_trimmed_data), crc_type)
+            padded_and_trimmed_data = bytes(data + ([0] * 14))[:14]
+            msg = Msg.OutExtended.direct(self.addr, cmd1, cmd2, padded_and_trimmed_data, crc_type)
 
         if ext_resp:
             # Use the extended response command handler which will notify us when the

--- a/insteon_mqtt/device/base/Base.py
+++ b/insteon_mqtt/device/base/Base.py
@@ -185,7 +185,7 @@ class Base:
             'get_model' : self.get_model,
             'sync': self.sync,
             'import_scenes': self.import_scenes,
-            'raw_message': self.raw_message
+            'raw_command': self.raw_command
             }
 
         # Device database delta.  The delta tells us if the database is
@@ -495,9 +495,7 @@ class Base:
 
         seq.run()
     #-----------------------------------------------------------------------
-    # TODO: remove this? i'm adding it to make it easier for me to test commands
-    # or extend it to support extended commands?
-    def raw_message(self, cmd1, cmd2, data=None, crc_type=None, ext_resp=False, on_done=None):
+    def raw_command(self, cmd1, cmd2, data=None, crc_type=None, ext_resp=False, on_done=None):
         """Send a raw message to this device
 
         This can be used to send commands that aren't supported directly

--- a/tests/device/base/test_BaseDev.py
+++ b/tests/device/base/test_BaseDev.py
@@ -200,6 +200,22 @@ class Test_Base_Config():
         assert len(sent) == 1
         assert sent[0].msg.to_bytes() == msg.to_bytes()
 
+    def test_send_std_raw_command(self, test_device):
+        msg = Msg.OutStandard.direct(test_device.addr, 0x32, 0x43)
+        test_device.raw_command(0x32, 0x43)
+        sent = test_device.protocol.sent
+        assert len(sent) == 1
+        assert sent[0].msg.to_bytes() == msg.to_bytes()
+
+    def test_send_ext_raw_command(self, test_device):
+        crc="D14"
+        data = [i for i in range(0, 20)]
+        msg = Msg.OutExtended.direct(test_device.addr, 0x32, 0x43, bytes(data[:14]), crc_type=crc)
+        test_device.raw_command(0x32, 0x43, data, crc_type=crc)
+        sent = test_device.protocol.sent
+        assert len(sent) == 1
+        assert sent[0].msg.to_bytes() == msg.to_bytes()
+
     def test_get_engine(self, test_device):
         msg = Msg.OutStandard.direct(test_device.addr,
                                      Msg.CmdType.GET_ENGINE_VERSION, 0x00)


### PR DESCRIPTION
## Proposed change
This arose while debugging #411 (and messing around with the other commands I found in the command tables). Essentially I found it a lot easier to debug the actual commands when I had the ability to send raw insteon commands through mqtt

I don't think this is a common use case, and there's some cleanup that needs to happen if this were desired (tests, docs, etc); but am happy to work through those if this is would be desired

## Additional information

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated
