### PR TITLE
Tweak KPL LED Bit Process; Add Unit Tests

### DIFF
--- a/insteon_mqtt/device/KeypadLinc.py
+++ b/insteon_mqtt/device/KeypadLinc.py
@@ -967,15 +967,15 @@ class KeypadLinc(Scene, Backlight, ManualCtrl, ResponderBase):
           level (int): The new device level in the range [0,255].  0 is off.
           reason (str): Reason string to pass around.
         """
-        if is_on is not None:
-            self._is_on = is_on
         group = 0x01 if group is None else group
         if group == self._load_group:
             self._level = level
+            if is_on is not None:
+                self._is_on = is_on
 
         # Update the LED bits in the correct slot.
         if group < 9:
             self._led_bits = util.bit_set(self._led_bits, group - 1,
-                                          1 if level else 0)
+                                          1 if is_on else 0)
 
     #-----------------------------------------------------------------------

--- a/tests/device/test_KeypadLincDev.py
+++ b/tests/device/test_KeypadLincDev.py
@@ -323,6 +323,7 @@ class Test_KPL():
         (0x06,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": True, "reason":'device', "button":6}),
         (0x07,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": True, "reason":'device', "button":7}),
         (0x08,Msg.CmdType.ON, 0x00,{"level":255,"mode":IM.on_off.Mode.NORMAL, "is_on": True, "reason":'device', "button":8}),
+        (0x08,Msg.CmdType.OFF, 0x00,{"level":0,"mode":IM.on_off.Mode.NORMAL, "is_on": False, "reason":'device', "button":8}),
     ])
     def test_handle_on_off(self, test_device, group_num, cmd1, cmd2, expected):
         test_device._load_group = 1
@@ -336,6 +337,11 @@ class Test_KPL():
                 mocked.assert_called_once_with(test_device, **expected)
             else:
                 mocked.assert_not_called()
+            if group_num > 1:
+                if cmd1 == Msg.CmdType.ON:
+                    assert test_device._led_bits == 2 ** (group_num -1)
+                else:
+                    assert test_device._led_bits == 0
 
     def test_get_flags(self, test_device):
         # This should hijack get flags and should insert a call to


### PR DESCRIPTION
## Proposed change

Written originally for #433, but it doesn't look like this is the problem.  Unit tests of the old and new code produce the same results.

Never the less, using is_on rather than level seems more clear for setting the led bits.

Added unit tests to catch if led bit setting is not happening.

## Additional information
- This PR is related to issue: #433

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.
