### PR TITLE
Fix Wet Topic for Leak Sensor

### DIFF
--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -767,7 +767,9 @@ mqtt:
     # battery operated devices.
 
     # Output wet/dry change topic and payload.  This message is sent
-    # whenever the device changes state to wet or dry.
+    # whenever the device changes state to wet or dry.  This replaces the
+    # state_topic that would otherwise be inheritted from battery_sensor.
+    # If this is not specified, then state_topic will be used instead.
     # Available variables for templating are:
     #   address = 'aa.bb.cc'
     #   timestamp = the current timestamp

--- a/insteon_mqtt/mqtt/Leak.py
+++ b/insteon_mqtt/mqtt/Leak.py
@@ -24,7 +24,7 @@ class Leak(BatterySensor):
           device (device.Leak):  The Insteon object to link to.
         """
         super().__init__(mqtt, device,
-                         state_topic='insteon/{{address}}/wet',
+                         state_topic='insteon/{{address}}/state',
                          state_payload='{{is_wet_str.lower()}}')
 
         # This defines the default discovery_class for these devices

--- a/insteon_mqtt/mqtt/Leak.py
+++ b/insteon_mqtt/mqtt/Leak.py
@@ -46,7 +46,11 @@ class Leak(BatterySensor):
         if not data:
             return
 
-        # Load the various topics
+        # The state_topic uses a different name on the leak sensor
+        if 'state_topic' in self.rendered_topic_map:
+            self.rendered_topic_map.pop('state_topic')
+
+        # Load the special state topic
         self.load_state_data(data, qos, topic='wet_dry_topic',
                              payload='wet_dry_payload')
 
@@ -56,11 +60,6 @@ class Leak(BatterySensor):
             self.msg_heartbeat.load_config(data, 'heartbeat_topic',
                                            'heartbeat_payload', qos)
 
-        # Add our unique topics to the discovery topic map
-        # The state_topic uses a different name on the leak sensor
-        if 'state_topic' in self.rendered_topic_map:
-            rendered_topic = self.rendered_topic_map.pop('state_topic')
-            self.rendered_topic_map['wet_dry_topic'] = rendered_topic
 
     #-----------------------------------------------------------------------
     def state_template_data(self, **kwargs):


### PR DESCRIPTION
## Proposed change
The wrong topic string is being returned when the template variable `{{wet_dry_topic}}` for leak sensors.

I made a mistake with how I was adding the wet dry topic to the rendered topic map.  This fixes that error.

I fixed the unit tests to catch this error in the future.

There is one issue here.  We cannot specify a default topic string or payload string for the leak sensor in the code.  Because the wet_dry topic replaces the state_topic inherited from battery_sensor, the battery_sensor values will prevail if none are specified.  There is no elegant want to correct this.  The right answer would be to unify the config key values so that leak used state_topic and state_payload.  If future issues arise, we should consider that.

## Additional information
- This PR fixes or closes issue: #442

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.
- [x] Config documentation added/updated
