### PR TITLE
Fix Heartbeat Timestamp Sensors in HomeAssistant Discovery

### DIFF
--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -595,7 +595,8 @@ mqtt:
             "stat_t": "{{heartbeat_topic}}",
             "device_class": "timestamp",
             "device": {{device_info_template}},
-            "force_update": true
+            "force_update": true,
+            "val_tpl": "{%- raw -%}{{as_datetime(value|float|timestamp_local).isoformat()|string}}{%- endraw -%}"
           }
 
   motion:
@@ -734,7 +735,8 @@ mqtt:
             "stat_t": "{{heartbeat_topic}}",
             "device_class": "timestamp",
             "device": {{device_info_template}},
-            "force_update": true
+            "force_update": true,
+            "val_tpl": "{%- raw -%}{{as_datetime(value|float|timestamp_local).isoformat()|string}}{%- endraw -%}"
           }
       - component: 'sensor'
         config: |-
@@ -804,7 +806,8 @@ mqtt:
             "name": "{{name_user_case}} heartbeat",
             "stat_t": "{{heartbeat_topic}}",
             "device_class": "timestamp",
-            "device": {{device_info_template}}
+            "device": {{device_info_template}},
+            "val_tpl": "{%- raw -%}{{as_datetime(value|float|timestamp_local).isoformat()|string}}{%- endraw -%}"
           }
 
   remote:


### PR DESCRIPTION
## Proposed change
I noticed that my heartbeat sensors associated with my leak sensors were displaying "invalid timestamp" in HomeAssistant.  I would swear that these worked previously and I am not sure when HA changed things.

This simply changes the default discovery template for the leak sensors to add a value template which converts our timestamp into an ISO8601 date string required by HomeAssistant.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.