### PR TITLE
Don't prune blank entity names in overridden discovery data

### DIFF
--- a/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
+++ b/insteon_mqtt/mqtt/topic/DiscoveryTopic.py
@@ -367,7 +367,7 @@ class DiscoveryTopic(BaseTopic):
                 # delete any keys with empty string values
                 keys_to_delete = []
                 for key, val in config.items():
-                    if val == "":
+                    if val == "" and key != "name":
                         keys_to_delete.append(key)
                 for key in keys_to_delete:
                     del config[key]

--- a/tests/mqtt/topic/test_DiscoveryTopic.py
+++ b/tests/mqtt/topic/test_DiscoveryTopic.py
@@ -162,6 +162,7 @@ class Test_DiscoveryTopic:
             'fake': {
                 "component": "fan",
                 "config": {
+                    "name": "",
                     "unique_id": "unique",
                     "icon": "fake",
                 },
@@ -226,6 +227,7 @@ class Test_DiscoveryTopic:
         discovery_fan.disc_templates = []
 
         # test for adding config attribute
+        # Also test that name isn't removed
         discovery_fan.device.config_extra['discovery_overrides'] = { 'fake': {
             "config": {
                 "foo": "fake",
@@ -234,9 +236,12 @@ class Test_DiscoveryTopic:
         discovery_fan.load_discovery_data(config)
         payload = json.loads(discovery_fan.disc_templates[0].payload_str)
         assert payload.get("foo", None) == "fake"
+        assert "name" in payload
+        assert payload.get("name", None) == ""
         discovery_fan.disc_templates = []
 
         # test for deleting config attribute
+        # Also test that name isn't removed
         discovery_fan.device.config_extra['discovery_overrides'] = { 'fake': {
             "config": {
                 "icon": "",
@@ -245,6 +250,8 @@ class Test_DiscoveryTopic:
         discovery_fan.load_discovery_data(config)
         payload = json.loads(discovery_fan.disc_templates[0].payload_str)
         assert "icon" not in payload
+        assert "name" in payload
+        assert payload.get("name", None) == ""
         discovery_fan.disc_templates = []
 
         # test for overriding device info


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change fixes a bug where entities using the default, blank-string entity names that are configured with `device_override_class` settings that modify their config fields would have their blank name fields removed from their MQTT discovery data, causing Home Assistant to name the entity "&lt;device name&gt; MQTT JSON Light" instead of the default "&lt;device name&gt;".  I'm not really sure if this is the intended behavior of Home Assistant (i.e. this could be an HA bug, not ours), but we can preserve our desired naming by not pruning empty name fields from the MQTT discovery data.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

Here is a simple `discovery_overrides` config that can reproduce the problem using Insteon Dimmers:

```
  light_no_change:
    discovery_overrides:
      dimmer:
        config:
          brightness: true
```

With the above set as `device_override_class` for a dimmer named "Desk Lamp" Home Assistant produces the name "Desk Lamp MQTT JSON Light":

![image](https://github.com/TD22057/insteon-mqtt/assets/59430211/b8c55293-6360-485e-b575-833a70f126ea)

This appears to be because the "name" field is removed from the MQTT discovery data:

![image](https://github.com/TD22057/insteon-mqtt/assets/59430211/82311de2-f1ec-4242-b633-bc242298454d)

With the proposed change, the blank "name" field is preserved, and the entity name stays set to "Desk Lamp" as it would without using the `device_override_class`.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
- [ ] Code documentation was added where necessary - **N/A**

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated - **N/A**

Confirmed no new flake8 errors, pylint errors, or code coverage gaps. All tests passing. Also, confirmed updated test (test_load_device_discovery_overrides) fails prior to applying fix:

```
================================================================================ FAILURES ================================================================================
________________________________________________________ Test_DiscoveryTopic.test_load_device_discovery_overrides ________________________________________________________

self = <test_DiscoveryTopic.Test_DiscoveryTopic object at 0x7f1edc97eaa0>
discovery_fan = <insteon_mqtt.mqtt.topic.DiscoveryTopic.DiscoveryTopic object at 0x7f1edc6eac20>, caplog = <_pytest.logging.LogCaptureFixture object at 0x7f1edc87ff40>

    def test_load_device_discovery_overrides(self, discovery_fan, caplog):
        discovery_fan.mqtt.discovery_enabled = True
        # build and request fake class to be used for tests
        config = {}
        config['fake_dev'] = {'discovery_entities': {
            'fake': {
                "component": "fan",
                "config": {
                    "name": "",
                    "unique_id": "unique",
                    "icon": "fake",
                },
            },
        }}
        discovery_fan.device.config_extra['discovery_class'] = 'fake_dev'
        # Override data from this point
        discovery_fan.discovery_template_data = mock.Mock(return_value={})

        # test empty override dict
        discovery_fan.device.config_extra['discovery_overrides'] = {}
        discovery_fan.load_discovery_data(config)
        assert len(discovery_fan.disc_templates) == 1
        discovery_fan.disc_templates = []

        # test empty device override dict
        discovery_fan.device.config_extra['discovery_overrides'] = { 'device': {} }
        discovery_fan.load_discovery_data(config)
        assert len(discovery_fan.disc_templates) == 1
        discovery_fan.disc_templates = []

        # test empty config override dict
        discovery_fan.device.config_extra['discovery_overrides'] = { 'fake': {
            "config": {},
        }}
        discovery_fan.load_discovery_data(config)
        assert len(discovery_fan.disc_templates) == 1
        discovery_fan.disc_templates = []

        # test for non-matching entity name
        discovery_fan.device.config_extra['discovery_overrides'] = { 'fakefail': {
        }}
        discovery_fan.load_discovery_data(config)
        assert 'Entity to override was not found' in caplog.text
        caplog.clear()

        # test for suppressing entity
        discovery_fan.device.config_extra['discovery_overrides'] = { 'fake': {
            "discoverable": False,
        }}
        discovery_fan.load_discovery_data(config)
        assert len(discovery_fan.disc_templates) == 0

        # test for overriding component
        discovery_fan.device.config_extra['discovery_overrides'] = { 'fake': {
           "component": "switch",
        }}
        discovery_fan.load_discovery_data(config)
        expected_topic = "homeassistant/switch/11_22_33/unique/config"
        assert discovery_fan.disc_templates[0].topic_str == expected_topic
        discovery_fan.disc_templates = []

        # test for overriding config unique_id
        discovery_fan.device.config_extra['discovery_overrides'] = { 'fake': {
            "config": {
                "unique_id": "override",
            },
        }}
        discovery_fan.load_discovery_data(config)
        expected_topic = "homeassistant/fan/11_22_33/override/config"
        assert discovery_fan.disc_templates[0].topic_str == expected_topic
        discovery_fan.disc_templates = []

        # test for adding config attribute
        # Also test that name isn't removed
        discovery_fan.device.config_extra['discovery_overrides'] = { 'fake': {
            "config": {
                "foo": "fake",
            },
        }}
        discovery_fan.load_discovery_data(config)
        payload = json.loads(discovery_fan.disc_templates[0].payload_str)
        assert payload.get("foo", None) == "fake"
>       assert "name" in payload
E       AssertionError: assert 'name' in {'foo': 'fake', 'icon': 'fake', 'unique_id': 'unique'}

tests/mqtt/topic/test_DiscoveryTopic.py:239: AssertionError
--------------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------------
ERROR    insteon_mqtt:DiscoveryTopic.py:347 11.22.33 - Entity to override was not found - fakefail
======================================================================== short test summary info =========================================================================
FAILED tests/mqtt/topic/test_DiscoveryTopic.py::Test_DiscoveryTopic::test_load_device_discovery_overrides - AssertionError: assert 'name' in {'foo': 'fake', 'icon': 'fake', 'unique_id': 'unique'}
===================================================================== 1 failed, 706 passed in 10.65s =====================================================================
```
