### PR TITLE
Don't let refresh requests pile up while not awake

### DIFF
--- a/tests/device/test_BatterySensorDev.py
+++ b/tests/device/test_BatterySensorDev.py
@@ -133,3 +133,22 @@ class Test_Base_Config():
         assert len(test_device.protocol.sent) == 1
         assert len(test_device._send_queue) == 0
         assert msg_handler._num_retry > 0
+
+    def test_queued_refresh_replace(self, test_device):
+        # Queue multiple refresh commands
+        msg1 = Msg.OutStandard.direct(test_device.addr, 0x19, 0x00)
+        msg2 = Msg.OutStandard.direct(test_device.addr, 0x19, 0x00)
+        msg3 = Msg.OutStandard.direct(test_device.addr, 0x19, 0x00)
+        msg_handler1 = IM.handler.StandardCmd(msg1, None, None)
+        msg_handler2 = IM.handler.StandardCmd(msg2, None, None)
+        msg_handler3 = IM.handler.StandardCmd(msg3, None, None)
+        test_device.send(msg1, msg_handler1)
+        test_device.send(msg2, msg_handler2)
+        test_device.send(msg3, msg_handler3)
+        # Confirm that only the last command is queued
+        assert len(test_device._send_queue) == 1
+        m, h, p, a = test_device._send_queue[0]
+        assert m != msg1
+        assert m == msg3
+        assert h != msg_handler1
+        assert h == msg_handler3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!

You're welcome!
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change fixes a bug whereby identical refresh requests may pile up in a non-awake device's send queue over time.  For example, I had an automation running at 15-minute intervals that would perform a refresh-all command.  Several days later, when I performed an "awake" command against a mini-remote device (2342-232), Insteon-MQTT tried to send several hundred refresh commands to the mini-remote.

This change avoids queuing more than one refresh command by replacing identical queued refresh commands with newly-received refresh commands (under the assumption that it might be more convenient to the user if the new command is still waiting for a response at the time the device is woken up).

Confirmed no new flake8 errors, pylint errors, or code coverage gaps. All tests passing. Also, confirmed new test (test_queued_refresh_replace) fails prior to applying fix:

```
================================================================================ FAILURES ================================================================================
______________________________________________________________ Test_Base_Config.test_queued_refresh_replace ______________________________________________________________

self = <test_BatterySensorDev.Test_Base_Config object at 0x7f209f3739a0>, test_device = <insteon_mqtt.device.BatterySensor.BatterySensor object at 0x7f209ed35000>

    def test_queued_refresh_replace(self, test_device):
        # Queue multiple refresh commands
        msg1 = Msg.OutStandard.direct(test_device.addr, 0x19, 0x00)
        msg2 = Msg.OutStandard.direct(test_device.addr, 0x19, 0x00)
        msg3 = Msg.OutStandard.direct(test_device.addr, 0x19, 0x00)
        msg_handler1 = IM.handler.StandardCmd(msg1, None, None)
        msg_handler2 = IM.handler.StandardCmd(msg2, None, None)
        msg_handler3 = IM.handler.StandardCmd(msg3, None, None)
        test_device.send(msg1, msg_handler1)
        test_device.send(msg2, msg_handler2)
        test_device.send(msg3, msg_handler3)
        # Confirm that only the last command is queued
>       assert len(test_device._send_queue) == 1
E       assert 3 == 1
E        +  where 3 = len([[<insteon_mqtt.message.OutStandard.OutStandard object at 0x7f209ed34700>, <insteon_mqtt.handler.StandardCmd.StandardC...ndard object at 0x7f209ed37fa0>, <insteon_mqtt.handler.StandardCmd.StandardCmd object at 0x7f209ed36f20>, False, None]])
E        +    where [[<insteon_mqtt.message.OutStandard.OutStandard object at 0x7f209ed34700>, <insteon_mqtt.handler.StandardCmd.StandardC...ndard object at 0x7f209ed37fa0>, <insteon_mqtt.handler.StandardCmd.StandardCmd object at 0x7f209ed36f20>, False, None]] = <insteon_mqtt.device.BatterySensor.BatterySensor object at 0x7f209ed35000>._send_queue

tests/device/test_BatterySensorDev.py:149: AssertionError
======================================================================== short test summary info =========================================================================
FAILED tests/device/test_BatterySensorDev.py::Test_Base_Config::test_queued_refresh_replace - assert 3 == 1
===================================================================== 1 failed, 706 passed in 10.71s =====================================================================
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
- [ ] Code documentation was added where necessary - **N/A**

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated - **N/A**
