### PR TITLE
Fixes for Changes in Home Assistant 2022-06

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,5 +12,6 @@
     "schema": {},
     "image": "td22057/{arch}-insteon-mqtt",
     "ingress": true,
-    "ingress_port": 8099
+    "ingress_port": 8099,
+    "init": false
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ paho-mqtt>=1.3
 pyserial>=3.2
 pyyaml>=3
 Jinja2>=2.1
-ruamel.yaml>=0.15
+ruamel.yaml>=0.15,<=0.17.17
 Flask>=1.1.2
 Flask-SocketIO>=4.3.2
 requests>=2.18.2


### PR DESCRIPTION
I think if you attempted to install Insteon-MQTT as an addon for the first time in HomeAssistant 2022-06 it would fail.

## Proposed change
HomeAssistant now requires `init:false` to be set in the `config.json` which was previously a default setting.

Additionally, it seems that Ruamel >= 0.17.18 will not compile when building in docker.  Not sure why this is, but
in the interim, I am pegging to <=0.17.17 which shouldn't be an issue.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.