### PR TITLE
Use Remote Group When Adding Resp Link on Modem

### DIFF
--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -1305,9 +1305,15 @@ class Modem:
         seq = CommandSeq(self, "Device db update complete", on_done,
                          name="ModemDBUpd")
 
+        # Group number in the db is the group number of the controller since
+        # that's the group number in the broadcast message we'll receive.
+        db_group = local_group
+        if not is_controller:
+            db_group = remote_group
+
         # Create a new database entry for the modem and send it to the modem
         # for updating.
-        entry = db.ModemEntry(remote_addr, local_group, is_controller,
+        entry = db.ModemEntry(remote_addr, db_group, is_controller,
                               local_data)
         seq.add(self.db.add_on_device, entry)
 
@@ -1319,10 +1325,10 @@ class Modem:
             on_done = None
             if is_controller:
                 seq.add(remote.db_add_resp_of, remote_group, self.addr,
-                        local_group, two_way, refresh, remote_data=remote_data)
+                        local_group, two_way, refresh, local_data=remote_data)
             else:
                 seq.add(remote.db_add_ctrl_of, remote_group, self.addr,
-                        local_group, two_way, refresh, remote_data=remote_data)
+                        local_group, two_way, refresh, local_data=remote_data)
 
         # Start the command sequence.
         seq.run()

--- a/tests/test_Modem.py
+++ b/tests/test_Modem.py
@@ -3,11 +3,13 @@
 # Tests for: insteont_mqtt/Modem.py
 #
 #===========================================================================
+import logging
 import pytest
 # from pprint import pprint
 from unittest import mock
 from unittest.mock import call
 import insteon_mqtt as IM
+from insteon_mqtt.device.base.Base import Base
 import insteon_mqtt.message as Msg
 import insteon_mqtt.util as util
 import helpers as H
@@ -23,6 +25,42 @@ def test_device():
     device = IM.Modem(protocol, stack, timed_call)
     return device
 
+@pytest.fixture
+def test_device_2(tmpdir):
+    '''
+    Returns a generically configured device for testing
+    '''
+    protocol = H.main.MockProtocol()
+    modem = H.main.MockModem(tmpdir)
+    modem.db = IM.db.Modem(None, modem)
+    modem.scenes = IM.Scenes.SceneManager(modem, None)
+    addr = IM.Address(0x56, 0x78, 0xcd)
+    device = Base(protocol, modem, addr)
+    return device
+
+@pytest.fixture
+def test_entry_2():
+    addr = IM.Address('56.78.cd')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x01
+    in_use = True
+    is_controller = True
+    is_last_rec = False
+    db_flags = Msg.DbFlags(in_use, is_controller, is_last_rec)
+    mem_loc = 1
+    return IM.db.DeviceEntry(addr, group, mem_loc, db_flags, data)
+
+@pytest.fixture
+def test_entry_multigroup():
+    addr = IM.Address('56.78.cd')
+    data = bytes([0xff, 0x00, 0x00])
+    group = 0x02
+    in_use = True
+    is_controller = True
+    is_last_rec = False
+    db_flags = Msg.DbFlags(in_use, is_controller, is_last_rec)
+    mem_loc = 1
+    return IM.db.DeviceEntry(addr, group, mem_loc, db_flags, data)
 
 class Test_Base_Config():
     def test_load_config_no_addr(self, test_device):
@@ -87,3 +125,103 @@ class Test_Base_Config():
         for record in caplog.records:
             assert record.levelname != "ERROR"
         assert test_device.addr == IM.Address('44.85.12')
+
+    def test_db_update(self, test_device, test_entry_2,
+                       test_device_2, caplog):
+        test_device.add(test_device_2)
+        with mock.patch.object(IM.CommandSeq, 'add') as mocked:
+            with caplog.at_level(logging.DEBUG):
+                two_way = True
+                refresh = True
+                test_device._db_update(test_entry_2.group,
+                                       test_entry_2.is_controller,
+                                       test_entry_2.addr,
+                                       test_entry_2.group,
+                                       two_way,
+                                       refresh,
+                                       None,
+                                       bytes([0x00, 0x00, 0x00]),
+                                       test_entry_2.data)
+                assert mocked.call_count == 2
+                call_args = mocked.call_args_list
+                assert call_args[0].args[0] == test_device.db.add_on_device
+                assert call_args[0].args[1].addr == test_entry_2.addr
+                assert call_args[0].args[1].group == test_entry_2.group
+                assert call_args[0].args[1].is_controller == test_entry_2.is_controller
+                assert call_args[0].args[1].data == bytes([0x00, 0x00, 0x00])
+                assert call_args[1] == call(test_device_2.db_add_resp_of, 
+                                            test_entry_2.group,
+                                            test_device.addr, test_entry_2.group, 
+                                            False,
+                                            refresh, local_data=test_entry_2.data)
+
+    def test_db_update_resp(self, test_device, test_entry_2,
+                            test_device_2, caplog):
+        test_device.add(test_device_2)
+        with mock.patch.object(IM.CommandSeq, 'add') as mocked:
+            with caplog.at_level(logging.DEBUG):
+                two_way = True
+                refresh = True
+                test_device._db_update(test_entry_2.group,
+                                       False,
+                                       test_entry_2.addr,
+                                       test_entry_2.group,
+                                       two_way,
+                                       refresh,
+                                       None,
+                                       bytes([0x00, 0x00, 0x00]),
+                                       test_entry_2.data)
+                assert mocked.call_count == 2
+                call_args = mocked.call_args_list
+                assert call_args[0].args[0] == test_device.db.add_on_device
+                assert call_args[0].args[1].addr == test_entry_2.addr
+                assert call_args[0].args[1].group == test_entry_2.group
+                assert call_args[0].args[1].is_controller == False
+                assert call_args[0].args[1].data == bytes([0x00, 0x00, 0x00])
+                assert call_args[1] == call(test_device_2.db_add_ctrl_of, test_entry_2.group,
+                                            test_device.addr, test_entry_2.group, False,
+                                            refresh, local_data=test_entry_2.data)
+
+    def test_db_update_no_remote(self, test_device, test_entry_2, caplog):
+        with mock.patch.object(IM.CommandSeq, 'add') as mocked:
+            with caplog.at_level(logging.DEBUG):
+                two_way = True
+                refresh = True
+                test_device._db_update(test_entry_2.group,
+                                       test_entry_2.is_controller,
+                                       test_entry_2.addr,
+                                       test_entry_2.group,
+                                       two_way,
+                                       refresh,
+                                       None,
+                                       bytes([0x00, 0x00, 0x00]),
+                                       test_entry_2.data)
+                calls = [call(test_device.db.add_on_device, test_entry_2.addr,
+                              test_entry_2.group, test_entry_2.is_controller,
+                              bytes([0x00, 0x00, 0x00]))]
+                assert mocked.call_count == 1
+                call_args = mocked.call_args_list
+                assert call_args[0].args[0] == test_device.db.add_on_device
+                assert call_args[0].args[1].addr == test_entry_2.addr
+                assert call_args[0].args[1].group == test_entry_2.group
+                assert call_args[0].args[1].is_controller == test_entry_2.is_controller
+                assert call_args[0].args[1].data == bytes([0x00, 0x00, 0x00])
+                assert "Modem db add CTRL can't find remote" in caplog.text
+
+    def test_db_add_resp_multigroup(self, test_device, test_device_2, 
+                                    test_entry_multigroup):
+        test_device.add(test_device_2)
+        with mock.patch.object(IM.CommandSeq, 'add') as mocked:
+            test_device.db_add_resp_of(0x01,  # local group for responder links on modem is always 0x01
+                                       test_device_2.addr,
+                                       test_entry_multigroup.group,
+                                       False,
+                                       False,
+                                       local_data=bytes([0x00, 0x00, 0x00]))
+            assert mocked.call_count == 1
+            call_args = mocked.call_args_list
+            assert call_args[0].args[0] == test_device.db.add_on_device
+            assert call_args[0].args[1].addr == test_entry_multigroup.addr
+            assert call_args[0].args[1].group == test_entry_multigroup.group
+            assert call_args[0].args[1].is_controller == False
+            assert call_args[0].args[1].data == bytes([0x00, 0x00, 0x00])


### PR DESCRIPTION
## Proposed change
This is a __significant__ bug fix.  Not sure how long this has been an issue.  I only noticed it when I had to replace a PLM.

### The Issue
When pairing a multigroup device such as a keypadlinc, remote, motion, ... The responder links for the secondary groups (not 0/1) were not being added to the modem.

This was happening because `_db_update` on the modem was treating the local_group as the scene group number for responder links.  Since all responder links on the modem have a local_group of `0x01` this essentially meant that only one responder link would be added to the modem per device since all responder links looked the same.

### The Solution
The solution is to use the remote_group as the scene group number on responder links.  This code is written properly for all other devices except the modem, so I just copied the same code.

## Additional information
I am not sure how long this has been happening.  The code I modified is 4 years old.  But I believe things were working at some point.  Strange

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.  Including tests to catch any change in this in the future.
- [x] Code documentation was added where necessary