### PR TITLE
Better Error Report When Unknown Fields are in Discovery Class

### DIFF
--- a/insteon_mqtt/data/config-schema.yaml
+++ b/insteon_mqtt/data/config-schema.yaml
@@ -140,6 +140,7 @@ insteon:
 mqtt:
   type: dict
   allow_unknown:
+    allow_unknown: False
     ## The only unknown keys are user defined discovery_class settings
     type: dict
     schema:


### PR DESCRIPTION
## Proposed change
A simple one-liner.

If a user mistakenly puts extra keys in a discovery class the
current error looks like:

```yaml
mqtt:
  kpl_six:
    btn_on_off_payload:
    - must be of dict type
```

This updates the schema so that the error now looks like:

```yaml
mqtt:
  kpl_six:
    btn_on_off_payload:
    - unknown field
```

A slight improvement in wording.

## Additional information
- This PR is related to issue: #418

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.