### PR TITLE
Add Min Max Values to Discovery and Suggested HA Config

### DIFF
--- a/docs/HA_yaml_config.md
+++ b/docs/HA_yaml_config.md
@@ -308,8 +308,7 @@ binary_sensor:
 
 ### Thermostat
 
-This example assumes the use of Farenheit, to use Celsius, be sure to make the
-necessary changes.
+#### Farenheit
 
 ```yaml
 climate:
@@ -323,6 +322,8 @@ climate:
     current_temperature_template: "{{value_json.temp_f}}"
     fan_mode_command_topic: 'insteon/aa.bb.cc/fan_command'
     hold_state_topic: 'insteon/aa.bb.cc/hold_state'
+    max_temp: 95
+    min_temp: 45
     mode_command_topic: 'insteon/aa.bb.cc/mode_command'
     mode_state_topic: 'insteon/aa.bb.cc/mode_state'
     modes: ["off", "cool", "heat", "auto"]

--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -1110,6 +1110,8 @@ mqtt:
             "fan_mode_stat_t": "{{fan_state_topic}}",
             "fan_modes": ["auto", "on"],
             "hold_stat_t": "{{hold_state_topic}}",
+            "max_temp": 95,
+            "min_temp": 45,
             "mode_cmd_t": "{{mode_command_topic}}",
             "mode_stat_t": "{{mode_state_topic}}",
             "modes": ["off", "cool", "heat", "auto"],


### PR DESCRIPTION
## Proposed change
Turns out HomeAssistant needs the min max values set, without them things can get weird.  This doesn't have any effect on anyone not using HomeAssistant.

Updated the default Discovery payload to provide the HA defaults for min and max temps.  Also updated the documentation of suggested HA configuration.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Documentation added/updated
