### PR TITLE
Request V1 Paho API

### DIFF
--- a/insteon_mqtt/cmd_line/util.py
+++ b/insteon_mqtt/cmd_line/util.py
@@ -74,7 +74,7 @@ def send(config, topic, payload, quiet=False):
         "quiet" : int(quiet),
         }
 
-    client = mqtt.Client(userdata=session)
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, userdata=session)
 
     # Add user/password if the config file has them set.
     if config["mqtt"].get("username", None):

--- a/insteon_mqtt/network/Mqtt.py
+++ b/insteon_mqtt/network/Mqtt.py
@@ -108,7 +108,8 @@ class Mqtt(Link):
         client_args = {'client_id': self.id, 'clean_session': False}
 
         if not hasattr(self, 'client'):
-            self.client = paho.Client(**client_args)
+            self.client = paho.Client(paho.CallbackAPIVersion.VERSION1,
+                                      **client_args)
         else:
             self.client.reinitialise(**client_args)
         self.client.on_connect = self._on_connect

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-paho-mqtt>=1.3
+paho-mqtt>=2.0
 pyserial>=3.2
 pyyaml>=3
 Jinja2>=2.1


### PR DESCRIPTION
Fixes `missing 1 required positional argument: 'callback_api_version'` error.

Introduces `DeprecationWarning: Callback API version 1 is deprecated, update to latest version` warning.

<!--
  You are amazing! Thanks for contributing to our project!
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a (temporary?) change to fix errors encountered with the latest version of paho-mqtt (2.0).  A more complete/permanent fix would be to update to use the new 2.0 API.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #528
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
  - New test warning introduced: `DeprecationWarning: Callback API version 1 is deprecated, update to latest version`
- [x] Tests have been added to verify that the new code works. - **N/A**
- [x] Code documentation was added where necessary - **N/A**

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated - **N/A**
