### PR TITLE
If not all DB records are received, try one-by-one

### DIFF
--- a/insteon_mqtt/db/Device.py
+++ b/insteon_mqtt/db/Device.py
@@ -175,6 +175,23 @@ class Device:
         return delta == self.delta
 
     #-----------------------------------------------------------------------
+    def is_complete(self):
+        """See if the database is complete.
+
+        Check that all DB entries between START_MEM_LOC and self.last
+        (inclusive) are present in either self.entries or self.unused.
+
+        Returns:
+          (bool) Returns True if the database is complete.
+        """
+        if (self.last not in self.entries.values() and
+                self.last not in self.unused.values()):
+            # Last entry hasn't been added/downloaded yet
+            return False
+        expected_entries = ((START_MEM_LOC - self.last.mem_loc) / 8) + 1
+        return len(self.entries) + len(self.unused) == expected_entries
+
+    #-----------------------------------------------------------------------
     def increment_delta(self):
         """Increments the current database delta by 1
 
@@ -770,7 +787,7 @@ class Device:
     #-----------------------------------------------------------------------
     def _add_using_new(self, addr, group, is_controller, data,
                        on_done):
-        """Add a anew entry at the end of the database.
+        """Add a new entry at the end of the database.
 
         First we send the new entry to the remote device.  If that works,
         then we update the previously last entry to mart it as "not the last

--- a/insteon_mqtt/db/DeviceScanManagerI2.py
+++ b/insteon_mqtt/db/DeviceScanManagerI2.py
@@ -1,0 +1,121 @@
+#===========================================================================
+#
+# Device Scan Manager for i2 or newer Devices
+#
+#===========================================================================
+from .. import log
+from .. import message as Msg
+from .. import util
+from .. import handler
+from .DeviceEntry import DeviceEntry
+from .Device import START_MEM_LOC
+
+LOG = log.get_logger()
+
+
+class DeviceScanManagerI2:
+    """Manager for scaning the link database of an i2 or newer device.
+
+    This class can be used to download any entries that failed to download
+    using DeviceDbGet.py (or all entries, if started with a cleared DB).
+    """
+    def __init__(self, device, device_db, on_done=None, *, num_retry=3,
+                 mem_addr: int = START_MEM_LOC):
+        """Constructor
+
+        Args
+          device:  (Device) The Insteon Device object
+          device_db: (db.Device) The device database being retrieved.
+          on_done:   Finished callback.  Will be called when the scan
+                     operation is done.
+        Keyword-only Args:
+          num_retry: (int) The number of times to retry each message if the
+                     handler times out without returning Msg.FINISHED.
+                     This count does include the initial sending so a
+                     retry of 3 will send once and then retry 2 more times.
+          mem_addr:  (int) Address at which to start downloading.
+        """
+        self.db = device_db
+        self.device = device
+        self._mem_addr = mem_addr
+        self.on_done = util.make_callback(on_done)
+        self._num_retry = num_retry
+
+    #-------------------------------------------------------------------
+    def start_scan(self):
+        """Start a managed scan of a i2 (or newer) device database."""
+        self._request_next_record(self.on_done)
+
+    #-------------------------------------------------------------------
+    def _request_next_record(self, on_done):
+        """Request the next missing DB record.
+
+        Args:
+          on_done: (callback) a callback that is passed around and run on the
+                   completion of the scan
+        """
+
+        done, last_entry = self._calculate_next_addr()
+        if done:
+            if self.db.is_complete():
+                on_done(True, "Database received", last_entry)
+            else:
+                on_done(False, "Database incomplete", last_entry)
+            return
+
+        data = bytes([
+            0x00,
+            0x00,                   # ALDB record request
+            self._mem_addr >> 8,    # Address MSB
+            self._mem_addr & 0xff,  # Address LSB
+            0x01,                   # Read one record
+            ] + [0x00] * 9)
+        msg = Msg.OutExtended.direct(self.device.addr, 0x2f, 0x00, data)
+        msg_handler = handler.ExtendedCmdResponse(msg, self.handle_record,
+                                                  on_done=on_done,
+                                                  num_retry=self._num_retry)
+        self.device.send(msg, msg_handler)
+
+    #-------------------------------------------------------------------
+    def handle_record(self, msg, on_done):
+        """Handle an ALDB record response by adding an entry to the DB and
+        fetching the next entry.
+
+        Args:
+          msg:     (message.InpExtended) The ALDB record response.
+          on_done: (callback) a callback that is passed around and run on the
+                   completion of the scan
+        """
+
+        # Convert the message to a database device entry.
+        entry = DeviceEntry.from_bytes(msg.data, db=self.db)
+        LOG.ui("Entry: %s", entry)
+
+        # Skip entries w/ a null memory location.
+        if entry.mem_loc:
+            self.db.add_entry(entry)
+
+        self._request_next_record(on_done)
+
+    #-------------------------------------------------------------------
+    def _calculate_next_addr(self) -> (bool, DeviceEntry):
+        """Calculate the memory address of the next missing record.
+
+        Returns:
+          (bool) True if no more records to read
+          (DeviceEntry) Last entry or closest-to-last (if not received yet)
+        """
+        done = False
+        last = None
+        addr = self._mem_addr
+        entry = self.db.entries.get(addr, self.db.unused.get(addr, None))
+        while entry is not None:
+            last = entry
+            if self.db.last.identical(entry):
+                # This is the last record (and we already have it)
+                done = True
+                break
+            addr -= 0x8
+            entry = self.db.entries.get(addr, self.db.unused.get(addr, None))
+        self._mem_addr = addr
+        return done, last

--- a/insteon_mqtt/db/__init__.py
+++ b/insteon_mqtt/db/__init__.py
@@ -18,5 +18,6 @@ from .Device import Device
 from .DeviceEntry import DeviceEntry
 from .DeviceModifyManagerI1 import DeviceModifyManagerI1
 from .DeviceScanManagerI1 import DeviceScanManagerI1
+from .DeviceScanManagerI2 import DeviceScanManagerI2
 from .Modem import Modem
 from .ModemEntry import ModemEntry

--- a/insteon_mqtt/handler/DeviceDbGet.py
+++ b/insteon_mqtt/handler/DeviceDbGet.py
@@ -143,7 +143,10 @@ class DeviceDbGet(Base):
             # Note that if the entry is a null entry (all zeros), then
             # is_last_rec will be True as well.
             if entry.db_flags.is_last_rec:
-                self.on_done(True, "Database received", entry)
+                if self.db.is_complete():
+                    self.on_done(True, "Database received", entry)
+                else:
+                    self.on_done(False, "Database incomplete", entry)
                 return Msg.FINISHED
 
             # Otherwise keep processing records as they arrive.

--- a/tests/db/test_DeviceScanManagerI2.py
+++ b/tests/db/test_DeviceScanManagerI2.py
@@ -1,0 +1,155 @@
+#===========================================================================
+#
+# Tests for: insteont_mqtt/db/DeviceScanManagerI2.py
+#
+#===========================================================================
+import pytest
+import insteon_mqtt as IM
+import insteon_mqtt.message as Msg
+from insteon_mqtt.db.Device import START_MEM_LOC
+
+class Test_DeviceScanManagerI2:
+    def test_start_scan(self):
+        dev_addr = IM.Address('0a.12.34')
+        device = MockDevice(dev_addr, 0)
+        manager = IM.db.DeviceScanManagerI2(device, device.db)
+
+        first_mem_addr = START_MEM_LOC
+        data = bytes([
+            0x00,
+            0x00,                   # ALDB record request
+            first_mem_addr >> 8,    # Address MSB
+            first_mem_addr & 0xff,  # Address LSB
+            0x01,                   # Read one record
+            ] + [0x00] * 9)
+        db_msg = Msg.OutExtended.direct(dev_addr, 0x2f, 0x00, data)
+
+        manager.start_scan()
+        assert device.sent[0].to_bytes() == db_msg.to_bytes()
+
+    #-------------------------------------------------------------------
+    @pytest.mark.parametrize("init_db,mem_addr,recv,exp_calls,next_addr", [
+        # Have all but last record.  Receive it, making DB complete.
+        ( [ [ 0x00, 0x00, 0x0f, 0xff, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+            [ 0x00, 0x00, 0x0f, 0xf7, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+            [ 0x00, 0x00, 0x0f, 0xef, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ] ],
+          None,
+          [ 0x00, 0x01, 0x0f, 0xe7, 0xff,
+            0x00, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+          [ "Database received" ],
+          None ),
+        # Have all but third record.  Receive it, making DB complete.
+        ( [ [ 0x00, 0x00, 0x0f, 0xff, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+            [ 0x00, 0x00, 0x0f, 0xf7, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+            [ 0x00, 0x00, 0x0f, 0xe7, 0xff,
+              0x00, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ] ],
+          None,
+          [ 0x00, 0x01, 0x0f, 0xef, 0xff,
+            0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+          [ "Database received" ],
+          None ),
+        # Have first two records.  Receive third and request fourth.
+        ( [ [ 0x00, 0x00, 0x0f, 0xff, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+            [ 0x00, 0x00, 0x0f, 0xef, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ] ],
+          None,
+          [ 0x00, 0x01, 0x0f, 0xf7, 0xff,
+            0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+          [ ],
+          0xfe7 ),
+        # Have first two records.  Receive last.  DB still incomplete.
+        ( [ [ 0x00, 0x00, 0x0f, 0xff, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+            [ 0x00, 0x00, 0x0f, 0xf7, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ] ],
+          None,
+          [ 0x00, 0x01, 0x0f, 0xe7, 0xff,
+            0x00, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+          [ "Database incomplete" ],
+          None ),
+        # Have first and last records.  Receive third.  DB still incomplete.
+        ( [ [ 0x00, 0x00, 0x0f, 0xff, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+            [ 0x00, 0x00, 0x0f, 0xe7, 0xff,
+              0x00, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ] ],
+          None,
+          [ 0x00, 0x01, 0x0f, 0xef, 0xff,
+            0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+          [ "Database incomplete" ],
+          None ),
+        # Have first and last records.  Receive second and request third.
+        ( [ [ 0x00, 0x00, 0x0f, 0xff, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+            [ 0x00, 0x00, 0x0f, 0xe7, 0xff,
+              0x00, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ] ],
+          None,
+          [ 0x00, 0x01, 0x0f, 0xf7, 0xff,
+            0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+          [ ],
+          0xfef ),
+        # Have first and last records.  Expecting second, but receive third.
+        # Request second.
+        ( [ [ 0x00, 0x00, 0x0f, 0xff, 0xff,
+              0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+            [ 0x00, 0x00, 0x0f, 0xe7, 0xff,
+              0x00, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ] ],
+          0xff7,
+          [ 0x00, 0x01, 0x0f, 0xef, 0xff,
+            0xff, 0x01, 0x0a, 0x12, 0x34, 0x00, 0x00, 0x00, 0x00 ],
+          [ ],
+          0xff7 )
+    ])
+    def test_handle_record(self, init_db, mem_addr, recv, exp_calls,
+                           next_addr):
+        calls = []
+
+        def callback(success, msg, value):
+            calls.append(msg)
+
+        modem_addr = IM.Address('09.12.34')
+        dev_addr = IM.Address('0a.12.34')
+        device = MockDevice(dev_addr, 0)
+        if mem_addr is None:
+            # Expecting the same address that we're about to receive
+            mem_addr = (recv[2] << 8) + recv[3]
+        manager = IM.db.DeviceScanManagerI2(device, device.db, callback,
+                                            mem_addr=mem_addr)
+
+        # Initialize DB starting state
+        for data in init_db:
+            entry = IM.db.DeviceEntry.from_bytes(data, db=device.db)
+            device.db.add_entry(entry)
+
+        # Handle received message, check callbacks
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
+        msg = Msg.InpExtended(dev_addr, modem_addr, flags, 0x2f, 0x00, recv)
+        manager.handle_record(msg, callback)
+        assert len(calls) == len(exp_calls)
+        for idx, call in enumerate(exp_calls):
+            assert calls[idx] == call
+
+        # Check address of next requested entry (if any expected)
+        if next_addr is not None:
+            assert len(device.sent) == 1
+            sent_data = device.sent[0].data
+            requested_addr = (sent_data[2] << 8) + sent_data[3]
+            assert requested_addr == next_addr
+
+#===========================================================================
+class MockDevice:
+    """Mock insteon_mqtt/Device class
+    """
+    def __init__(self, addr, db_delta):
+        self.sent = []
+        self.addr = addr
+        self.db = IM.db.Device(addr, None, self)
+        self.db.delta = db_delta
+
+    def send(self, msg, handler, priority=None, after=None):
+        self.sent.append(msg)

--- a/tests/handler/test_DeviceRefresh.py
+++ b/tests/handler/test_DeviceRefresh.py
@@ -1,0 +1,288 @@
+#===========================================================================
+#
+# Tests for: insteon_mqtt/handler/DeviceRefresh.py
+#
+#===========================================================================
+import insteon_mqtt as IM
+import insteon_mqtt.message as Msg
+
+class Test_DeviceRefresh:
+    def test_acks(self):
+        proto = None
+        force = False
+        refresh_msg = None
+        calls = []
+
+        def refresh_cb(msg):
+            nonlocal refresh_msg
+            refresh_msg = msg
+
+        def done_cb(success, msg, value):
+            calls.append(msg)
+
+        modem_addr = IM.Address('09.12.34')
+        dev_addr = IM.Address('0a.12.34')
+        db_delta = 2
+        device = MockDevice(dev_addr, db_delta)
+        handler = IM.handler.DeviceRefresh(device, refresh_cb, force, done_cb)
+
+        # Early device ACK, before PLM sent
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        early = Msg.InpStandard(dev_addr, modem_addr, flags, db_delta, 0x00)
+        early.is_ack = True
+        r = handler.msg_received(proto, early)
+        assert r == Msg.UNKNOWN
+
+        handler._PLM_sent = True
+
+        # PLM NAK
+        plm_nak = Msg.OutStandard.direct(dev_addr, 0x19, 0x00)
+        plm_nak.is_ack = False
+        r = handler.msg_received(proto, plm_nak)
+        assert r == Msg.CONTINUE
+        assert handler._PLM_ACK == False
+
+        # PLM ACK
+        plm_ack = Msg.OutStandard.direct(dev_addr, 0x19, 0x00)
+        plm_ack.is_ack = True
+        r = handler.msg_received(proto, plm_ack)
+        assert r == Msg.CONTINUE
+        assert handler._PLM_ACK == True
+
+        # PLM ACK - wrong address
+        nomatch = Msg.OutStandard.direct(IM.Address('0a.12.35'), 0x19, 0x00)
+        nomatch.is_ack = True
+        r = handler.msg_received(proto, nomatch)
+        assert r == Msg.UNKNOWN
+
+        # Now pass in the input message.
+
+        # Direct NAK
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_NAK, False)
+        msg = Msg.InpStandard(dev_addr, modem_addr, flags, 0x19, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert len(calls) == 1
+        assert calls[0] == "Device refresh failed. " + msg.nak_str()
+        calls = []
+
+        # Expected input message, DB up-to-date
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(dev_addr, modem_addr, flags, db_delta, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert refresh_msg == msg
+        assert len(calls) == 1
+        assert calls[0] == "Refresh complete"
+        calls = []
+
+    def test_dbget_start(self):
+        proto = None
+        force = False
+        refresh_msg = None
+        calls = []
+
+        def refresh_cb(msg):
+            nonlocal refresh_msg
+            refresh_msg = msg
+
+        def done_cb(success, msg, value):
+            calls.append(msg)
+
+        modem_addr = IM.Address('09.12.34')
+        dev_addr = IM.Address('0a.12.34')
+        db_delta = 2
+        device = MockDevice(dev_addr, db_delta)
+        handler = IM.handler.DeviceRefresh(device, refresh_cb, force, done_cb)
+        handler._PLM_sent = True
+        handler._PLM_ACK = True
+
+        # Expected input message, DB up-to-date, force update DB
+        handler.force = True
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(dev_addr, modem_addr, flags, db_delta, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert refresh_msg == msg
+        assert len(calls) == 0
+        # Assert DB-get message was sent
+        db_download_msg = Msg.OutExtended.direct(dev_addr, 0x2f, 0x00,
+                                                 bytes(14))
+        assert len(device.sent) == 1
+        assert (Msg.OutExtended.to_bytes(db_download_msg) ==
+                Msg.OutExtended.to_bytes(device.sent[0]))
+        device.sent = []
+        # Reset force-update setting to initial value (False)
+        handler.force = force
+
+        # Expected input message, DB stale, skip_db
+        handler.skip_db = True
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(dev_addr, modem_addr, flags, db_delta + 1, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert refresh_msg == msg
+        assert len(calls) == 1
+        assert calls[0] == "Refresh complete"
+        calls = []
+        handler.skip_db = False
+
+        # Expected input message, DB stale
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(dev_addr, modem_addr, flags, db_delta + 1, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert refresh_msg == msg
+        assert len(calls) == 0
+        # Assert DB-get message was sent
+        db_download_msg = Msg.OutExtended.direct(dev_addr, 0x2f, 0x00,
+                                                 bytes(14))
+        assert len(device.sent) == 1
+        assert (Msg.OutExtended.to_bytes(db_download_msg) ==
+                Msg.OutExtended.to_bytes(device.sent[0]))
+        device.sent = []
+
+        # Expected input message, DB stale (i1 device)
+        device.db.engine = 0 # i1 device engine
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(dev_addr, modem_addr, flags, db_delta + 1, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert refresh_msg == msg
+        assert len(calls) == 0
+        # Assert first set-MSB message was sent
+        set_msb = Msg.OutStandard.direct(dev_addr, 0x28, 0x0F)
+        assert len(device.sent) == 1
+        assert (Msg.OutStandard.to_bytes(set_msb) ==
+                Msg.OutStandard.to_bytes(device.sent[0]))
+        device.sent = []
+        device.db.engine = None # Reset to unknown engine
+
+    def test_dbget_finish(self):
+        proto = None
+        force = False
+        refresh_msg = None
+        calls = []
+
+        def refresh_cb(msg):
+            nonlocal refresh_msg
+            refresh_msg = msg
+
+        def done_cb(success, msg, value):
+            calls.append(msg)
+
+        modem_addr = IM.Address('09.12.34')
+        dev_addr = IM.Address('0a.12.34')
+        db_delta = 2
+        device = MockDevice(dev_addr, db_delta)
+        handler = IM.handler.DeviceRefresh(device, refresh_cb, force, done_cb)
+        handler._PLM_sent = True
+        handler._PLM_ACK = True
+
+        # Expected input message, DB stale
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(dev_addr, modem_addr, flags, db_delta + 1, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert refresh_msg == msg
+        assert len(calls) == 0
+        # Assert DB-get message was sent
+        db_download_msg = Msg.OutExtended.direct(dev_addr, 0x2f, 0x00,
+                                                 bytes(14))
+        assert len(device.sent) == 1
+        assert (Msg.OutExtended.to_bytes(db_download_msg) ==
+                Msg.OutExtended.to_bytes(device.sent[0]))
+        device.sent = []
+
+        # Get ahold of DeviceDbGet object created by DeviceRefresh
+        assert len(device.handlers) == 1
+        dbget_handler = device.handlers[0]
+        assert isinstance(dbget_handler, IM.handler.DeviceDbGet)
+        device.handlers = []
+
+        # Simulate DB download complete
+        dbget_handler._PLM_sent = True
+        dbget_handler._PLM_ACK = True
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
+        data = bytes([0x01, 0, 0x0F, 0xFF, 0, 0x0, 0, 0x01, 0, 0, 0, 0, 0, 0])
+        msg = Msg.InpExtended(dev_addr, modem_addr, flags, 0x2f, 0x00, data)
+
+        r = dbget_handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert len(calls) == 1
+        assert calls[0] == "Database received"
+        assert len(device.sent) == 0
+        calls = []
+        db_delta += 1
+        assert device.db.delta == db_delta
+
+        # Expected input message, DB stale
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT_ACK, False)
+        msg = Msg.InpStandard(dev_addr, modem_addr, flags, db_delta + 1, 0x00)
+        r = handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert refresh_msg == msg
+        assert len(calls) == 0
+        # Assert DB-get message was sent
+        db_download_msg = Msg.OutExtended.direct(dev_addr, 0x2f, 0x00,
+                                                 bytes(14))
+        assert len(device.sent) == 1
+        assert (Msg.OutExtended.to_bytes(db_download_msg) ==
+                Msg.OutExtended.to_bytes(device.sent[0]))
+        device.sent = []
+
+        # Get ahold of DeviceDbGet object created by DeviceRefresh
+        assert len(device.handlers) == 1
+        dbget_handler = device.handlers[0]
+        assert isinstance(dbget_handler, IM.handler.DeviceDbGet)
+        device.handlers = []
+
+        # Simulate DB download incomplete
+        # Only receive the first and last records, so DB is incomplete.
+        dbget_handler._PLM_sent = True
+        dbget_handler._PLM_ACK = True
+        flags = Msg.Flags(Msg.Flags.Type.DIRECT, True)
+        data = bytes([0x01, 0, 0x0F, 0xFF, 0, 0xFF, 0, 0x01, 0, 0, 0, 0, 0, 0])
+        msg = Msg.InpExtended(dev_addr, modem_addr, flags, 0x2f, 0x00, data)
+
+        r = dbget_handler.msg_received(proto, msg)
+        assert r == Msg.CONTINUE
+        assert len(calls) == 0
+
+        data = bytes([0x01, 0, 0x0F, 0xEF, 0, 0x0, 0, 0x01, 0, 0, 0, 0, 0, 0])
+        msg = Msg.InpExtended(dev_addr, modem_addr, flags, 0x2f, 0x00, data)
+
+        r = dbget_handler.msg_received(proto, msg)
+        assert r == Msg.FINISHED
+        assert len(calls) == 0
+
+        # Assert read-ALDB message sent for missing record
+        mem_addr = 0xff7
+        data = bytes([
+            0x00,
+            0x00,                   # ALDB record request
+            mem_addr >> 8,          # Address MSB
+            mem_addr & 0xff,        # Address LSB
+            0x01,                   # Read one record
+            ] + [0x00] * 9)
+        read_rec = Msg.OutExtended.direct(dev_addr, 0x2f, 0x00, data)
+        assert len(device.sent) == 1
+        assert (Msg.OutStandard.to_bytes(read_rec) ==
+                Msg.OutStandard.to_bytes(device.sent[0]))
+        device.sent = []
+
+#===========================================================================
+class MockDevice:
+    """Mock insteon_mqtt/Device class
+    """
+    def __init__(self, addr, db_delta):
+        self.sent = []
+        self.handlers = []
+        self.addr = addr
+        self.label = "MockDevice"
+        self.db = IM.db.Device(addr, None, self)
+        self.db.delta = db_delta
+
+    def send(self, msg, handler, priority=None, after=None):
+        self.sent.append(msg)
+        self.handlers.append(handler)


### PR DESCRIPTION
Also, improve DeviceDbGet & DeviceRefresh test coverage.

<!--
  You are amazing! Thanks for contributing to our project!
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Thanks for considering this PR!

This PR changes the DeviceRefresh handling so that, after attempting a bulk database download (with DeviceDbGet), if the database is incomplete, Insteon-MQTT will attempt to retrieve the missing DB entries one-by-one.

This feature was previously proposed by @krkeegan in [this message](https://github.com/TD22057/insteon-mqtt/issues/233#issuecomment-742697299) on #233:

> I thought about this a bit more. I am still of the mindset that the current system using the single request is preferable. However, I thought of a way to add in support for individual requests as a fallback. The process would look like:
> 
> 1. Perform the db get as we do currently. (at the start of this the cached db is emptied)
> 2. Whenever a) the process finishes OR b) the process times out
> 3. Check the cached DB
> 4. If the cached DB lacks either a) a last_entry entry OR b) is missing entries for addresses (the addresses are non-contiguous)
> 5. Then spawn a separate handler to a) specifically query the missing entries AND b) query entries at the end until the last_entry is found.
> 
> Basically, the separate handler is patching up the holes of what was missed.
> 
> The two downsides to this are:
> 1. Some complexity in the code (but keeping this as a separate handler should contain things)
> 2. We will lose the "future proof" feature of not needing to know the address layout in the devices.  This is a bummer, but probably not a big deal.

The one-by-one downloading is performed in DeviceScanManagerI2, to reduce the effect of the added complexity on the rest of the DeviceRefresh/DebiceDbGet code.

Notably, this one-by-one fallback approach [appears to be the same technique employed by pyinsteon](https://github.com/pyinsteon/pyinsteon/blob/9e719ac97ff003cb963cd0da0533face1ff847b4/pyinsteon/aldb/aldb.py#L76) (which is used by Home Assistant's native Insteon integration).

Flake8 passes without errors, pylint shows no new warnings, and all new code is shown as covered by pytest coverage report.  Also, DeviceDbGet and DeviceRefresh are now listed as 100% covered.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #233
- Link to documentation pull request: N/A

Example force-refresh output for a particularly persnickety device is attached (device ID's have been changed to so as not to dox innocent devices):
- [db-2nd-pass.txt](https://github.com/user-attachments/files/17695641/db-2nd-pass.txt)
- [db-2nd-pass2.txt](https://github.com/user-attachments/files/17695645/db-2nd-pass2.txt)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated -- N/A
