### PR TITLE
Add Instructions for Home Assistant Yaml Config; Update HA Installation for Discovery

### DIFF
--- a/docs/HA_Addon_Instructions.md
+++ b/docs/HA_Addon_Instructions.md
@@ -34,14 +34,16 @@ These instructions assume that you:
 8. Click __Start__ to start the Add-on, this will create your initial config
    files.
 9. Edit `/config/insteon-mqtt/config.yaml` as appropriate. See [configuration](configuration.md) for detailed instructions.
+10. Enable the [Discovery Platform](discovery.md)
 
-10. Restart the insteon-mqtt addon to pick up the changes to the `config.yaml` file.
-11. Initialize your devices as discussed in [initializing](initializing.md).
-12. Edit your Home Assistant configuration to add your devices as MQTT devices
-    to Home Assistant.  In the __mqtt__ section of the initial config.yaml
-    file, there are examples of Home Assistant configurations for each device
-    type.
-13. See the [device documentation](mqtt.md) for additional commands.
+> Alternatively, if you choose to define your entities in Home Assistant
+> manually instead of using the Discovery Platform, see [Home Assistant yaml
+  config](HA_yaml_config.md)
+
+11. Restart the insteon-mqtt addon to pick up the changes to the `config.yaml` file.
+12. If you navigate in Home Assistant to __Configuration -> Integrations -> MQTT__ you should see your devices and entities.
+13. Initialize your devices as discussed in [initializing](initializing.md).
+14. See the [device documentation](mqtt.md) for additional commands.
 
 ## Backing up your Data
 

--- a/docs/HA_yaml_config.md
+++ b/docs/HA_yaml_config.md
@@ -1,0 +1,555 @@
+## Defining Entities in HomeAssistant Using Yaml
+
+> This page is only relevant to those who are using HomeAssistant
+> __without__ the Discovery Platform.
+
+The following are some example yaml configuration settings that can be used if
+you want to manually define your entities in HomeAssistant.  Manually defining
+your entities requires an intermediate level of familiarity with
+[Yaml](https://www.tutorialspoint.com/yaml/index.htm),
+[HomeAssistant](https://www.home-assistant.io/docs/configuration/),
+and [Jinja Templates](https://github.com/TD22057/insteon-mqtt/blob/master/docs/Templating.md).
+__Beginners are highly encouraged to use the Discovery Platform.__
+
+These are just example configurations. You will at minimum need to edit the
+names and addresses to match your devices.  You may also need to make changes
+to suit your setup.  For example, if you have changed the template for a topic
+you will need to alter how that topic is defined in HomeAssistant.
+
+> Configuration settings and variables for HomeAssistant are defined by
+> HomeAssistant.  We do not vigilantly track the changes that are made to
+> HomeAssistant, so it is possible that these examples may not be exactly
+> corret.
+
+<!-- TOC -->
+
+  - [Modem Scenes](#modem-scenes)
+  - [Switches](#switches)
+  - [Dimmers](#dimmers)
+  - [Generic Battery Sensors](#generic-battery-sensors)
+  - [Motion Sensors](#motion-sensors)
+  - [Hidden Door Sensors](#hidden-door-sensors)
+  - [Leak Sensors](#leak-sensors)
+  - [Remotes](#remotes)
+  - [SmokeBridge](#smokebridge)
+  - [Thermostat](#thermostat)
+  - [FanLinc](#fanlinc)
+  - [KeypadLincs](#keypadlincs)
+  - [IOLincs](#iolincs)
+  - [Outlets](#outlets)
+  - [EZIO4O](#ezio4o)
+
+<!-- /TOC -->
+
+### Modem Scenes
+
+There is no "state" for modem scenes.  So you only need to define the command
+topic.
+
+```yaml
+switch:
+  - platform: mqtt
+    name: Modem Group 10
+    command_topic: 'insteon/modem/scene'
+    payload_on: '{"state": "on", "group": "10"}'
+    payload_off: '{"state": "off", "group": "10"}'
+```
+
+### Switches
+
+```yaml
+switch:
+  - platform: mqtt
+    state_topic: 'insteon/aa.bb.cc/state'
+    command_topic: 'insteon/aa.bb.cc/set'
+    json_attributes_topic: 'insteon/aa.bb.cc/state'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+    value_template: '{{value_json.state}}'
+```
+
+### Dimmers
+
+```yaml
+light:
+  - platform: mqtt
+    schema: json
+    name: "insteon 1"
+    state_topic: "insteon/aa.bb.cc/state"
+    command_topic: "insteon/aa.bb.cc/level"
+    brightness: true
+    json_attributes_topic: "insteon/aa.bb.cc/state"
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+```
+
+### Generic Battery Sensors
+
+Generic Battery Sensors include triggerlinc door and window sensors.  But
+could also include other battery devices if no specific support has been
+added. Not all battery sensors off all of these entities.  For example the
+basic Triggerlinc door sensors do not have heartbeats.
+
+```yaml
+binary_sensor:
+  - platform: mqtt
+    name: Door Sensor
+    state_topic: 'insteon/aa.bb.cc/state'
+    device_class: 'door'
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/state'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+    value_template: '{{value_json.state}}'
+
+  - platform: mqtt
+    name: Door Sensor Battery
+    state_topic: 'insteon/aa.bb.cc/battery'
+    device_class: 'battery'
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/battery'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}}
+      }
+    value_template: '{{value_json.state}}'
+
+sensor:
+  - platform: mqtt
+    name: Door Sensor Heartbeat
+    state_topic: 'insteon/aa.bb.cc/heartbeat'
+    device_class: timestamp
+    force_update: true
+```
+
+### Motion Sensors
+
+```yaml
+binary_sensor:
+  - platform: mqtt
+    name: Motion Sensor
+    state_topic: 'insteon/aa.bb.cc/state'
+    device_class: motion
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/state'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+    value_template: '{{value_json.state}}'
+
+  - platform: mqtt
+    name: Motion Sensor Battery
+    state_topic: 'insteon/aa.bb.cc/battery'
+    device_class: 'battery'
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/battery'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}}
+      }
+    value_template: '{{value_json.state}}'
+
+  - platform: mqtt
+    name: Motion Sensor Dusk/Dawn
+    state_topic: 'insteon/aa.bb.cc/dawn'
+    device_class: light
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/dawn'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}}
+      }
+    value_template: '{{value_json.state}}'
+```
+
+### Hidden Door Sensors
+
+```yaml
+binary_sensor:
+  - platform: mqtt
+    name: Door Sensor
+    state_topic: 'insteon/aa.bb.cc/state'
+    device_class: 'door'
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/state'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+    value_template: '{{value_json.state}}'
+
+  - platform: mqtt
+    name: Door Sensor Battery
+    state_topic: 'insteon/aa.bb.cc/battery'
+    device_class: 'battery'
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/battery'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}}
+      }
+    value_template: '{{value_json.state}}'
+
+sensor:
+  - platform: mqtt
+    name: Door Sensor Heartbeat
+    state_topic: 'insteon/aa.bb.cc/heartbeat'
+    device_class: timestamp
+    force_update: true
+  - platform: mqtt
+    name: Door Sensor Voltage
+    state_topic: 'insteon/aa.bb.cc/battery_voltage'
+    device_class: 'voltage'
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/battery_voltage'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}}
+      }
+    value_template: '{{value_json.voltage}}'
+```
+
+### Leak Sensors
+
+```yaml
+binary_sensor:
+  - platform: mqtt
+    name: Leak Sensor
+    state_topic: 'insteon/aa.bb.cc/wet'
+    device_class: 'moisture'
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/wet'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}}
+      }
+    value_template: '{{value_json.state}}'
+
+sensor:
+  - platform: mqtt
+    name: Leak Sensor Heartbeat
+    state_topic: 'insteon/aa.bb.cc/heartbeat'
+    device_class: timestamp
+    force_update: true
+```
+
+### Remotes
+
+```yaml
+binary_sensor:
+  # You will need to repeat this entity entry for as many buttons as you have
+  - platform: mqtt
+    name: Remote Button 1
+    state_topic: 'insteon/aa.bb.cc/state/1'
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/state/1'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+    value_template: '{{value_json.state}}'
+
+  - platform: mqtt
+    name: Remote Battery
+    state_topic: 'insteon/aa.bb.cc/battery'
+    device_class: 'battery'
+    force_update: true
+    json_attributes_topic: 'insteon/aa.bb.cc/battery'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}}
+      }
+    value_template: '{{value_json.state}}'
+```
+
+### SmokeBridge
+
+```yaml
+binary_sensor:
+  - platform: mqtt
+    state_topic: 'insteon/aa.bb.cc/smoke'
+    name: Smoke Sensor
+    device_class: 'smoke'
+
+  - platform: mqtt
+    state_topic: 'insteon/aa.bb.cc/battery'
+    name: Smoke Detector Battery
+    device_class: 'battery'
+
+  - platform: mqtt
+    state_topic: 'insteon/aa.bb.cc/co'
+    name: Gas Sensor
+    device_class: 'gas'
+
+  - platform: mqtt
+    state_topic: 'insteon/aa.bb.cc/error'
+    name: Smoke Detector Problem
+    device_class: 'problem'
+```
+
+### Thermostat
+
+This example assumes the use of Farenheit, to use Celsius, be sure to make the
+necessary changes.
+
+```yaml
+climate:
+  - platform: mqtt
+    name: Upstairs Thermostat
+    mode_state_topic: "insteon/aa.bb.cc/mode_state"
+    current_temperature_topic: "insteon/aa.bb.cc/ambient_temp"
+    fan_mode_state_topic: "insteon/aa.bb.cc/fan_state"
+    fan_modes: ["auto", "on"]
+    action_topic: 'insteon/aa.bb.cc/status_state'
+    current_temperature_template: "{{value_json.temp_f}}"
+    fan_mode_command_topic: 'insteon/aa.bb.cc/fan_command'
+    hold_state_topic: 'insteon/aa.bb.cc/hold_state'
+    mode_command_topic: 'insteon/aa.bb.cc/mode_command'
+    mode_state_topic: 'insteon/aa.bb.cc/mode_state'
+    modes: ["off", "cool", "heat", "auto"]
+    precision: 1.0
+    temperature_high_command_topic: 'insteon/aa.bb.cc/cool_sp_command'
+    temperature_high_state_topic: 'insteon/aa.bb.cc/cool_sp_state'
+    temperature_high_state_template: "{{value_json.temp_f}}"
+    temperature_low_command_topic: 'insteon/aa.bb.cc/heat_sp_command'
+    temperature_low_state_topic: 'insteon/aa.bb.cc/heat_sp_state'
+    temperature_low_state_template: "{{value_json.temp_f}}"
+    temperature_unit: "F"
+```
+
+### FanLinc
+
+The light entity on the fan is a duplicate of the dimmer entry above.
+
+```yaml
+fan:
+  - platform: mqtt
+    name: FanLinc Fan
+    command_topic: 'insteon/aa.bb.cc/fan/set'
+    state_topic: 'insteon/aa.bb.cc/fan/state'
+    percentage_command_topic: 'insteon/aa.bb.cc/fan/speed/set'
+    percentage_command_template: >-
+      {% if value < 10 %}
+        off
+      {% elif value < 40 %}
+        low
+      {% elif value < 75 %}
+        medium
+      {% else %}
+        high
+      {% endif %}
+    percentage_state_topic: 'insteon/aa.bb.cc/fan/speed/state'
+    percentage_value_template: >-
+      {% if value == 'low' %}
+        33
+      {% elif value == 'medium' %}
+        67
+      {% elif value == 'high' %}
+        100
+      {% else %}
+        0
+      {% endif %}
+    preset_mode_state_topic: "insteon/aa.bb.cc/fan/speed/state"
+    preset_mode_command_topic: "insteon/aa.bb.cc/fan/speed/set"
+    preset_modes: ["off", "low", "medium", "high"]
+    json_attributes_topic: 'insteon/aa.bb.cc/fan/state'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "reason" : "{{value_json.reason}}"
+      }
+
+light:
+  - platform: mqtt
+    schema: json
+    name: "FanLinc Light"
+    state_topic: "insteon/aa.bb.cc/state"
+    command_topic: "insteon/aa.bb.cc/level"
+    brightness: true
+    json_attributes_topic: "insteon/aa.bb.cc/state"
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+```
+
+### KeypadLincs
+A KeypadLinc is an on/off or dimmer switch (Insteon group 1) plus a
+series of scene control buttons which operate on other groups.  The group
+1 behavior will depend on whether the device is an on/off or dimmer.  The
+4 or 6 other buttons are controlled like switches.
+
+6 button and 8 button keypads have use the following button numbers:
+```
+   1 on           1       2
+ 3       4        3       4
+ 5       6        5       6
+   1 off          7       8
+```
+
+```yaml
+#### Group 1 Entity
+# If KPL is a dimmer
+light:
+  - platform: mqtt
+    schema: json
+    name: "KPL Dimmer"
+    state_topic: "insteon/aa.bb.cc/state/1"
+    command_topic: "insteon/aa.bb.cc/set/1"
+    brightness: true
+    json_attributes_topic: "insteon/aa.bb.cc/state/1"
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+
+# If KPL is a switch
+switch:
+  - platform: mqtt
+    name: "KPL Switch"
+    state_topic: 'insteon/aa.bb.cc/state/1'
+    command_topic: 'insteon/aa.bb.cc/set/1'
+    json_attributes_topic: 'insteon/aa.bb.cc/state/1'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+    value_template: '{{value_json.state}}'
+
+#### Remaining Buttons
+# You will need to duplicate this entity for as many buttons as you have
+switch:
+  - platform: mqtt
+    name: "KPL Button 2"
+    state_topic: 'insteon/aa.bb.cc/state/2'
+    command_topic: 'insteon/aa.bb.cc/set/2'
+    json_attributes_topic: 'insteon/aa.bb.cc/state/2'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+    value_template: '{{value_json.state}}'
+```
+
+### IOLincs
+
+The IOLinc is both a switch (momentary or latching on/off) and a sensor
+that can be on or off.  If you configure the IOLinc to be momentary, then
+the on command will trigger it for the duration that is configured and
+the off command is ignored.  If it's configured as a latching switch,
+then the on and off commands work like a normal switch.
+
+> NOTE: the on/off payload forces the relay to on or off ignoring any special
+requirements associated with the Momentary_A,B,C functions or the
+relay_linked flag.
+
+```yaml
+switch:
+  - platform: mqtt
+    state_topic: 'insteon/aa.bb.cc/relay'
+    command_topic: 'insteon/aa.bb.cc/set'
+    name: IOLinc Relay
+    json_attributes_topic: 'insteon/aa.bb.cc/state'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+
+binary_sensor:
+  - platform: mqtt
+    state_topic: 'insteon/aa.bb.cc/sensor'
+    name: IOLinc Sensor
+    json_attributes_topic: 'insteon/aa.bb.cc/state'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+```
+
+### Outlets
+
+The non-dimming in wall outlet modules is two independent switches
+(top and bottom outlet).  The top outlet is group 1, the bottom
+outlet is group 2.
+
+```yaml
+switch:
+  - platform: mqtt
+    state_topic: 'insteon/aa.bb.cc/state/1'
+    command_topic: 'insteon/aa.bb.cc/set/1'
+    name: "Outlet Top"
+    json_attributes_topic: 'insteon/aa.bb.cc/state/1'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+    value_template: "{{value_json.state}}"
+
+  - platform: mqtt
+    state_topic: 'insteon/aa.bb.cc/state/2'
+    command_topic: 'insteon/aa.bb.cc/set/2'
+    name: "Outlet Top"
+    json_attributes_topic: 'insteon/aa.bb.cc/state/2'
+    json_attributes_template: >-
+      {
+      "timestamp" : {{value_json.timestamp}},
+      "mode" : "{{value_json.mode}}",
+      "reason" : "{{value_json.reason}}"
+      }
+    value_template: "{{value_json.state}}"
+```
+
+### EZIO4O
+
+```yaml
+switch:
+  - platform: mqtt
+    name: Relay 1
+    state_topic: 'insteon/aa.bb.cc/state/1'
+    command_topic: 'insteon/aa.bb.cc/set/1'
+  - platform: mqtt
+    name: Relay 2
+    state_topic: 'insteon/aa.bb.cc/state/2'
+    command_topic: 'insteon/aa.bb.cc/set/2'
+  - platform: mqtt
+    name: Relay 3
+    state_topic: 'insteon/aa.bb.cc/state/3'
+    command_topic: 'insteon/aa.bb.cc/set/3'
+  - platform: mqtt
+    name: Relay 4
+    state_topic: 'insteon/aa.bb.cc/state/4'
+    command_topic: 'insteon/aa.bb.cc/set/4'
+```

--- a/docs/HA_yaml_config.md
+++ b/docs/HA_yaml_config.md
@@ -521,7 +521,7 @@ switch:
   - platform: mqtt
     state_topic: 'insteon/aa.bb.cc/state/2'
     command_topic: 'insteon/aa.bb.cc/set/2'
-    name: "Outlet Top"
+    name: "Outlet Bottom"
     json_attributes_topic: 'insteon/aa.bb.cc/state/2'
     json_attributes_template: >-
       {

--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -217,27 +217,11 @@ mqtt:
       "via_device": "{{modem_addr}}"
     }
 
-  # Trigger modem virtual scenes.  Modem scenes are where the modem is a
-  # controller and emits a scene broadcast with the specified group number.
-  # There is no state topic since the scene doesn't have an on/off state.
-  #
-  # In Home Assistant use MQTT switch with a configuration like this to trigger
-  # modem scene 10:
-  #   switch:
-  #     - platform: mqtt
-  #       name: "scene #10"
-  #       command_topic: "insteon/modem/scene"
-  #       payload_on: { "cmd" : "on", "group" : 10 }
-  #       payload_off: { "cmd" : "off", "group" : 10 }
-  # In Home Assistant use MQTT switch with a configuration like this to trigger
-  # modem scene named 'test_scene':
-  #   switch:
-  #     - platform: mqtt
-  #       name: "test_scene"
-  #       command_topic: "insteon/modem/scene"
-  #       payload_on: { "cmd" : "on", "name" : test_scene }
-  #       payload_off: { "cmd" : "off", "name" : test_scene }
   modem:
+    # Trigger modem virtual scenes.  Modem scenes are where the modem is a
+    # controller and emits a scene broadcast with the specified group number.
+    # There is no state topic since the scene doesn't have an on/off state.
+
     # The output of passing the payload through the template must match the
     # following where group is in the range 1-255 and NAME is a string name
     # defined in a scenes.yaml file.  Either GROUP or NAME must be specified.
@@ -286,22 +270,13 @@ mqtt:
             "payload_off": "{\"state\": \"off\", \"group\": \"{{scene}}\"}"
           }
 
-  # IMPORTANT: all devices must have the pair() command run one time to make
-  # sure that the all the necessary controller/responder links are defined
-  # between the device and the modem.  If these links are there, the commands
-  # and outputs below will not work properly.
-
-  #------------------------------------------------------------------------
-  # On/off switches
-  #------------------------------------------------------------------------
-
-  # On/Off switch.  Non-dimming lamp modules and wall switches.  In Home
-  # Assistant use MQTT switch with a configuration like:
-  #   switch:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/state'
-  #       command_topic: 'insteon/aa.bb.cc/set'
   switch:
+    #------------------------------------------------------------------------
+    # On/off switches
+    #------------------------------------------------------------------------
+
+    # On/Off switch.  Non-dimming lamp modules and wall switches.
+
     # Output state change topic and template.  This message is sent whenever
     # the device state changes for any reason.  Available variables for
     # templating are:
@@ -375,23 +350,13 @@ mqtt:
             "val_tpl": "{% raw %}{{value_json.state}}{% endraw %}"
           }
 
-  #------------------------------------------------------------------------
-  # Dimmers
-  #------------------------------------------------------------------------
-
-  # Dimmer switch.  Dimming lamp modules and wall switches.  In Home
-  # Assistant use MQTT light with a configuration like the following -
-  # this gets HA to send the brightness value as the payload for all
-  # control of the light.
-  #   light:
-  #     - platform: mqtt
-  #       schema: json
-  #       name: "insteon 1"
-  #       state_topic: "insteon/48.b0.ad/state"
-  #       command_topic: "insteon/48.b0.ad/level"
-  #       brightness: true
-  #
   dimmer:
+    #------------------------------------------------------------------------
+    # Dimmers
+    #------------------------------------------------------------------------
+
+    # Dimmer switch.  Dimming lamp modules and wall switches.
+
     # Output state change topic and payload.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
@@ -436,7 +401,7 @@ mqtt:
     #   value = the input payload
     #   json = the input payload converted to json.  Use json.VAR to extract
     #          a variable from a json payload.
-    # NOTE: this isn't used by the HA example above - it's only useful when
+    # NOTE: this isn't used by the default HA setup - it's only useful when
     # treating the dimmer as an on/off switch and sending ON/OFF payloads
     on_off_topic: 'insteon/{{address}}/set'
     on_off_payload: '{ "cmd" : "{{value.lower()}}" }'
@@ -502,24 +467,15 @@ mqtt:
             {%- endraw -%}"
           }
 
-  #------------------------------------------------------------------------
-  # Battery powered sensors
-  #    door sensors, window sensors
-  #
-  #    Other devices (motion, leak, hidden_door, and remote) inherit the
-  #    topics defined here and then add a few more.
-  #------------------------------------------------------------------------
-
-  # In Home Assistant use MQTT binary sensor with a configuration like:
-  #   binary_sensor:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/state'
-  #       device_class: 'motion'
-  #
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/battery'
-  #       device_class: 'battery'
   battery_sensor:
+    #------------------------------------------------------------------------
+    # Battery powered sensors
+    #    door sensors, window sensors
+    #
+    #    Other devices (motion, leak, hidden_door, and remote) inherit the
+    #    topics defined here and then add a few more.
+    #------------------------------------------------------------------------
+
     # Output state change topic and payload.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
@@ -606,21 +562,15 @@ mqtt:
             "force_update": true
           }
 
-  #------------------------------------------------------------------------
-  # Motion sensors
-  #------------------------------------------------------------------------
-
-  # Motion sensors will use the state and low battery configuration
-  # inputs from battery_sensor and some sensors add an addition
-  # dawn/dusk notification which is configured here.
-  #
-  # To register the dawn/dusk signa in  Home Assistant use MQTT binary
-  # sensor with a configuration like:
-  #   binary_sensor:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/dawn'
-  #       device_class: 'light'
   motion:
+    #------------------------------------------------------------------------
+    # Motion sensors
+    #------------------------------------------------------------------------
+
+    # Motion sensors will use the state and low battery configuration
+    # inputs from battery_sensor and some sensors add an addition
+    # dawn/dusk notification which is configured here.
+
     # Output dawn/dusk change topic and payload.  This message is sent
     # whenever the device light sensor detects dawn or dusk changes.
     # Available variables for templating are:
@@ -685,21 +635,15 @@ mqtt:
             "val_tpl": "{% raw %}{{value_json.state}}{% endraw %}"
           }
 
-  #------------------------------------------------------------------------
-  # Hidden Door Sensors
-  #------------------------------------------------------------------------
-
-  # Hidden Door Sensors will use the state and low battery configuration
-  # inputs from battery_sensor and add battery voltage which is configured
-  # here.
-  #
-  # To register the battery voltage sensor in Home Assistant use MQTT
-  # sensor with a configuration like:
-  #   sensor:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/battery_voltage'
-  #       device_class: 'voltage'
   hidden_door:
+    #------------------------------------------------------------------------
+    # Hidden Door Sensors
+    #------------------------------------------------------------------------
+
+    # Hidden Door Sensors will use the state and low battery configuration
+    # inputs from battery_sensor and add battery voltage which is configured
+    # here.
+
     # Output topic and payload.  This message is sent
     # whenever the device is polled and a new voltage, low battery voltage
     # or heart beat interval is obtained from the device.
@@ -772,28 +716,18 @@ mqtt:
             "val_tpl": "{% raw %}{{value_json.voltage}}{% endraw %}"
           }
 
-  #------------------------------------------------------------------------
-  # Leak sensors
-  #------------------------------------------------------------------------
-
-  # Leak sensors will use the heartbeat configuration
-  # inputs from battery_sensor.
-  #
-  # Leak sensors will report the dry/wet status and a heartbeat every 24
-  # hours. The leak sensors does not support low battery signal like other
-  # battery operated devices.
-  #
-  # In Home Assistant use a combination of MQTT binary sensor and template
-  # sensor with a configuration like:
-  #   binary_sensor:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/wet'
-  #       device_class: 'moisture'
-  #
-  #   sensors:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/heartbeat'
   leak:
+    #------------------------------------------------------------------------
+    # Leak sensors
+    #------------------------------------------------------------------------
+
+    # Leak sensors will use the heartbeat configuration
+    # inputs from battery_sensor.
+    #
+    # Leak sensors will report the dry/wet status and a heartbeat every 24
+    # hours. The leak sensors does not support low battery signal like other
+    # battery operated devices.
+
     # Output wet/dry change topic and payload.  This message is sent
     # whenever the device changes state to wet or dry.
     # Available variables for templating are:
@@ -837,16 +771,17 @@ mqtt:
             "device": {{device_info_template}}
           }
 
-  #------------------------------------------------------------------------
-  # Mini remotes
-  #------------------------------------------------------------------------
-
-  # Battery powered remotes (usually 4 or 8 buttons).  A message is
-  # sent whenever one of the buttons is pressed.
-  #
-  # The Remote will use the low_battery configuration
-  # inputs from battery_sensor.
   remote:
+    #------------------------------------------------------------------------
+    # Mini remotes
+    #------------------------------------------------------------------------
+
+    # Battery powered remotes (usually 4 or 8 buttons).  A message is
+    # sent whenever one of the buttons is pressed.
+    #
+    # The Remote will use the low_battery configuration
+    # inputs from battery_sensor.
+
     # Output state change topic and template.  This message is sent
     # whenever a button is pressed.  Available variables for templating are:
     #   address = 'aa.bb.cc'
@@ -1011,30 +946,14 @@ mqtt:
             "val_tpl": "{% raw %}{{value_json.state}}{% endraw %}"
           }
 
-  #------------------------------------------------------------------------
-  # Smoke Bridge
-  #------------------------------------------------------------------------
-
-  # The smoke bridge will broadcast on a variety of groups for various error
-  # conditions.
-  #
-  # In Home Assistant use MQTT binary sensor with a configuration like:
-  #   binary_sensor:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/smoke'
-  #       device_class: 'smoke'
-  #
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/battery'
-  #       device_class: 'battery'
-  #
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/co'
-  #       device_class: 'gas'
-  #
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/error'
   smoke_bridge:
+    #------------------------------------------------------------------------
+    # Smoke Bridge
+    #------------------------------------------------------------------------
+
+    # The smoke bridge will broadcast on a variety of groups for various error
+    # conditions.
+
     # Output state change topic and payload.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
@@ -1095,31 +1014,16 @@ mqtt:
             "device": {{device_info_template}}
           }
 
-  #------------------------------------------------------------------------
-  # Thermostat
-  #------------------------------------------------------------------------
-
-  # The thermostat has a lot of available states and commands
-  #
-  #
-  # In Home Assistant use MQTT climate sensor with a configuration like:
-  # climate:
-  #   - platform: mqtt
-  #     name: Study
-  #     mode_state_topic: "insteon/aa.bb.cc/mode_state"
-  #     modes: ["OFF", "AUTO", "HEAT", "COOL", "PROGRAM"]
-  #     current_temperature_topic: "insteon/aa.bb.cc/ambient_temp"
-  #     fan_mode_state_topic: "insteon/aa.bb.cc/fan_state"
-  #     fan_modes: ["AUTO", "ON"]
-  #
-  # The current Home Assistant mqtt hvac component is not great.  It lacks
-  # a lot of functionality offered by the thermostat.  At some point I will
-  # submit a PR to Home Assistant to try and fix this.
-  # Major issues:
-  #   - no concept of separate heat and cool set points
-  #   - no humidity state
-  #   - no status state
   thermostat:
+    #------------------------------------------------------------------------
+    # Thermostat
+    #------------------------------------------------------------------------
+
+    # The thermostat has a lot of available states and commands
+
+    # The current Home Assistant mqtt hvac component lacks humidity which
+    # you could add as a seperate sensor.
+
     # Output state change topic and payload.  Available variables for
     # templating in all cases are:
     #   address = 'aa.bb.cc'
@@ -1219,54 +1123,22 @@ mqtt:
             "temperature_unit": "F"
           }
 
-  #------------------------------------------------------------------------
-  # Fan Linc
-  #------------------------------------------------------------------------
-
-  # A FanLinc is a dimmer switch (Insteon group 1) plus a fan control
-  # (group 2).  The dimmer MQTT messages use the dimmer settings
-  # above.  The settings here are just for the fan input and output.
-  # The settings can be used to turn the fan on and off (and report
-  # on/off state changes).
-  #
-  # NOTE: Both the fan state and fan speed state topics will be
-  # published on ANY fan change.  So if you only need one of them, you
-  # can put both payloads in a single message and set the other inputs
-  # to blank (which will turn off the output).
-  #
-  # In Home Assistant, use the dimmer example above for the light and
-  # use MQTT fan with a configuration like this for the fan:
-  # fan:
-  #   - platform: mqtt
-  #     command_topic: 'insteon/aa.bb.cc/fan/set'
-  #     state_topic: 'insteon/aa.bb.cc/fan/state'
-  #     percentage_command_topic: 'insteon/aa.bb.cc/fan/speed/set'
-  #     percentage_command_template: >
-  #       {% if value < 10 %}
-  #         off
-  #       {% elif value < 40 %}
-  #         low
-  #       {% elif value < 75 %}
-  #         medium
-  #       {% else %}
-  #         high
-  #       {% endif %}
-  #     percentage_state_topic: 'insteon/aa.bb.cc/fan/speed/state'
-  #     percentage_value_template: >
-  #       {% if value == 'low' %}
-  #         33
-  #       {% elif value == 'medium' %}
-  #         67
-  #       {% elif value == 'high' %}
-  #         100
-  #       {% else %}
-  #         0
-  #       {% endif %}
-  #     preset_mode_state_topic: "insteon/aa.bb.cc/fan/speed/state"
-  #     preset_mode_command_topic: "insteon/aa.bb.cc/fan/speed/set"
-  #     preset_modes: ["off", "low", "medium", "high"]
-
   fan_linc:
+    #------------------------------------------------------------------------
+    # Fan Linc
+    #------------------------------------------------------------------------
+
+    # A FanLinc is a dimmer switch (Insteon group 1) plus a fan control
+    # (group 2).  The dimmer MQTT messages use the dimmer settings
+    # above.  The settings here are just for the fan input and output.
+    # The settings can be used to turn the fan on and off (and report
+    # on/off state changes).
+    #
+    # NOTE: Both the fan state and fan speed state topics will be
+    # published on ANY fan change.  So if you only need one of them, you
+    # can put both payloads in a single message and set the other inputs
+    # to blank (which will turn off the output).
+
     # Output fan state change topic and payload.  This message is sent
     # whenever the fan state changes for any reason.  Available
     # variables for templating are:
@@ -1361,45 +1233,24 @@ mqtt:
             {%- endraw -%}"
           }
 
-  #------------------------------------------------------------------------
-  # Keypad Linc
-  #------------------------------------------------------------------------
-
-  # A KeypadLinc is an on/off or dimmer switch (Insteon group 1) plus a
-  # series of scene control buttons which operate on other groups.  The group
-  # 1 behavior will depend on whether the device is an on/off or dimmer.  The
-  # 4 or 6 other buttons are controlled like switches - but the only affect
-  # is turning on and off the LED on the button since they have no directly
-  # attached load.
-  #
-  # 6 button and 8 button keypads have use the following button numbers:
-  #    1 on           1       2
-  #  3       4        3       4
-  #  5       6        5       6
-  #    1 off          7       8
-  #
-  # In Home Assistant, use MQTT switches to represent the on/off switches and
-  # the MQTT json component for a dimmer.  The non-group 1 buttons are switches.
-  #   # dimmers:
-  #   light:
-  #     - platform: mqtt
-  #       schema: json
-  #       state_topic: "insteon/aa.bb.cc/state/1"
-  #       command_topic: "insteon/aa.bb.cc/set/1"
-  #       brightness: true
-  #
-  #   # switches:
-  #   switch:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/state/1'
-  #       command_topic: 'insteon/aa.bb.cc/set/1'
-  #
-  #   # other buttons:
-  #   switch:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/state/2'
-  #       command_topic: 'insteon/aa.bb.cc/set/2'
   keypad_linc:
+    #------------------------------------------------------------------------
+    # Keypad Linc
+    #------------------------------------------------------------------------
+
+    # A KeypadLinc is an on/off or dimmer switch (Insteon group 1) plus a
+    # series of scene control buttons which operate on other groups.  The group
+    # 1 behavior will depend on whether the device is an on/off or dimmer.  The
+    # 4 or 6 other buttons are controlled like switches - but the only affect
+    # is turning on and off the LED on the button since they have no directly
+    # attached load.
+    #
+    # 6 button and 8 button keypads have use the following button numbers:
+    #    1 on           1       2
+    #  3       4        3       4
+    #  5       6        5       6
+    #    1 off          7       8
+
     # On/off switch state change topic and template.  This message is sent
     # whenever one of the on/off buttons is pressed.  It will not be sent for
     # button 1 if it's a dimmer.  Available variables for templating are:
@@ -1677,36 +1528,26 @@ mqtt:
             "val_tpl": "{% raw %}{{value_json.state}}{% endraw %}"
           }
 
-  #------------------------------------------------------------------------
-  # IO Linc relay controllers
-  #------------------------------------------------------------------------
-
-  # The IOLinc is both a switch (momentary or latching on/off) and a sensor
-  # that can be on or off.  If you configure the IOLinc to be momentary, then
-  # the on command will trigger it for the duration that is configured and
-  # the off command is ignored.  If it's configured as a latching switch,
-  # then the on and off commands work like a normal switch.  The set-flags
-  # command line command can be used to change the settings.
-  #
-  # NOTE: the on/off payload forces the relay to on or off ignoring any special
-  # requirements associated with the Momentary_A,B,C functions or the
-  # relay_linked flag.  It can be used without issue for latching setups, but
-  # if you want to use this accurately for Momentary_A,B,C setups, you may need
-  # to have some logic upstream from this command to check the state of sensor
-  # and or the command to determine if setting the relay on or off is
-  # appropriate .
-  #
-  # In Home Assistant use MQTT switch with a configuration like:
-  #   switch:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/relay'
-  #       command_topic: 'insteon/aa.bb.cc/set'
-  #
-  # To monitor the sensor, use an MQTT binary_sensor with a configuration like:
-  #   binary_sensor:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/sensor'
   io_linc:
+    #------------------------------------------------------------------------
+    # IO Linc relay controllers
+    #------------------------------------------------------------------------
+
+    # The IOLinc is both a switch (momentary or latching on/off) and a sensor
+    # that can be on or off.  If you configure the IOLinc to be momentary, then
+    # the on command will trigger it for the duration that is configured and
+    # the off command is ignored.  If it's configured as a latching switch,
+    # then the on and off commands work like a normal switch.  The set-flags
+    # command line command can be used to change the settings.
+    #
+    # NOTE: the on/off payload forces the relay to on or off ignoring any special
+    # requirements associated with the Momentary_A,B,C functions or the
+    # relay_linked flag.  It can be used without issue for latching setups, but
+    # if you want to use this accurately for Momentary_A,B,C setups, you may need
+    # to have some logic upstream from this command to check the state of sensor
+    # and or the command to determine if setting the relay on or off is
+    # appropriate .
+
     # Output state change topic and template.  This message is sent whenever
     # the device sensor or device relay state changes.  Available variables for
     # templating are:
@@ -1788,23 +1629,15 @@ mqtt:
             {%- endraw -%}"
           }
 
-  #------------------------------------------------------------------------
-  # On/off outlets
-  #------------------------------------------------------------------------
-
-  # On/Off outlets.  Non-dimming in wall outlet modules is two independent
-  # switchs (top and bottom outlet.  The top outlet is button 1, the bottom
-  # outlet is button 2.  In Home Assistant use MQTT switch with a
-  # configuration like:
-  #   switch:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/state/1'
-  #       command_topic: 'insteon/aa.bb.cc/set/1'
-  #   switch:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/state/2'
-  #       command_topic: 'insteon/aa.bb.cc/set/2'
   outlet:
+    #------------------------------------------------------------------------
+    # On/off outlets
+    #------------------------------------------------------------------------
+
+    # On/Off outlets.  Non-dimming in wall outlet modules is two independent
+    # switchs (top and bottom outlet.  The top outlet is button 1, the bottom
+    # outlet is button 2.
+
     # Output state change topic and template.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:
@@ -1881,22 +1714,14 @@ mqtt:
             "val_tpl": "{% raw %}{{value_json.state}}{% endraw %}"
           }
 
-  #------------------------------------------------------------------------
-  # EZIO4O 4 relay output module
-  #------------------------------------------------------------------------
-  # EZIO4O is a 4 relay output wall plug module from Smartenit.
-  # Each relay has a normally open and a normally closed contact.
-  # Device relay 1 to 4 correspond to topics button 1 to 4.
-  # In Home Assistant use MQTT switch with a configuration like:
-  #   switch:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/state/1'
-  #       command_topic: 'insteon/aa.bb.cc/set/1'
-  #   switch:
-  #     - platform: mqtt
-  #       state_topic: 'insteon/aa.bb.cc/state/2'
-  #       command_topic: 'insteon/aa.bb.cc/set/2'
   ezio4o:
+    #------------------------------------------------------------------------
+    # EZIO4O 4 relay output module
+    #------------------------------------------------------------------------
+    # EZIO4O is a 4 relay output wall plug module from Smartenit.
+    # Each relay has a normally open and a normally closed contact.
+    # Device relay 1 to 4 correspond to topics button 1 to 4.
+
     # Output state change topic and template.  This message is sent
     # whenever the device state changes for any reason.  Available
     # variables for templating are:


### PR DESCRIPTION
## Proposed change
This adds a new documentation page with instructions for manually configuring HomeAssistant entities using yaml.  The page provides example yaml configurations that should work for all device types.

Any similar instructions contained in the config_base.yaml were removed.

The instructions for installing on Home Assistant were also updated to recommend using the Discovery Platform.

Comments in the config_base.yaml were also moved to be underneath there respective subkey.  This makes code folding of the comments possible.

## Additional information
- This PR is related to issue: #425

## Checklist
Note, no actual code was touched.  These are all comment or documentation changes.
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Code documentation was added where necessary
- [x] Documentation added/updated
