### PR TITLE
Overhaul of Commandline Help Output

### DIFF
--- a/insteon_mqtt/cmd_line/argparse_ext.py
+++ b/insteon_mqtt/cmd_line/argparse_ext.py
@@ -1,0 +1,57 @@
+#===========================================================================
+#
+# Extend Argparse to Enable Sub-Parser Groups
+#
+# Based on this very old issue: https://bugs.python.org/issue9341
+#
+# Adds the method `add_parser_group()` to the sub-parser class.
+# This adds a group heading to the sub-parser list, just like the
+# `add_argument_group()` method.
+#
+# NOTE: As noted on the issue page, this probably won't work with [parents].
+# see http://bugs.python.org/issue16807
+#
+#===========================================================================
+# Pylint doesn't like us access protected items like this
+#pylint:disable=protected-access,abstract-method
+import argparse
+
+
+class _SubParsersAction(argparse._SubParsersAction):
+
+    class _PseudoGroup(argparse.Action):
+
+        def __init__(self, container, title):
+            sup = super(_SubParsersAction._PseudoGroup, self)
+            sup.__init__(option_strings=[], dest=title)
+            self.container = container
+            self._choices_actions = []
+
+        def add_parser(self, name, **kwargs):
+            # add the parser to the main Action, but move the pseudo action
+            # in the group's own list
+            parser = self.container.add_parser(name, **kwargs)
+            choice_action = self.container._choices_actions.pop()
+            self._choices_actions.append(choice_action)
+            return parser
+
+        def _get_subactions(self):
+            return self._choices_actions
+
+        def add_parser_group(self, title):
+            # the formatter can handle recursive subgroups
+            grp = _SubParsersAction._PseudoGroup(self, title)
+            self._choices_actions.append(grp)
+            return grp
+
+    def add_parser_group(self, title):
+        #
+        grp = _SubParsersAction._PseudoGroup(self, title)
+        self._choices_actions.append(grp)
+        return grp
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.register('action', 'parsers', _SubParsersAction)

--- a/insteon_mqtt/cmd_line/main.py
+++ b/insteon_mqtt/cmd_line/main.py
@@ -3,8 +3,8 @@
 # Command line parsing and main entry point.
 #
 #===========================================================================
-import argparse
 import sys
+from . import argparse_ext
 from .. import config
 from . import device
 from . import modem
@@ -16,17 +16,44 @@ def parse_args(args):
     """Input is command line arguments w/o arg[0]
     """
     # pylint: disable=too-many-statements
-    p = argparse.ArgumentParser(prog="insteon-mqtt",
-                                description="Insteon<->MQTT tool")
+    prog_description = """ This is a Python 3 package that communicates with
+                       an Insteon PLM modem (USB and serial) or an Insteon Hub
+                       and converts Insteon state changes to MQTT and MQTT
+                       commands to Insteon commands. It allows an Insteon
+                       network to be integrated into and controlled from
+                       anything that can use MQTT. This package works well
+                       with HomeAssistant and can be easily installed as an
+                       addon using the HomeAssistant Supervisor."""
+    p = argparse_ext.ArgumentParser(prog="insteon-mqtt",
+                                    description=prog_description)
     p.add_argument('-v', '--version', action='version', version='%(prog)s ' +
                    __version__)
     p.add_argument("config", metavar="config.yaml", help="Configuration "
                    "file to use.")
-    sub = p.add_subparsers(help="Command help")
+    sub = p.add_subparsers(title="commands",
+                           description="See %(prog)s config.yaml <command> -h"
+                                       " for specific command help.",
+                           metavar="command")
+
+    # Define sub-parser groups.  The order they appear here will define the
+    # order they print on the screen
+    startgrp = sub.add_parser_group('\n    Startup:')
+    initgrp = sub.add_parser_group('\n    Initialize:')
+    commandgrp = sub.add_parser_group('\n    Device Commands:')
+    infogrp = sub.add_parser_group('\n    Get Information:')
+    configgrp = sub.add_parser_group('\n    Configure:')
+    linkgrp = sub.add_parser_group('\n    Link Management:')
+    systemgrp = sub.add_parser_group('\n    System Wide:')
+    batterygrp = sub.add_parser_group('\n    Battery Devices:')
+    advancedgrp = sub.add_parser_group('\n    Advanced Commands:')
+
+    # Define sub-parser commands.  The order they appear here will define the
+    # order they appear within their respective groups.
 
     #---------------------------------------
     # START command
-    sp = sub.add_parser("start", help="Start the Insteon<->MQTT server.")
+    sp = startgrp.add_parser("start", help="Start the Insteon<->MQTT server.",
+                             description="Start the Insteon<->MQTT server.")
     sp.add_argument("-l", "--log", metavar="log_file",
                     help="Logging file to use.")
     sp.add_argument("-ls", "--log-screen", action="store_true",
@@ -37,19 +64,51 @@ def parse_args(args):
     sp.set_defaults(func=start.start)
 
     #---------------------------------------
+    # modem.join_all command
+    sp = systemgrp.add_parser("join-all", help="Run 'join' command on all "
+                              "devices.",
+                              description="Run 'join' command on all devices.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=modem.join_all)
+
+    #---------------------------------------
+    # modem.pair_all command
+    sp = systemgrp.add_parser("pair-all", help="Run 'pair' command on all "
+                              "devices.",
+                              description="Run 'pair' command on all devices.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=modem.pair_all)
+
+    #---------------------------------------
     # modem.refresh_all command
-    sp = sub.add_parser("refresh-all", help="Call refresh all on the devices "
-                        "in the configuration.")
+    sp = systemgrp.add_parser("refresh-all", help="Run 'refresh' command on "
+                              "all devices.",
+                              description="Run 'refresh' command on all "
+                              "devices.")
     sp.add_argument("-f", "--force", action="store_true",
                     help="Force the modem/device database to be downloaded.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=modem.refresh_all)
 
+    # modem.get_engine_all command
+    sp = systemgrp.add_parser("get-engine-all", help="Run 'get-engine' "
+                              "command on all devices.",
+                              description="Run 'get-engine' command on all "
+                              "devices.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=modem.get_engine_all)
+
     #---------------------------------------
     # modem.sync_all command
-    sp = sub.add_parser("sync-all", help="Call sync on all the devices "
-                        "in the configuration.")
+    sp = systemgrp.add_parser("sync-all", help="Run 'sync' command on all "
+                              "devices.",
+                              description="Run 'sync' command on all devices. "
+                              "This will add or remove links on the device to "
+                              "match those defined in the scenes.yaml file.")
     sp.add_argument("--run", action="store_true", default=False,
                     help="Perform the actions altering the device db to bring "
                     "it in sync.  If not specified, will perform a dry-run "
@@ -63,8 +122,13 @@ def parse_args(args):
 
     #---------------------------------------
     # modem.import_scenes_all command
-    sp = sub.add_parser("import-scenes-all", help="Call import-scenes on all "
-                        "the devices in the configuration.")
+    sp = systemgrp.add_parser("import-scenes-all", help="Run 'import-scenes' "
+                              "command on all devices.",
+                              description="Run 'import-scenes' command on all "
+                              "devices. This will add all links defined on "
+                              "the devices to the scenes.yaml file.  Any link "
+                              "defined in the scenes.yaml file that is not "
+                              "present on the devices will be DELETED.")
     sp.add_argument("--run", action="store_true", default=False,
                     help="Perform the actions altering the scenes config file "
                     "to bring it in sync.  If not specified, will perform a "
@@ -73,50 +137,44 @@ def parse_args(args):
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=modem.import_scenes_all)
 
-    # modem.get_engine_all command
-    sp = sub.add_parser("get-engine-all", help="Call get-engine on the "
-                        "devices in the configuration.")
-    sp.add_argument("-q", "--quiet", action="store_true",
-                    help="Don't print any command results to the screen.")
-    sp.set_defaults(func=modem.get_engine_all)
-
-    #---------------------------------------
-    # modem.join_all command
-    sp = sub.add_parser("join-all", help="Call join all on the devices "
-                        "in the configuration.")
-    sp.add_argument("-q", "--quiet", action="store_true",
-                    help="Don't print any command results to the screen.")
-    sp.set_defaults(func=modem.join_all)
-
-    #---------------------------------------
-    # modem.pair_all command
-    sp = sub.add_parser("pair-all", help="Call pair all on the devices "
-                        "in the configuration.")
-    sp.add_argument("-q", "--quiet", action="store_true",
-                    help="Don't print any command results to the screen.")
-    sp.set_defaults(func=modem.pair_all)
-
-    #---------------------------------------
-    # modem.factory_reset command
-    sp = sub.add_parser("factory-reset", help="Perform a remote factory "
-                        "reset.  Currently only supported on the modem.")
-    sp.add_argument("-q", "--quiet", action="store_true",
-                    help="Don't print any command results to the screen.")
-    sp.set_defaults(func=modem.factory_reset)
-
     #---------------------------------------
     # modem.get_devices command
-    sp = sub.add_parser("get-devices", help="Return a list of all the devices "
-                        "that the modem knows about.")
+    sp = infogrp.add_parser("get-devices", help="Print a list of all the "
+                            "devices that the program knows about.",
+                            description="Print a list of all the devices "
+                                        "that the program knows about.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.set_defaults(func=modem.get_devices)
 
     #---------------------------------------
+    # device.print_db
+    sp = linkgrp.add_parser("print-db", help="Print the cache of the device "
+                            "database.",
+                            description="Print the cache of the device "
+                            "database.")
+    sp.add_argument("address", help="Device address or name.")
+    sp.set_defaults(func=device.print_db)
+
+    #---------------------------------------
+    # device.refresh command
+    sp = linkgrp.add_parser("refresh", help="Refresh device state and link "
+                            "database.",
+                            description="Refresh device state and link "
+                            "database.")
+    sp.add_argument("-f", "--force", action="store_true",
+                    help="Force the device database to be downloaded.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.add_argument("address", help="Device address or name.")
+    sp.set_defaults(func=device.refresh)
+
+    #---------------------------------------
     # device.linking command
-    sp = sub.add_parser("linking", help="Turn on device or modem linking.  "
-                        "This is the same as holding the modem set button "
-                        "for 3 seconds.")
+    sp = linkgrp.add_parser("linking", help="Put device into linking mode.",
+                            description="Put device into linking mode. This "
+                                        "is the same as holding the device "
+                                        "set button for 3 seconds.")
     sp.add_argument("-g", "--group", type=int, default=0x01,
                     help="Group number to link with (1-255)")
     sp.add_argument("-q", "--quiet", action="store_true",
@@ -126,33 +184,31 @@ def parse_args(args):
 
     #---------------------------------------
     # device.join command
-    sp = sub.add_parser("join", help="Join the device to the modem. "
-                        "Allows the modem to talk to the device.")
+    sp = initgrp.add_parser("join", help="Join a device to the modem.",
+                            description="Join a device to the modem. "
+                            "This adds a modem->device link, which "
+                            "allows the modem to talk to the device. "
+                            "This is generally the first thing you need "
+                            "to do with a new device.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.add_argument("address", help="Device address or name.")
     sp.set_defaults(func=device.join)
 
     #---------------------------------------
-    # device.refresh command
-    sp = sub.add_parser("refresh", help="Refresh device/modem state and "
-                        "all link database.")
-    sp.add_argument("-f", "--force", action="store_true",
-                    help="Force the device database to be downloaded.")
-    sp.add_argument("-q", "--quiet", action="store_true",
-                    help="Don't print any command results to the screen.")
-    sp.add_argument("address", help="Device address or name.")
-    sp.set_defaults(func=device.refresh)
-
-    #---------------------------------------
     # device.get_flags command
-    sp = sub.add_parser("get-flags", help="Get device operating flags.")
+    sp = infogrp.add_parser("get-flags", help="Get device operating flags.",
+                            description="Get the device operating flags.")
     sp.add_argument("address", help="Device address or name.")
     sp.set_defaults(func=device.get_flags)
 
     #---------------------------------------
     # device.set_flags command
-    sp = sub.add_parser("set-flags", help="Set device operating flags.")
+    sp = configgrp.add_parser("set-flags", help="Set device operating flags.",
+                              description="Set device operating flags. "
+                              "Flags are set using FLAG=VALUE format. "
+                              "Use an intentionally bad flag such as "
+                              "BAD=FLAG to see a list of valid flags.")
     sp.add_argument("address", help="Device address or name.")
     sp.add_argument("flags", nargs="+", help="FLAG=VALUE to set.  Valid "
                     "flags names are device dependent.  See the device "
@@ -161,19 +217,25 @@ def parse_args(args):
 
     #---------------------------------------
     # device.get_engine command
-    sp = sub.add_parser("get-engine", help="Get device engine version.")
+    sp = infogrp.add_parser("get-engine", help="Get device engine version.",
+                            description="Get device engine version. "
+                            "May solve communications problems with the "
+                            "device.")
     sp.add_argument("address", help="Device address or name.")
     sp.set_defaults(func=device.get_engine)
 
     #---------------------------------------
     # device.get_model command
-    sp = sub.add_parser("get-model", help="Get device model information.")
+    sp = infogrp.add_parser("get-model", help="Get device model information.",
+                            description="Get device model information.")
     sp.add_argument("address", help="Device address or name.")
     sp.set_defaults(func=device.get_model)
 
     #---------------------------------------
     # device.on command
-    sp = sub.add_parser("on", help="Turn a device on.")
+    sp = commandgrp.add_parser("on", help="Turn a device on.",
+                               description="Turn a device on. Will not "
+                               "trigger linked devices, see 'scene' for that.")
     sp.add_argument("-l", "--level", metavar="level", type=int, default=255,
                     help="Level to use for dimmers (0-255)")
     sp.add_argument("-q", "--quiet", action="store_true",
@@ -193,8 +255,31 @@ def parse_args(args):
     sp.set_defaults(func=device.on)
 
     #---------------------------------------
+    # device.off command
+    sp = commandgrp.add_parser("off", help="Turn a device off.",
+                               description="Turn a device off.  Will not "
+                               "trigger linked devices, see 'scene' for that.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.add_argument("-g", "--group", type=int, default=0x01,
+                    help="Group (button) number to turn off for multi-button "
+                    "devices.")
+    sp.add_argument("-r", "--reason", metavar="reason", type=str, default="",
+                    help="Reason message to send with the command.  No "
+                    "message with use 'command'.")
+    gp = sp.add_mutually_exclusive_group()
+    gp.add_argument("-i", "--instant", dest="mode", action="store_const",
+                    const="instant", help="Instant (rather than ramping) on.")
+    gp.add_argument("-f", "--fast", dest="mode", action="store_const",
+                    const="fast", help="Send an Insteon fast on command.")
+    sp.add_argument("address", help="Device address or name.")
+    sp.set_defaults(func=device.off)
+
+    #---------------------------------------
     # device.set command
-    sp = sub.add_parser("set", help="Turn a device to specific level.")
+    sp = commandgrp.add_parser("set", help="Turn a device to specific level.",
+                               description="Turn a device to specific level. "
+                               "Will not trigger linked devices.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.add_argument("-g", "--group", type=int, default=0x01,
@@ -214,27 +299,10 @@ def parse_args(args):
     sp.set_defaults(func=device.set)
 
     #---------------------------------------
-    # device.off command
-    sp = sub.add_parser("off", help="Turn a device off.")
-    sp.add_argument("-q", "--quiet", action="store_true",
-                    help="Don't print any command results to the screen.")
-    sp.add_argument("-g", "--group", type=int, default=0x01,
-                    help="Group (button) number to turn off for multi-button "
-                    "devices.")
-    sp.add_argument("-r", "--reason", metavar="reason", type=str, default="",
-                    help="Reason message to send with the command.  No "
-                    "message with use 'command'.")
-    gp = sp.add_mutually_exclusive_group()
-    gp.add_argument("-i", "--instant", dest="mode", action="store_const",
-                    const="instant", help="Instant (rather than ramping) on.")
-    gp.add_argument("-f", "--fast", dest="mode", action="store_const",
-                    const="fast", help="Send an Insteon fast on command.")
-    sp.add_argument("address", help="Device address or name.")
-    sp.set_defaults(func=device.off)
-
-    #---------------------------------------
     # device.increment_up command
-    sp = sub.add_parser("up", help="Increments a dimmer up.")
+    sp = commandgrp.add_parser("up", help="Increments a dimmer up.",
+                               description="Increments a dimmer up in 1/32 "
+                               "steps. Will not trigger linked devices.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.add_argument("-r", "--reason", metavar="reason", type=str, default="",
@@ -244,8 +312,10 @@ def parse_args(args):
     sp.set_defaults(func=device.increment_up)
 
     #---------------------------------------
-    # device.increment_up command
-    sp = sub.add_parser("down", help="Decrements a dimmer up.")
+    # device.increment_down command
+    sp = commandgrp.add_parser("down", help="Decrements a dimmer down.",
+                               description="Increments a dimmer down in 1/32 "
+                               "steps. Will not trigger linked devices.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.add_argument("-r", "--reason", metavar="reason", type=str, default="",
@@ -256,7 +326,11 @@ def parse_args(args):
 
     #---------------------------------------
     # device.scene command
-    sp = sub.add_parser("scene", help="Simulate a scene command.")
+    sp = commandgrp.add_parser("scene", help="Simulate a scene command.",
+                               description="Simulate a scene command. "
+                               "This triggers the device to react as though "
+                               "its button was pressed, causing all linked "
+                               "devices to react as well.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.add_argument("-r", "--reason", metavar="reason", type=str, default="",
@@ -278,7 +352,13 @@ def parse_args(args):
 
     #---------------------------------------
     # device.pair command
-    sp = sub.add_parser("pair", help="Pair a device with the modem.")
+    sp = initgrp.add_parser("pair", help="Pair a device with the modem.",
+                            description="Pair a device to the modem. "
+                            "This adds all the necessary device->modem links, "
+                            "so that the modem will be informed of changes on "
+                            "the device. "
+                            "This is generally the second thing you need "
+                            "to do with a new device.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.add_argument("address", help="Device address or name.")
@@ -286,11 +366,12 @@ def parse_args(args):
 
     #---------------------------------------
     # device.db_add add ctrl/rspdr command
-    sp = sub.add_parser("db-add", help="Add the device/modem as the "
-                        "controller or responder of another device.  The "
-                        "addr1 input sets the device to modify.  Also adds "
-                        "the corresponding entry on the linked device unless "
-                        "--one-way is set.")
+    sp = advancedgrp.add_parser("db-add", help="Add a link.",
+                                description="Add the device/modem as the "
+                                "controller or responder of another device.  "
+                                "The addr1 input sets the device to modify.  "
+                                "Also adds the corresponding entry on the "
+                                "linked device unless --one-way is set.")
     sp.add_argument("-o", "--one-way", action="store_true",
                     help="Only add the entry on address1.  Otherwise the "
                     "corresponding entry on address2 is also added.")
@@ -322,10 +403,12 @@ def parse_args(args):
 
     #---------------------------------------
     # device.db_del delete ctrl/rspdr command
-    sp = sub.add_parser("db-delete", help="Delete an entry in the device/"
-                        "modem's all link database with the input address, "
-                        "group, and mode.  Also deletes the corresponding "
-                        "entry on the linked device unless --one-way is set.")
+    sp = advancedgrp.add_parser("db-delete", help="Delete a link.",
+                                description="Delete an entry in the device/"
+                                "modem's all link database with the input "
+                                "address, group, and mode.  Also deletes the "
+                                "corresponding entry on the linked device "
+                                "unless --one-way is set.")
     sp.add_argument("-o", "--one-way", action="store_true",
                     help="Only delete the modem entries.  Otherwise the "
                     "corresponding entry on the device is also removed.")
@@ -346,8 +429,10 @@ def parse_args(args):
 
     #---------------------------------------
     # device.set_button_led
-    sp = sub.add_parser("set-button-led", help="Set the button LED state for "
-                        "a KeyPadLinc.")
+    sp = configgrp.add_parser("set-button-led", help="Set the button LED "
+                              "state for a KeyPadLinc.",
+                              description="Set the button LED state for a "
+                              "KeyPadLinc.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
     sp.add_argument("address", help="Device address or name.")
@@ -357,14 +442,12 @@ def parse_args(args):
     sp.set_defaults(func=device.set_button_led)
 
     #---------------------------------------
-    # device.print_db
-    sp = sub.add_parser("print-db", help="Print the current device database")
-    sp.add_argument("address", help="Device address or name.")
-    sp.set_defaults(func=device.print_db)
-
-    #---------------------------------------
     # device.sync
-    sp = sub.add_parser("sync", help="Sync the defined scenes with device db")
+    sp = linkgrp.add_parser("sync", help="Sync the scenes defined in "
+                            "scenes.yaml with device.",
+                            description="This will add or remove links on the "
+                                        "device to match those defined in the "
+                                        "scenes.yaml file.")
     sp.add_argument("address", help="Device address or name.")
     sp.add_argument("--run", action="store_true", default=False,
                     help="Perform the actions altering the device db to bring "
@@ -379,8 +462,14 @@ def parse_args(args):
 
     #---------------------------------------
     # device.import_scenes
-    sp = sub.add_parser("import-scenes", help="Import all of the scenes "
-                        "defined on the device into the scenes config file.")
+    sp = linkgrp.add_parser("import-scenes", help="Import all of the scenes "
+                                                  "defined on the device into "
+                                                  "the scenes.yaml file.",
+                            description="This will add all links defined on "
+                                        "the device to the scenes.yaml file. "
+                                        "Any link defined in the scenes.yaml "
+                                        "file that is not present on the "
+                                        "device will be DELETED.")
     sp.add_argument("address", help="Device address or name.")
     sp.add_argument("--run", action="store_true", default=False,
                     help="Perform the actions altering the scenes config file "
@@ -393,9 +482,18 @@ def parse_args(args):
     #---------------------------------------
     # device.awake
     # Only works on battery devices
-    sp = sub.add_parser("awake", help="Mark a battery device as being awake."
-                        "Hold the set button on the device until the light "
-                        "blinks to force the device awake for 3 minutes.")
+    sp = batterygrp.add_parser("awake", help="Mark a battery device as being "
+                               "awake.",
+                               description="Mark a battery device as being "
+                                           "awake. Necessary in order to send "
+                                           "commands to the device in real "
+                                           "time. Otherwise commands will be "
+                                           "queued until the device is next "
+                                           "awake. To wake up a battery "
+                                           "device hold the set button on the "
+                                           "device until the light blinks. "
+                                           "The device will remain awake for "
+                                           "~3 minutes.")
     sp.add_argument("address", help="Device address or name.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
@@ -404,9 +502,11 @@ def parse_args(args):
     #---------------------------------------
     # device.get_battery_voltage
     # Only works on some battery devices
-    sp = sub.add_parser("get-battery-voltage", help="Check the battery "
-                        "voltage.  Will request the value the nex time the "
-                        "device is awake.")
+    sp = batterygrp.add_parser("get-battery-voltage", help="Check the battery "
+                               "voltage.",
+                               description="Check the battery voltage. Will "
+                                           "request the value "
+                                           "the nex time the device is awake.")
     sp.add_argument("address", help="Device address or name.")
     sp.add_argument("-q", "--quiet", action="store_true",
                     help="Don't print any command results to the screen.")
@@ -415,8 +515,12 @@ def parse_args(args):
     #---------------------------------------
     # device.set_low_battery_voltage
     # Only works on some battery devices, notably those with removable batts
-    sp = sub.add_parser("set-low-battery-voltage", help="Sets the threshold "
-                        "voltage at which a battery will be signaled as low.")
+    sp = batterygrp.add_parser("set-low-battery-voltage", help="Sets the "
+                               "threshold voltage at which a battery will be "
+                               "signaled as low.",
+                               description="Sets the threshold "
+                               "voltage at which a battery will be signaled "
+                               "as low.")
     sp.add_argument("address", help="Device address or name.")
     sp.add_argument("voltage", type=float, help="Low voltage as float.")
     sp.add_argument("-q", "--quiet", action="store_true",
@@ -427,8 +531,11 @@ def parse_args(args):
 
     #---------------------------------------
     # device.raw_message
-    sp = sub.add_parser("raw-command", help="Sends a raw message to a "
-                            "configured device")
+    sp = advancedgrp.add_parser("raw-command", help="Sends a raw message to "
+                                "the device.",
+                                description="Sends a raw message to the "
+                                            "device. Useful for testing "
+                                            "features not yet supported")
     sp.add_argument("address", help="Device address or name.")
     sp.add_argument("cmd1", type=auto_int, help="cmd1 byte (supports "
                         "both hex and decimal)")
@@ -445,6 +552,18 @@ def parse_args(args):
     sp.add_argument("-q", "--quiet", action="store_true",
                         help="Don't print any command results to the screen.")
     sp.set_defaults(func=device.send_raw_command)
+
+    #---------------------------------------
+    # modem.factory_reset command
+    sp = advancedgrp.add_parser("factory-reset", help="Perform a remote "
+                                "factory reset.  Currently only supported on "
+                                "the modem.",
+                                description="Perform a remote factory "
+                                "reset.  Currently only supported on the "
+                                "modem.")
+    sp.add_argument("-q", "--quiet", action="store_true",
+                    help="Don't print any command results to the screen.")
+    sp.set_defaults(func=modem.factory_reset)
 
     return p.parse_args(args)
 


### PR DESCRIPTION
## Proposed change
A major cleanup of the helptext produced on the command line.

* Removed excess matter where possible
* Add description and pointer to command help
* Extend Argparse module to Enable Grouping Sub-Parsers
* Create groups for all commands to make them easier to find and read.
* Reorder Commands in a logical fashion
* Rewrite some help text
* Add Description to all Commands so that command help contains details about the command.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.

### Example of Changes

#### Prior Output

```
usage: insteon-mqtt [-h] [-v]
                    config.yaml
                    {start,refresh-all,sync-all,import-scenes-all,get-engine-all,join-all,pair-all,factory-reset,
get-devices,linking,join,refresh,get-flags,set-flags,get-engine,get-model,on,set,off,up,down,scene,
pair,db-add,db-delete,set-button-led,print-db,sync,import-scenes,awake,get-battery-voltage,
set-low-battery-voltage,raw-command}
                    ...

Insteon<->MQTT tool

positional arguments:
  config.yaml           Configuration file to use.
  {start,refresh-all,sync-all,import-scenes-all,get-engine-all,join-all,pair-all,factory-reset,get-devices,
linking,join,refresh,get-flags,set-flags,get-engine,get-model,on,set,off,up,down,scene,pair,db-add,
db-delete,set-button-led,print-db,sync,import-scenes,awake,get-battery-voltage,
set-low-battery-voltage,raw-command}
                        Command help
    start               Start the Insteon<->MQTT server.
    refresh-all         Call refresh all on the devices in the configuration.
    sync-all            Call sync on all the devices in the configuration.
    import-scenes-all   Call import-scenes on all the devices in the configuration.
    get-engine-all      Call get-engine on the devices in the configuration.
    join-all            Call join all on the devices in the configuration.
    pair-all            Call pair all on the devices in the configuration.
    factory-reset       Perform a remote factory reset. Currently only supported on the modem.
    get-devices         Return a list of all the devices that the modem knows about.
    linking             Turn on device or modem linking. This is the same as holding the modem set
                        button for 3 seconds.
    join                Join the device to the modem. Allows the modem to talk to the device.
    refresh             Refresh device/modem state and all link database.
    get-flags           Get device operating flags.
    set-flags           Set device operating flags.
    get-engine          Get device engine version.
    get-model           Get device model information.
    on                  Turn a device on.
    set                 Turn a device to specific level.
    off                 Turn a device off.
    up                  Increments a dimmer up.
    down                Decrements a dimmer up.
    scene               Simulate a scene command.
    pair                Pair a device with the modem.
    db-add              Add the device/modem as the controller or responder of another device. The
                        addr1 input sets the device to modify. Also adds the corresponding entry on
                        the linked device unless --one-way is set.
    db-delete           Delete an entry in the device/modem's all link database with the input
                        address, group, and mode. Also deletes the corresponding entry on the
                        linked device unless --one-way is set.
    set-button-led      Set the button LED state for a KeyPadLinc.
    print-db            Print the current device database
    sync                Sync the defined scenes with device db
    import-scenes       Import all of the scenes defined on the device into the scenes config file.
    awake               Mark a battery device as being awake.Hold the set button on the device
                        until the light blinks to force the device awake for 3 minutes.
    get-battery-voltage
                        Check the battery voltage. Will request the value the nex time the device
                        is awake.
    set-low-battery-voltage
                        Sets the threshold voltage at which a battery will be signaled as low.
    raw-command         Sends a raw message to a configured device

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
```

#### New Output

```
usage: insteon-mqtt [-h] [-v] config.yaml command ...

This is a Python 3 package that communicates with an Insteon PLM modem (USB and serial) or an
Insteon Hub and converts Insteon state changes to MQTT and MQTT commands to Insteon commands. It
allows an Insteon network to be integrated into and controlled from anything that can use MQTT.
This package works well with HomeAssistant and can be easily installed as an addon using the
HomeAssistant Supervisor.

positional arguments:
  config.yaml           Configuration file to use.

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit

commands:
  See insteon-mqtt config.yaml <command> -h for specific command help.

  command
    
    Startup:
      start             Start the Insteon<->MQTT server.
    
    Initialize:
      join              Join a device to the modem.
      pair              Pair a device with the modem.
    
    Device Commands:
      on                Turn a device on.
      off               Turn a device off.
      set               Turn a device to specific level.
      up                Increments a dimmer up.
      down              Decrements a dimmer down.
      scene             Simulate a scene command.
    
    Get Information:
      get-devices       Print a list of all the devices that the program knows about.
      get-flags         Get device operating flags.
      get-engine        Get device engine version.
      get-model         Get device model information.
    
    Configure:
      set-flags         Set device operating flags.
      set-button-led    Set the button LED state for a KeyPadLinc.
    
    Link Management:
      print-db          Print the cache of the device database.
      refresh           Refresh device state and link database.
      linking           Put device into linking mode.
      sync              Sync the scenes defined in scenes.yaml with device.
      import-scenes     Import all of the scenes defined on the device into the scenes.yaml file.
    
    System Wide:
      join-all          Run 'join' command on all devices.
      pair-all          Run 'pair' command on all devices.
      refresh-all       Run 'refresh' command on all devices.
      get-engine-all    Run 'get-engine' command on all devices.
      sync-all          Run 'sync' command on all devices.
      import-scenes-all
                        Run 'import-scenes' command on all devices.
    
    Battery Devices:
      awake             Mark a battery device as being awake.
      get-battery-voltage
                        Check the battery voltage.
      set-low-battery-voltage
                        Sets the threshold voltage at which a battery will be signaled as low.
    
    Advanced Commands:
      db-add            Add a link.
      db-delete         Delete a link.
      raw-command       Sends a raw message to the device.
      factory-reset     Perform a remote factory reset. Currently only supported on the modem.
```

#### Old Awake Command Help

```
usage: insteon-mqtt config.yaml awake [-h] [-q] address

positional arguments:
  address      Device address or name.

optional arguments:
  -h, --help   show this help message and exit
  -q, --quiet  Don't print any command results to the screen.
```

#### New Awake Command Help

```
usage: insteon-mqtt config.yaml awake [-h] [-q] address

Mark a battery device as being awake. Necessary in order to send commands to the device in real
time. Otherwise commands will be queued until the device is next awake. To wake up a battery device
hold the set button on the device until the light blinks. The device will remain awake for ~3
minutes.

positional arguments:
  address      Device address or name.

optional arguments:
  -h, --help   show this help message and exit
  -q, --quiet  Don't print any command results to the screen.
```