### PR TITLE
Allow 'scenes.yaml' to be empty

### DIFF
--- a/insteon_mqtt/data/scenes-schema.yaml
+++ b/insteon_mqtt/data/scenes-schema.yaml
@@ -24,6 +24,7 @@
 ## document contents
 
 scenes:
+  nullable: True
   type: list
   schema:
     type: dict

--- a/tests/configs/scenes_empty.yaml
+++ b/tests/configs/scenes_empty.yaml
@@ -1,0 +1,7 @@
+insteon:
+  port: '/dev/insteon'
+  scenes: !rel_path empty.yaml
+
+mqtt:
+  broker: 127.0.0.1
+  port: 1883

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,13 @@ class Test_config:
         assert val == ""
 
     #-----------------------------------------------------------------------
+    def test_scenes_empty(self):
+        file = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                            'configs', 'scenes_empty.yaml')
+        val = IM.config.validate(file)
+        assert val == ""
+
+    #-----------------------------------------------------------------------
     def test_validate_addr(self):
         validator = IM.config.IMValidator()
         validator._error = mock.Mock()


### PR DESCRIPTION
This allows users to enable scene support and then import their
existing scenes from the Insteon network.

- This PR fixes or closes issue: fixes #482

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
- [ ] Code documentation was added where necessary

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated
