### PR TITLE
Invert On_Only and Night_Only Bits on Motion Sensor

### DIFF
--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -250,10 +250,11 @@ class Motion(BatterySensor):
             on_only = self.on_only
 
         # Generate the value of the combined flags.
+        # on_only and night_only are inverted
         value = 0
         value = util.bit_set(value, 3, led_on)
-        value = util.bit_set(value, 2, night_only)
-        value = util.bit_set(value, 1, on_only)
+        value = util.bit_set(value, 2, False if night_only else True)
+        value = util.bit_set(value, 1, False if on_only else True)
 
         # Push the flags value to the device.
         data = bytes([

--- a/tests/device/test_MotionDev.py
+++ b/tests/device/test_MotionDev.py
@@ -246,20 +246,20 @@ class Test_Base_Config():
         # already test extended flags above
 
     def test_change_flags_led_on(self, test_device):
-        test_device.led_on = 1
+        test_device.led_on = 0
         test_device.night_only = 1
         test_device.on_only = 1
         def on_done(*args):
             pass
         # Mark awake so messages get sent to protocol
         test_device.awake(on_done)
-        test_device._change_flags({'led_on':0})
+        test_device._change_flags({'led_on':1})
         # should see an ext flag request first
         assert len(test_device.protocol.sent) == 1
         assert test_device.protocol.sent[0].msg.cmd1 == Msg.CmdType.EXTENDED_SET_GET
         assert test_device.protocol.sent[0].msg.cmd2 == 0x00
         assert test_device.protocol.sent[0].msg.data[1] == 0x05  # Set flags
-        assert test_device.protocol.sent[0].msg.data[2] == 0x06
+        assert test_device.protocol.sent[0].msg.data[2] == 0x08
 
     def test_change_flags_night_only(self, test_device):
         test_device.led_on = 1
@@ -275,7 +275,7 @@ class Test_Base_Config():
         assert test_device.protocol.sent[0].msg.cmd1 == Msg.CmdType.EXTENDED_SET_GET
         assert test_device.protocol.sent[0].msg.cmd2 == 0x00
         assert test_device.protocol.sent[0].msg.data[1] == 0x05  # Set flags
-        assert test_device.protocol.sent[0].msg.data[2] == 0x0A
+        assert test_device.protocol.sent[0].msg.data[2] == 0x0C
 
     def test_change_flags_on_only(self, test_device):
         test_device.led_on = 1
@@ -291,7 +291,7 @@ class Test_Base_Config():
         assert test_device.protocol.sent[0].msg.cmd1 == Msg.CmdType.EXTENDED_SET_GET
         assert test_device.protocol.sent[0].msg.cmd2 == 0x00
         assert test_device.protocol.sent[0].msg.data[1] == 0x05  # Set flags
-        assert test_device.protocol.sent[0].msg.data[2] == 0x0C
+        assert test_device.protocol.sent[0].msg.data[2] == 0x0A
 
     def test_change_flags_bad(self, test_device, caplog):
         test_device.led_on = 1


### PR DESCRIPTION
## Proposed change
On_Only and Night_Only are actually false on the device.  Looking back at my old notes, I captured this data before, but failed to pay attention to the bit value and was only focused on the position.

This is just a simple fix to invert those bits when setting them.

Tests were updated to catch this.

## Additional information
- This PR fixes or closes issue: fixes #462

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.