### PR TITLE
Report Which PyTests Were Run on Which Lines in Coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[html]
+show_contexts = True

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,8 +61,8 @@ added.
    # Show lines that need coverage
    pytest --cov=insteon_mqtt --cov-report term-missing
 
-   # Create html files that show missing lines
-   pytest --cov=insteon_mqtt --cov-report html
+   # Create html files that show missing lines and which tests are run on which lines
+   pytest --cov=insteon_mqtt --cov-report=html --cov-context=test
    ```
 
 # Logging


### PR DESCRIPTION
## Proposed change
Modifies the pytest config and adds an instruction in the developer guide showing how to print which tests were run on which lines of code.  Helpful for figuring out if something has really been tested.

These changes do not affect any production files, it only affects the test setup.

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Documentation added/updated

