### PR TITLE
Migrate to Paho API Version 2

### DIFF
--- a/insteon_mqtt/cmd_line/util.py
+++ b/insteon_mqtt/cmd_line/util.py
@@ -74,7 +74,7 @@ def send(config, topic, payload, quiet=False):
         "quiet" : int(quiet),
         }
 
-    client = mqtt.Client(userdata=session)
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, userdata=session)
 
     # Add user/password if the config file has them set.
     if config["mqtt"].get("username", None):

--- a/insteon_mqtt/network/Mqtt.py
+++ b/insteon_mqtt/network/Mqtt.py
@@ -105,7 +105,11 @@ class Mqtt(Link):
         """ Create or reinitialise the MQTT client and set the callbacks.
         """
 
-        client_args = {'client_id': self.id, 'clean_session': False}
+        client_args = {
+            'callback_api_version': paho.CallbackAPIVersion.VERSION2,
+            'client_id': self.id,
+            'clean_session': False
+        }
 
         if not hasattr(self, 'client'):
             self.client = paho.Client(**client_args)
@@ -385,7 +389,7 @@ class Mqtt(Link):
         self.signal_needs_write.emit(self, True)
 
     #-----------------------------------------------------------------------
-    def _on_connect(self, client, data, flags, result):
+    def _on_connect(self, client, userdata, flags, reason_code, properties):
         """MQTT connection callback.
 
         This is called by the MQTT client once the connection has occurred.
@@ -398,20 +402,20 @@ class Mqtt(Link):
                  client, 3 = server unavailable, 4 = bad login, 5 = not
                  authorized.
         """
-        if result == 0:
+        if reason_code == 0:
             self.connected = True
             self.signal_connected.emit(self, True)
             self.client.publish(self.availability_topic, payload="online",
                                 qos=0, retain=True)
         else:
             LOG.error("MQTT connection refused %s %s %s", self.host, self.port,
-                      result)
+                      reason_code)
 
     #-----------------------------------------------------------------------
-    def _on_disconnect(self, client, data, result):
+    def _on_disconnect(self, client, userdata, flags, reason_code, properties):
         """MQTT disconnection callback.
 
-        This is called by the MQTT client when the connection is droppped.
+        This is called by the MQTT client when the connection is dropped.
 
         Args:
           client (paho.Client):  The paho mqtt client (self.client).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-paho-mqtt>=1.3
+paho-mqtt>=2.0
 pyserial>=3.2
 pyyaml>=3
 Jinja2>=2.1


### PR DESCRIPTION
## Proposed change
Upgrades Paho Client to API Version 2, removed deprecation warning.  Relatively simple migration, not much to change, shouldn't be any user impact

## Additional information
- This PR fixes or closes issue: fixes #528 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.