### PR TITLE
Reverse Dusk/Dawn Signal

### DIFF
--- a/insteon_mqtt/device/Motion.py
+++ b/insteon_mqtt/device/Motion.py
@@ -205,7 +205,7 @@ class Motion(BatterySensor):
         # Send True for dawn, False for dusk.
         LOG.info("Motion %s broadcast grp: %s cmd %s", self.addr,
                  msg.group, msg.cmd1)
-        self.signal_dawn.emit(self, msg.cmd1 == Msg.CmdType.ON)
+        self.signal_dawn.emit(self, msg.cmd1 == Msg.CmdType.OFF)
 
     #-----------------------------------------------------------------------
     def update_flags(self, on_done=None, **kwargs):

--- a/tests/device/test_MotionDev.py
+++ b/tests/device/test_MotionDev.py
@@ -64,8 +64,8 @@ class Test_Base_Config():
                 mocked.assert_not_called()
 
     @pytest.mark.parametrize("group_num,cmd1,cmd2,expected", [
-        (0x02,Msg.CmdType.ON, 0x00,[True]),
-        (0x02,Msg.CmdType.OFF, 0x00, [False]),
+        (0x02,Msg.CmdType.ON, 0x00,[False]),
+        (0x02,Msg.CmdType.OFF, 0x00, [True]),
         (0x03,Msg.CmdType.ON, 0x00,[True]),
         (0x03,Msg.CmdType.OFF, 0x00, [False]),
         (0x04,Msg.CmdType.ON, 0x00,[True]),


### PR DESCRIPTION
## Breaking change
Theoretically this could be a breaking change if users are relying on the bad values.  But I don't think many people use this function, and this brings it inline with the expected value.


## Proposed change
Flips the reported dusk/dawn values.  According to #511 this was backwards.  I was unable to get these messages to work on my sensors and sadly the tech documents for the motion sensor are silent about this feature.  But this report is backed up by documentation found here: https://wiki.indigodomo.com/doku.php?id=insteon_devices:sensors

## Additional information
- This PR fixes or closes issue: fixes #511

## Checklist
- [ ] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.

