### PR TITLE
Enable Optional Encryption Without CA_Cert

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -170,6 +170,9 @@ mqtt:
   #retain: 1
 
   encryption:
+    # Whether to enable a TLS encrypted connection to your MQTT broker.
+    enable: False
+
     # Encryption Options for encrypted broker connections
     # These settings will be passed to the `tls_set()` method.  Please refer
     # to the Paho client documentation for details:
@@ -177,8 +180,9 @@ mqtt:
 
     # A string path to the Certificate Authority certificate files that are to
     # be treated as trusted by this client.
-    # A Certificate Authority cert is REQUIRED for any encrypted connection.
-    # an encrypted connection will not be attempted unless this is specified.
+    # WARNING: If a ca_cert is specified, encryption will be enabled. You should
+    # however use the enable setting above as this is a deprecated way to enable
+    # encryption.
     # ca_cert:
 
     # Client certificate and private key - Optional

--- a/insteon_mqtt/cmd_line/util.py
+++ b/insteon_mqtt/cmd_line/util.py
@@ -86,17 +86,20 @@ def send(config, topic, payload, quiet=False):
     if encryption is None:
         encryption = {}
     ca_cert = encryption.get('ca_cert', None)
-    if ca_cert is not None and ca_cert != "":
+    enable_tls = encryption.get('enable', None)
+    if (ca_cert is not None and ca_cert != "") or enable_tls:
         # Set the basic arguments
+        if ca_cert is not None and ca_cert != "":
+            addl_tls_kwargs['ca_certs'] = ca_cert
         certfile = encryption.get('certfile', None)
-        if certfile == "":
-            certfile = None
+        if certfile is not None and certfile != "":
+            addl_tls_kwargs['certfile'] = certfile
         keyfile = encryption.get('keyfile', None)
-        if keyfile == "":
-            keyfile = None
+        if keyfile is not None and keyfile != "":
+            addl_tls_kwargs['keyfile'] = keyfile
         ciphers = encryption.get('ciphers', None)
-        if ciphers == "":
-            ciphers = None
+        if ciphers is not None and ciphers != "":
+            addl_tls_kwargs['ciphers'] = ciphers
 
         # These require passing specific constants so we use a lookup
         # map for them.
@@ -112,10 +115,7 @@ def send(config, topic, payload, quiet=False):
 
         # Finally, try the connection
         try:
-            client.tls_set(ca_certs=ca_cert,
-                           certfile=certfile,
-                           keyfile=keyfile,
-                           ciphers=ciphers, **addl_tls_kwargs)
+            client.tls_set(**addl_tls_kwargs)
         except FileNotFoundError as e:
             print("Cannot locate a SSL/TLS file = %s.", e)
 

--- a/insteon_mqtt/cmd_line/util.py
+++ b/insteon_mqtt/cmd_line/util.py
@@ -85,6 +85,7 @@ def send(config, topic, payload, quiet=False):
     encryption = config["mqtt"].get('encryption', {})
     if encryption is None:
         encryption = {}
+    addl_tls_kwargs = {}
     ca_cert = encryption.get('ca_cert', None)
     enable_tls = encryption.get('enable', None)
     if (ca_cert is not None and ca_cert != "") or enable_tls:
@@ -103,7 +104,6 @@ def send(config, topic, payload, quiet=False):
 
         # These require passing specific constants so we use a lookup
         # map for them.
-        addl_tls_kwargs = {}
         tls_ver = encryption.get('tls_version', 'tls')
         tls_version_const = TLS_VER_OPTIONS.get(tls_ver, None)
         if tls_version_const is not None:

--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -155,6 +155,9 @@ mqtt:
   retain: 1
 
   encryption:
+    # Whether to enable a TLS encrypted connection to your MQTT broker.
+    enable: False
+
     # Encryption Options for encrypted broker connections
     # These settings will be passed to the `tls_set()` method.  Please refer
     # to the Paho client documentation for details:
@@ -162,8 +165,9 @@ mqtt:
 
     # A string path to the Certificate Authority certificate files that are to
     # be treated as trusted by this client.
-    # A Certificate Authority cert is REQUIRED for any encrypted connection.
-    # an encrypted connection will not be attempted unless this is specified.
+    # WARNING: If a ca_cert is specified, encryption will be enabled. You should
+    # however use the enable setting above as this is a deprecated way to enable
+    # encryption.
     # ca_cert:
 
     # Client certificate and private key - Optional

--- a/insteon_mqtt/data/config-schema.yaml
+++ b/insteon_mqtt/data/config-schema.yaml
@@ -264,6 +264,8 @@ mqtt:
       nullable: True
       type: dict
       schema:
+        enable:
+          type: boolean
         ca_cert:
           type: string
         certfile:

--- a/insteon_mqtt/network/Mqtt.py
+++ b/insteon_mqtt/network/Mqtt.py
@@ -155,6 +155,7 @@ class Mqtt(Link):
         encryption = config.get('encryption', {})
         if encryption is None:
             encryption = {}
+        addl_tls_kwargs = {}
         ca_cert = encryption.get('ca_cert', None)
         enable_tls = encryption.get('enable', None)
         if (ca_cert is not None and ca_cert != "") or enable_tls:
@@ -174,7 +175,6 @@ class Mqtt(Link):
 
             # These require passing specific constants so we use a lookup
             # map for them.
-            addl_tls_kwargs = {}
             tls_ver = encryption.get('tls_version', 'tls')
             tls_version_const = self.TLS_VER_OPTIONS.get(tls_ver, None)
             if tls_version_const is not None:

--- a/insteon_mqtt/network/Mqtt.py
+++ b/insteon_mqtt/network/Mqtt.py
@@ -156,18 +156,21 @@ class Mqtt(Link):
         if encryption is None:
             encryption = {}
         ca_cert = encryption.get('ca_cert', None)
-        if ca_cert is not None and ca_cert != "":
+        enable_tls = encryption.get('enable', None)
+        if (ca_cert is not None and ca_cert != "") or enable_tls:
             LOG.info("Using TLS for MQTT broker connection.")
             # Set the basic arguments
+            if ca_cert is not None and ca_cert != "":
+                addl_tls_kwargs['ca_certs'] = ca_cert
             certfile = encryption.get('certfile', None)
-            if certfile == "":
-                certfile = None
+            if certfile is not None and certfile != "":
+                addl_tls_kwargs['certfile'] = certfile
             keyfile = encryption.get('keyfile', None)
-            if keyfile == "":
-                keyfile = None
+            if keyfile is not None and keyfile != "":
+                addl_tls_kwargs['keyfile'] = keyfile
             ciphers = encryption.get('ciphers', None)
-            if ciphers == "":
-                ciphers = None
+            if ciphers is not None and ciphers != "":
+                addl_tls_kwargs['ciphers'] = ciphers
 
             # These require passing specific constants so we use a lookup
             # map for them.
@@ -183,10 +186,7 @@ class Mqtt(Link):
 
             # Finally, try the connection
             try:
-                self.client.tls_set(ca_certs=ca_cert,
-                                    certfile=certfile,
-                                    keyfile=keyfile,
-                                    ciphers=ciphers, **addl_tls_kwargs)
+                self.client.tls_set(**addl_tls_kwargs)
             except FileNotFoundError as e:
                 LOG.error("Cannot locate a SSL/TLS file = %s.", e)
                 sys.exit()


### PR DESCRIPTION
## Proposed change
Adds the following enable setting to `config.yaml`
```
mqtt:
  encryption:
    enable: False
```

Previously encryption was enabled by setting the `ca_cert` value.  But this is not necessary if your servers cert is from a trusted authority such as Let's Encrypt.

I added a deprecation warning to the documentation, but for the time being if `ca_cert` is set encryption will continue to be enabled even if `enable: False`.  This will only affect users who have enabled encryption previously and now attempt to disable it with `encryption: False`.  Since I suspect basically no one updates their config files with settings that are added in later, I doubt this will ever be an issue.

Also encryption seems to be a little used feature.

## Additional information
- This PR fixes or closes issue: fixes #535 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. 

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated
