### PR TITLE
Add Encryption Support to MQTT Broker Connection

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -169,6 +169,25 @@ mqtt:
   #qos: 1
   #retain: 1
 
+  encryption:
+    # Encryption Options for encrypted broker connections
+    # These settings will be passed to the `tls_set()` method.  Please refer
+    # to the Paho client documentation for details:
+    # https://eclipse.org/paho/clients/python/docs/
+
+    # A string path to the Certificate Authority certificate files that are to
+    # be treated as trusted by this client.
+    # A Certificate Authority cert is REQUIRED for any encrypted connection.
+    # an encrypted connection will not be attempted unless this is specified.
+    # ca_cert:
+
+    # Client certificate and private key - Optional
+    # Used for TLS authentication of the client.
+    # Strings pointing to the PEM encoded client certificate and private keys.
+    # These CANNOT be encrypted with a password.
+    # certfile:
+    # keyfile:
+
   ### Discovery Settings
   #
   # Home Assistant implements mqtt device discovery as outlined at:

--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -154,6 +154,42 @@ mqtt:
   qos: 1
   retain: 1
 
+  encryption:
+    # Encryption Options for encrypted broker connections
+    # These settings will be passed to the `tls_set()` method.  Please refer
+    # to the Paho client documentation for details:
+    # https://eclipse.org/paho/clients/python/docs/
+
+    # A string path to the Certificate Authority certificate files that are to
+    # be treated as trusted by this client.
+    # A Certificate Authority cert is REQUIRED for any encrypted connection.
+    # an encrypted connection will not be attempted unless this is specified.
+    # ca_cert:
+
+    # Client certificate and private key - Optional
+    # Used for TLS authentication of the client.
+    # Strings pointing to the PEM encoded client certificate and private keys.
+    # These CANNOT be encrypted with a password.
+    # certfile:
+    # keyfile:
+
+    # The following generally do not need to be specified
+
+    # Specifies the version of the SSL/TLS protocol to be used.
+    # Can be: tls, tlsv1, tlsv11, tlsv12, sslv2, sslv23, sslv3
+    tls_version: tls
+
+    # A string that defines the certificate requirements that the client
+    # imposes on the broker. Can be 'none', 'required'
+    # none means just about any cert is accepted. Validation errors, such as
+    # untrusted or expired cert, are ignored and do not abort the TLS/SSL
+    # handshake.
+    cert_reqs: required
+
+    # A string specifying which encryption ciphers are allowable for this
+    # connection.  This is a very advanced setting!!
+    # ciphers:
+
   # Input commands topic to allow changes to a device.  See the device
   # documentation for details.  NOTE: This is usually not needed for
   # home automation - it's used by the command line tool to modify the

--- a/insteon_mqtt/data/config-schema.yaml
+++ b/insteon_mqtt/data/config-schema.yaml
@@ -174,6 +174,25 @@ mqtt:
       type: string
     id:
       type: string
+    encryption:
+      nullable: True
+      type: dict
+      schema:
+        ca_cert:
+          type: string
+        certfile:
+          type: string
+        keyfile:
+          type: string
+        tls_version:
+          type: string
+          allowed: ['tls', 'tlsv1', 'tlsv11', 'tlsv12', 'sslv2', 'sslv23',
+                    'sslv3']
+        ciphers:
+          type: string
+        cert_reqs:
+          type: string
+          allowed: ['none', 'optional', 'required']
     keep_alive:
       type: integer
       min: 0

--- a/insteon_mqtt/network/Mqtt.py
+++ b/insteon_mqtt/network/Mqtt.py
@@ -306,9 +306,12 @@ class Mqtt(Link):
                      self.port, self.keep_alive)
             return True
         except ssl.SSLError as e:
-            LOG.error("MQTT SSL/TLS connection error to %s %s. Specified "
-                      "tls_version or ciphers may not be supported by broker. "
-                      "Error %s",
+            # Sadly the exceptions returned are too general to give good
+            # instructions to the user.
+            LOG.error("MQTT SSL/TLS connection error to %s %s. Error %s "
+                      "Check if port is correct, if hostname matches cert. "
+                      "If you have specified tls_version or ciphers, check "
+                      "those too.",
                       self.host, self.port, e)
             sys.exit()
 

--- a/insteon_mqtt/network/Mqtt.py
+++ b/insteon_mqtt/network/Mqtt.py
@@ -3,6 +3,8 @@
 # Network link to an MQTT client class
 #
 #===========================================================================
+import ssl
+import sys
 import paho.mqtt.client as paho
 from .. import log
 from ..Signal import Signal
@@ -27,6 +29,42 @@ class Mqtt(Link):
     Input fields can be set via the constructor or by loading a configuration
     file (see load_config for details).
     """
+
+    # map for Paho acceptable TLS cert request options
+    CERT_REQ_OPTIONS = {'none': ssl.CERT_NONE, 'required': ssl.CERT_REQUIRED}
+
+    # Map for Paho acceptable TLS version options. Some options are
+    # dependent on the OpenSSL install so catch exceptions
+    TLS_VER_OPTIONS = dict()
+    try:
+        TLS_VER_OPTIONS['tls'] = ssl.PROTOCOL_TLS
+    except AttributeError:
+        pass
+    try:
+        TLS_VER_OPTIONS['tlsv1'] = ssl.PROTOCOL_TLSv1
+    except AttributeError:
+        pass
+    try:
+        TLS_VER_OPTIONS['tlsv11'] = ssl.PROTOCOL_TLSv1_1
+    except AttributeError:
+        pass
+    try:
+        TLS_VER_OPTIONS['tlsv12'] = ssl.PROTOCOL_TLSv1_2
+    except AttributeError:
+        pass
+    try:
+        TLS_VER_OPTIONS['sslv2'] = ssl.PROTOCOL_SSLv2
+    except AttributeError:
+        pass
+    try:
+        TLS_VER_OPTIONS['sslv23'] = ssl.PROTOCOL_SSLv23
+    except AttributeError:
+        pass
+    try:
+        TLS_VER_OPTIONS['sslv3'] = ssl.PROTOCOL_SSLv3
+    except AttributeError:
+        pass
+
     def __init__(self, host="127.0.0.1", port=1883, id=None,
                  reconnect_dt=10):
         """Construct an MQTT client.
@@ -108,6 +146,49 @@ class Mqtt(Link):
         if username is not None:
             password = config.get('password', None)
             self.client.username_pw_set(username, password)
+
+        encryption = config.get('encryption', {})
+        if encryption is None:
+            encryption = {}
+        ca_cert = encryption.get('ca_cert', None)
+        if ca_cert is not None and ca_cert != "":
+            LOG.info("Using TLS for MQTT broker connection.")
+            # Set the basic arguments
+            certfile = encryption.get('certfile', None)
+            if certfile == "":
+                certfile = None
+            keyfile = encryption.get('keyfile', None)
+            if keyfile == "":
+                keyfile = None
+            ciphers = encryption.get('ciphers', None)
+            if ciphers == "":
+                ciphers = None
+
+            # These require passing specific constants so we use a lookup
+            # map for them.
+            addl_tls_kwargs = {}
+            tls_ver = encryption.get('tls_version', 'tls')
+            tls_version_const = self.TLS_VER_OPTIONS.get(tls_ver, None)
+            if tls_version_const is not None:
+                addl_tls_kwargs['tls_version'] = tls_version_const
+            cert_reqs = encryption.get('cert_reqs', None)
+            cert_reqs = self.CERT_REQ_OPTIONS.get(cert_reqs, None)
+            if cert_reqs is not None:
+                addl_tls_kwargs['cert_reqs'] = cert_reqs
+
+            # Finally, try the connection
+            try:
+                self.client.tls_set(ca_certs=ca_cert,
+                                    certfile=certfile,
+                                    keyfile=keyfile,
+                                    ciphers=ciphers, **addl_tls_kwargs)
+            except FileNotFoundError as e:
+                LOG.error("Cannot locate a SSL/TLS file = %s.", e)
+                sys.exit()
+
+            except ssl.SSLError as e:
+                LOG.error("SSL/TLS Config error = %s.", e)
+                sys.exit()
 
     #-----------------------------------------------------------------------
     def publish(self, topic, payload, qos=0, retain=False):
@@ -224,6 +305,13 @@ class Mqtt(Link):
             LOG.info("MQTT device opened %s %s with keepalive=%s", self.host,
                      self.port, self.keep_alive)
             return True
+        except ssl.SSLError as e:
+            LOG.error("MQTT SSL/TLS connection error to %s %s. Specified "
+                      "tls_version or ciphers may not be supported by broker. "
+                      "Error %s",
+                      self.host, self.port, e)
+            sys.exit()
+
         except:
             LOG.exception("MQTT connection error to %s %s", self.host,
                           self.port)


### PR DESCRIPTION
## Proposed change
This adds optional support for encryption of the connection to the MQTT broker.  It also includes an option to use certificates to authenticate the client.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Code documentation was added where necessary
- [x] Documentation added/updated (Updated the contents of the relevant config.yaml files)
