### PR TITLE
Allow Installation of Insteon_MQTT Module via Pip in Addon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache add python3-dev
 COPY . /opt/insteon-mqtt
 
 RUN apk add --no-cache py3-pip && \
-    pip3 install /opt/insteon-mqtt && \
+    pip3 install --break-system-packages /opt/insteon-mqtt && \
     chmod +x /opt/insteon-mqtt/hassio/entrypoint.sh
 
 CMD ["/opt/insteon-mqtt/hassio/entrypoint.sh"]


### PR DESCRIPTION
Fixes #536

Adds a command line argument to suppress the pip error.