### PR TITLE
Fix KPL Unit Test; Only Add Level if Defined

### DIFF
--- a/tests/mqtt/test_KeypadLinc.py
+++ b/tests/mqtt/test_KeypadLinc.py
@@ -906,9 +906,9 @@ class Test_KeypadLinc:
             'btn_on_off_payload' : ('{ "cmd" : "{{json.on.lower()}}" }'),
             'dimmer_level_topic' : 'foo/{{address}}/1',
             'dimmer_level_payload' : ('{ "cmd" : "{{json.on.lower()}}"'
-                                      '{% if json.num is defined %},'
-                                      ' "level" : {{json.num}}'
-                                      ' {% endif %} }')}}
+                                      '{% if json.num is defined %}'
+                                      ', "level" : {{json.num}}'
+                                      '{% endif %} }')}}
         mdev.load_config(config, qos=qos)
         mdev.subscribe(link, qos)
 

--- a/tests/mqtt/test_KeypadLinc.py
+++ b/tests/mqtt/test_KeypadLinc.py
@@ -905,8 +905,10 @@ class Test_KeypadLinc:
             'btn_on_off_topic' : 'foo/{{address}}/{{button}}',
             'btn_on_off_payload' : ('{ "cmd" : "{{json.on.lower()}}" }'),
             'dimmer_level_topic' : 'foo/{{address}}/1',
-            'dimmer_level_payload' : ('{ "cmd" : "{{json.on.lower()}}",'
-                                      '"level" : "{{json.num}}" }')}}
+            'dimmer_level_payload' : ('{ "cmd" : "{{json.on.lower()}}"'
+                                      '{% if json.num is defined %},'
+                                      ' "level" : {{json.num}}'
+                                      ' {% endif %} }')}}
         mdev.load_config(config, qos=qos)
         mdev.subscribe(link, qos)
 


### PR DESCRIPTION
## Proposed change
Fixes a broken KPL Unit Test.  Not sure how this has slipped through for so long.  Was there a change in how python handles `int('')` that I missed?

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.