### PR TITLE
Fix switch state representation for scenes that turn switches off

### DIFF
--- a/insteon_mqtt/device/Switch.py
+++ b/insteon_mqtt/device/Switch.py
@@ -40,3 +40,67 @@ class Switch(Scene, Backlight, ManualCtrl, ResponderBase):
         self.group_map.update({0x01: self.handle_on_off})
 
     #-----------------------------------------------------------------------
+    def group_cmd_on_off(self, entry, is_on):
+        """Determine if device turns on or off for this Group Command
+
+        For switches, the database entry holds the actual on/off state that
+        is applied when the ON command is received.
+
+        Args:
+          entry (DeviceEntry):  The local db entry for this group command.
+          is_on (bool): Whether the command was ON or OFF
+        Returns:
+          is_on (bool):  The actual is_on value based on DB entry
+        """
+        # For on command, get actual on/off state from the database entry
+        if is_on:
+            is_on = bool(entry.data[0])
+        return is_on
+
+    #-----------------------------------------------------------------------
+    def link_data_to_pretty(self, is_controller, data):
+        """Converts Link Data1-3 to Human Readable Attributes
+
+        This takes a list of the data values 1-3 and returns a dict with
+        the human readable attibutes as keys and the human readable values
+        as values.
+
+        Args:
+          is_controller (bool): True if the device is the controller, false
+                        if it's the responder.
+          data (list[3]): List of three data values.
+
+        Returns:
+          list[3]:  list, containing a dict of the human readable values
+        """
+        ret = [{'data_1': data[0]}, {'data_2': data[1]}, {'data_3': data[2]}]
+        if not is_controller:
+            on = 1 if data[0] else 0
+            ret = [{'on_off': on},
+                   {'data_2': data[1]},
+                   {'data_3': data[2]}]
+        return ret
+
+    #-----------------------------------------------------------------------
+    def link_data_from_pretty(self, is_controller, data):
+        """Converts Link Data1-3 from Human Readable Attributes
+
+        This takes a dict of the human readable attributes as keys and their
+        associated values and returns a list of the data1-3 values.
+
+        Args:
+          is_controller (bool): True if the device is the controller, false
+                        if it's the responder.
+          data (dict[3]): Dict of three data values.
+
+        Returns:
+          list[3]: List of Data1-3 values
+        """
+        data_1, data_2, data_3 = super().link_data_from_pretty(is_controller,
+                                                               data)
+        if not is_controller:
+            if 'on_off' in data:
+                data_1 = 0xFF if data['on_off'] else 0x00
+        return [data_1, data_2, data_3]
+
+    #-----------------------------------------------------------------------

--- a/insteon_mqtt/device/base/ResponderBase.py
+++ b/insteon_mqtt/device/base/ResponderBase.py
@@ -289,6 +289,7 @@ class ResponderBase(Base):
                      self.label, msg.group, addr)
             is_on, mode = on_off.Mode.decode(msg.cmd1)
             level = self.group_cmd_on_level(entry, is_on)
+            is_on = self.group_cmd_on_off(entry, is_on)
             self._set_state(group=localGroup, is_on=is_on, level=level,
                             mode=mode, reason=reason)
 
@@ -340,6 +341,21 @@ class ResponderBase(Base):
         """
         level = None
         return level
+
+    #-----------------------------------------------------------------------
+    def group_cmd_on_off(self, entry, is_on):
+        """Determine if device turns on or off for this Group Command
+
+        For example, the database entry holds the actual on/off state that
+        is applied when the ON command is received by switches.
+
+        Args:
+          entry (DeviceEntry):  The local db entry for this group command.
+          is_on (bool): Whether the command was ON or OFF
+        Returns:
+          is_on (bool):  The actual is_on value based on DB entry
+        """
+        return is_on
 
     #-----------------------------------------------------------------------
     def group_cmd_handle_increment(self, cmd, group, reason):

--- a/tests/device/test_SwitchDev.py
+++ b/tests/device/test_SwitchDev.py
@@ -116,6 +116,22 @@ class Test_Base_Config():
             else:
                 assert IM.Signal.emit.call_count == 0
 
+    @pytest.mark.parametrize("data_1, pretty_data_1, name, is_controller", [
+        (0x00, 0, 'on_off', False),
+        (0xFF, 1, 'on_off', False),
+        (0xFF, 0XFF, 'data_1', True),
+    ])
+    def test_link_data(self, test_device, data_1, pretty_data_1, name,
+                       is_controller):
+        pretty = test_device.link_data_to_pretty(is_controller,
+                                                 [data_1, 0x00, 0x00])
+        assert pretty[0][name] == pretty_data_1
+        ugly = test_device.link_data_from_pretty(is_controller,
+                                                 {name: pretty_data_1,
+                                                  'data_2': 0x00,
+                                                  'data_3': 0x00})
+        assert ugly[0] == data_1
+
     def test_set_backlight(self, test_device):
         test_device.set_backlight(backlight=0)
         assert len(test_device.protocol.sent) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!

  You're welcome!
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change fixes a bug whereby switch scenes that are configured to turn the switch off (i.e. with data_1 == 0x00) would be marked as having turned the switch on in MQTT, despite the switch actually turning off.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Related to discussion: #338

**Note:** I wasn't sure if other device types that have on-off states (e.g. KeypadLinc, Outlet) behaved the same (as I don't have these devices), so this change only applies to the Switch device type.  Let me know if you know which other devices work this way and if you'd like me to add changes for them to this PR.

Confirmed no new flake8 errors, pylint errors, or code coverage gaps.  All tests passing.  Also, confirmed new test (test_handle_group_cmd) fails prior to applying fix:

```
================================================================================ FAILURES ================================================================================
___________________________________________________________ Test_Base_Config.test_handle_group_cmd[17-0-False] ___________________________________________________________

self = <test_SwitchDev.Test_Base_Config object at 0x7f9370aa5390>, test_device = <insteon_mqtt.device.Switch.Switch object at 0x7f937055b910>, cmd1 = 17, entry_d1 = 0
expected = False

    @pytest.mark.parametrize("cmd1, entry_d1, expected", [
        (0x11, None, None),
        (0x11, 0xFF, True),
        (0x11, 0x00, False),
        (0x13, None, None),
        (0x13, 0xFF, False),
        (0x13, 0x00, False),
    ])
    def test_handle_group_cmd(self, test_device, cmd1, entry_d1, expected):
        with mock.patch.object(IM.Signal, 'emit'):
            # Build the msg to send to the handler
            to_addr = test_device.addr
            from_addr = IM.Address(0x04, 0x05, 0x06)
            flags = IM.message.Flags(IM.message.Flags.Type.ALL_LINK_CLEANUP,
                                     False)
            msg = IM.message.InpStandard(from_addr, to_addr, flags, cmd1, 0x01)
            # If db entry is requested, build and add the entry to the dev db
            if entry_d1 is not None:
                db_flags = IM.message.DbFlags(True, False, True)
                entry = IM.db.DeviceEntry(from_addr, 0x01, 0xFFFF, db_flags,
                                          bytes([entry_d1, 0x00, 0x00]))
                test_device.db.add_entry(entry)
            # send the message to the handler
            test_device.handle_group_cmd(from_addr, msg)
            # Test the responses received
            calls = IM.Signal.emit.call_args_list
            if expected is not None:
                print(calls)
>               assert calls[0][1]['is_on'] == expected
E               assert True == False

tests/device/test_SwitchDev.py:113: AssertionError
-------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------
[call(<insteon_mqtt.device.Switch.Switch object at 0x7f937055b910>, is_on=True, level=None, mode=<Mode.NORMAL: 'normal'>, button=1, reason='scene')]
======================================================================== short test summary info =========================================================================
FAILED tests/device/test_SwitchDev.py::Test_Base_Config::test_handle_group_cmd[17-0-False] - assert True == False
===================================================================== 1 failed, 689 passed in 10.74s =====================================================================
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary - **N/A**

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated - **N/A**
