### PR TITLE
Suppress Flask Runtime Error

### DIFF
--- a/hassio/webcli/app.py
+++ b/hassio/webcli/app.py
@@ -106,4 +106,4 @@ def handle_estop(message):
         app.config['cmd'] = []
 
 def start_webcli():
-    socketio.run(app, host='0.0.0.0', port='8099')
+    socketio.run(app, host='0.0.0.0', port='8099', allow_unsafe_werkzeug=True)


### PR DESCRIPTION
Adds a newly required flag that allows Flask webserver to run.

As before, you will continue to get the following at the start of your log:

```
WebSocket transport not available. Install simple-websocket for improved performance.
Werkzeug appears to be used in a production deployment. Consider switching to a production web server instead.
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
```

This is fine.  We are running a webserver for a single client behind the authentication of HomeAssistant and behind the ingress proxy. 