### PR TITLE
Add fan state to fan_linc discovery info

### DIFF
--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -1243,6 +1243,8 @@ mqtt:
             "name": "{{name_user_case}} fan",
             "device": {{device_info_template}},
             "cmd_t": "{{fan_on_off_topic}}",
+            "stat_t": "{{fan_state_topic}}",
+            "stat_val_tpl": "{% raw %}{{value_json.state}}{% endraw %}",
             "pct_cmd_t": "{{fan_speed_set_topic}}",
             "pct_cmd_tpl": "{% raw %}{% if value < 10 %}off{% elif value < 40 %}low{% elif value < 75 %}medium{% else %}high{% endif %}{% endraw %}",
             "pct_stat_t": "{{fan_speed_topic}}",


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!

  You're welcome!
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds state_topic and state_value_template to the discovery information for the fan component of fanlinc devices.  Without these topics, Home Assistant treats the fan as always off.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes a problem where Home Assistant displays the state of fanlinc fans as "off" even though they are actually on.

### Without fix:
![image](https://user-images.githubusercontent.com/59430211/132621649-21647543-8a3f-4c8c-b87d-6a881e0a0ea8.png)
![image](https://user-images.githubusercontent.com/59430211/132621737-99392879-155a-4906-8792-0b6ef65bfd8f.png)

### With fix:
![image](https://user-images.githubusercontent.com/59430211/132621775-97ff02d4-4606-4599-b7ac-ea8546b22aa7.png)
![image](https://user-images.githubusercontent.com/59430211/132621798-d659e742-1686-48c1-9877-1b6b623354e6.png)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
  - Tested by overriding discovery_entities in config.yaml and applying as custom discovery class.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
  - Four tests fail both on master and on my branch locally.  I assume this is just a problem with my environment.
- [x] Tests have been added to verify that the new code works.
  - No new code added
- [x] Code documentation was added where necessary
  - N/A

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated
  - N/A