### PR TITLE
Home Assistant Dropped Support for the Hold Mode

### DIFF
--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -1185,7 +1185,6 @@ mqtt:
             "fan_mode_cmd_t": "{{fan_command_topic}}",
             "fan_mode_stat_t": "{{fan_state_topic}}",
             "fan_modes": ["auto", "on"],
-            "hold_stat_t": "{{hold_state_topic}}",
             "max_temp": 95,
             "min_temp": 45,
             "mode_cmd_t": "{{mode_command_topic}}",


### PR DESCRIPTION
## Breaking change
HomeAssistant dropped support for the Hold State for climate devices.
Hopefully this isn't too much of a big deal since Insteon only allows
reading and not setting this state.

## Proposed change
Removed the hold_state_topic from the discovery config

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.