### PR TITLE
Migrate HomeAssistant Config Files Location

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "arch": ["amd64","armhf","aarch64","i386"],
     "boot": "auto",
     "uart": true,
-    "map": ["config:rw"],
+    "map": ["addon_config:rw", "homeassistant_config:rw"],
     "options": {},
     "schema": {},
     "image": "td22057/{arch}-insteon-mqtt",

--- a/docs/HA_Addon_Instructions.md
+++ b/docs/HA_Addon_Instructions.md
@@ -33,7 +33,7 @@ These instructions assume that you:
 7. Click __Install__
 8. Click __Start__ to start the Add-on, this will create your initial config
    files.
-9. Edit `/config/insteon-mqtt/config.yaml` as appropriate. See [configuration](configuration.md) for detailed instructions.
+9. Edit `/config/config.yaml` (which can be found at '/addons_configs/83fc19e1_insteon-mqtt/config.yaml' within VSCode or SSH Addon) as appropriate. See [configuration](configuration.md) for detailed instructions.
 10. Enable the [Discovery Platform](discovery.md)
 
 > Alternatively, if you choose to define your entities in Home Assistant
@@ -48,10 +48,12 @@ These instructions assume that you:
 ## Backing up your Data
 
 The default settings in the config.yaml file will save all user data to the
-`/config/insteon-mqtt` directory.  So you only need to backup and save this
-data, you do not need to make a snapshot of the Insteon-MQTT add-on.  This
-directory may also contain a log file if you have enabled logging,
-be careful, this can get quite large.
+`/config/` directory.  This directory is backed up when you make a snapshot 
+of the Insteon-MQTT add-on.  This directory may also contain a log file if 
+you have enabled logging, be careful, this can get quite large.
+
+You can also access this directory '/addons_configs/83fc19e1_insteon-mqtt/'
+within VSCode or SSH Addon.
 
 ## Updating
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,9 @@
 
 The following is the bare minimum of changes to the `config.yaml` file that are necessary to get Insteon-MQTT started.
 
+> For HomeAssistant Addon users, the `config.yaml` file is stored at `/config/config.yaml` within the addon
+> and can be found at at '/addons_configs/83fc19e1_insteon-mqtt/' within VSCode or SSH Addon.
+
 1. __Configure Modem__ Set the Insteon port as `port` under the `insteon` section to be the USB port or address of the PLM modem on your system.  If using an Insteon Hub, see [Hub Instructions](hub.md).
 
 2. __Config Devices__ Edit the `insteon` -> `devices` section and enter the hex addresses of all the devices you have under the appropriate device types.

--- a/docs/hassio_development.md
+++ b/docs/hassio_development.md
@@ -1,19 +1,21 @@
 ## Testing Unreleased Versions in Home Assistant Supervisor
 The Home Assistant Supervisor system makes most things pretty simple.  Testing development releases or your own code fixes is mildly more difficult.  The following instructions should help.
 
-1. Uninstall the Insteon-MQTT addon.  Your config files are saved in `/config/insteon-mqtt` so you should be okay.  But you can back them up ahead of time just in case.
+1. Uninstall the Insteon-MQTT addon.  Your config files for the repository installed addon are saved in `/config/` (which can be found at '/addons_configs/83fc19e1_insteon-mqtt/' within VSCode or SSH Addon).  If you install the addon locally, as described below, the configs for the locally installed addon will be at:
+`/addons_configs/local_insteon-mqtt/` within VSCode or SSH Addon).
 2. SSH into Home Assistant using the SSH addon
 3. cd to `/addons`
 4. run `git clone https://github.com/TD22057/insteon-mqtt.git`  You can replace the repository with your own if you like.
 5. cd `insteon-mqtt`
 6. Use git to checkout the branch you desire.
 7. When you are ready to install on Home Assistant you will have to do the following:
-- edit `config.json`
+- edit `config.json` 
 - remove the entire line that reads: `"image": "td22057/{arch}-insteon-mqtt",`
 - edit the line that reads: `"version": "0.8.1",` to be something sensible, I use dates so: `"version": "2021.03.23.0",`
 8. You may have to use `git stash` and `git pop` when pulling in changes, particularly after a release has occured.  This is because both branches will have changed the version line.
 9. Go back into your Home Assistant instance and go to `Supervisor->Addon Store`
 10. In the menu on the top right click `Reload`
 11. You should now see the Insteon-MQTT addon listed as a `Local Add-on` install that, it may take a few minutes to compile locally.
-12. In the future to update your local version, you have to edit the `config.json` to trigger a new release, then run the `Reload` command in the store to see the new version.
+12. You will have to copy your InsteonMQTT `config.yaml` file to the local config directory (which can be found at '/addons_configs/local_insteon-mqtt/' within VSCode or SSH Addon)
+13. In the future to update your local version, you have to edit the `config.json` to trigger a new release, then run the `Reload` command in the store to see the new version.
 

--- a/hassio/CONFIG-MOVED.txt
+++ b/hassio/CONFIG-MOVED.txt
@@ -1,0 +1,16 @@
+InsteonMQTT Config Files Have Moved!!!
+
+Your config files were copied from this location on <<MIGRATION_DATE>>
+
+If InsteonMQTT is operating correctly, you may delete these files.
+
+
+Config files can now be found at:
+
+WITHIN Visual Code Addon or SSH Addon:
+
+    /addons_configs/83fc19e1_insteon-mqtt
+
+WITHIN InsteonMQTT Addon:
+
+    /config/

--- a/hassio/entrypoint.sh
+++ b/hassio/entrypoint.sh
@@ -6,14 +6,15 @@
 # to the add-on configuration folder.
 # We add a file to the old directory so that hopefully a user
 # doesn't get confused in the future.
-if [ ! -f /config/config.yaml ] && [ -f /homeassistant/insteon-mqtt/config.yaml]; then
-    shopt -s dotglob
-    mv /homeassistant/insteon-mqtt/* /config/ \
-        || echo "Failed to migrate InsteonMQTT configuration"; exit 1;
+
+
+if [ ! -f /config/config.yaml ] && [ -f /homeassistant/insteon-mqtt/config.yaml ]; then
+    mv /homeassistant/insteon-mqtt/* /config/ || \
+        { echo "Failed to migrate InsteonMQTT configuration"; exit 1; }
     # If user was using default data and log locations, edit them to match the new location
-    sed -i "s|storage: '/config/insteon-mqtt/data'|storage: '/config/data'|" /config/config.yaml
+    sed -i "s|storage: '\{0,1\}\"\{0,1\}/config/insteon-mqtt/data'\{0,1\}\"\{0,1\}|storage: /config/data|" /config/config.yaml
     sed -i "s|file: /config/insteon-mqtt/insteon_mqtt.log|file: /config/insteon_mqtt.log|" /config/config.yaml
-    cp /opt/insteon-mqtt/hassio/CONFIG-MOVED.txt /homeassistant/insteon-mqtt/CONFIG-MOVED.txt
+    /bin/cp /opt/insteon-mqtt/hassio/CONFIG-MOVED.txt /homeassistant/insteon-mqtt/CONFIG-MOVED.txt
     sed -i "s/<<MIGRATION_DATE>>/$(date)/g" /homeassistant/insteon-mqtt/CONFIG-MOVED.txt
     echo "InsteonMQTT configuration successfully migrated from /config/insteon-mqtt."
 fi
@@ -23,7 +24,7 @@ if [ ! -f /config/config.yaml ]; then
     echo "Creating your initial config.yaml file."
     /bin/cp /config/config.yaml.default /config/config.yaml \
       || echo "Unable to create initial InsteonMQTT config.yaml file"; exit 1;
-    sed -i "s|storage: 'data'|storage: '/config/data'|" /config/config.yaml
+    sed -i "s|storage: 'data'|storage: /config/data|" /config/config.yaml
     sed -i "s|#file: /var/log/insteon_mqtt.log|file: /config/insteon_mqtt.log|" /config/config.yaml
     echo "Please define the required settings in the file /config/config.yaml"
     echo "(which can be found at '/addons_configs/83fc19e1_insteon-mqtt/config.yaml'"

--- a/hassio/entrypoint.sh
+++ b/hassio/entrypoint.sh
@@ -10,6 +10,9 @@ if [ ! -f /config/config.yaml ] && [ -f /homeassistant/insteon-mqtt/config.yaml]
     shopt -s dotglob
     mv /homeassistant/insteon-mqtt/* /config/ \
         || echo "Failed to migrate InsteonMQTT configuration"; exit 1;
+    # If user was using default data and log locations, edit them to match the new location
+    sed -i "s|storage: '/config/insteon-mqtt/data'|storage: '/config/data'|" /config/config.yaml
+    sed -i "s|file: /config/insteon-mqtt/insteon_mqtt.log|file: /config/insteon_mqtt.log|" /config/config.yaml
     cp /opt/insteon-mqtt/hassio/CONFIG-MOVED.txt /homeassistant/insteon-mqtt/CONFIG-MOVED.txt
     sed -i "s/<<MIGRATION_DATE>>/$(date)/g" /homeassistant/insteon-mqtt/CONFIG-MOVED.txt
     echo "InsteonMQTT configuration successfully migrated from /config/insteon-mqtt."
@@ -20,7 +23,7 @@ if [ ! -f /config/config.yaml ]; then
     echo "Creating your initial config.yaml file."
     /bin/cp /config/config.yaml.default /config/config.yaml \
       || echo "Unable to create initial InsteonMQTT config.yaml file"; exit 1;
-    sed -i "s|#storage: 'data'|storage: '/config/data'|" /config/config.yaml
+    sed -i "s|storage: 'data'|storage: '/config/data'|" /config/config.yaml
     sed -i "s|#file: /var/log/insteon_mqtt.log|file: /config/insteon_mqtt.log|" /config/config.yaml
     echo "Please define the required settings in the file /config/config.yaml"
     echo "(which can be found at '/addons_configs/83fc19e1_insteon-mqtt/config.yaml'"

--- a/hassio/entrypoint.sh
+++ b/hassio/entrypoint.sh
@@ -1,17 +1,29 @@
 #!/bin/sh
 
-/bin/mkdir /config/insteon-mqtt/
+/bin/cp /opt/insteon-mqtt/config-example.yaml /config/config.yaml.default
 
-/bin/cp /opt/insteon-mqtt/config-example.yaml /config/insteon-mqtt/config.yaml.default
+# Migrate add-on data from the Home Assistant config folder,
+# to the add-on configuration folder.
+# We add a file to the old directory so that hopefully a user
+# doesn't get confused in the future.
+if [ ! -f /config/config.yaml ] && [ -d /homeassistant/insteon-mqtt]; then
+    shopt -s dotglob
+    mv /homeassistant/insteon-mqtt/* /config/ \
+        || echo "Failed to migrate InsteonMQTT configuration"; exit 1;
+    cp /opt/insteon-mqtt/hassio/CONFIG-MOVED.txt /homeassistant/insteon-mqtt/CONFIG-MOVED.txt
+    sed -i "s/<<MIGRATION_DATE>>/$(date)/g" /homeassistant/insteon-mqtt/CONFIG-MOVED.txt
+    echo "InsteonMQTT configuration successfully migrated from /config/insteon-mqtt."
+fi
 
-if [ ! -f /config/insteon-mqtt/config.yaml ]; then
+if [ ! -f /config/config.yaml ]; then
     echo "Welcome to InsteonMQTT!"
     echo "Creating your initial config.yaml file."
-    /bin/cp /config/insteon-mqtt/config.yaml.default /config/insteon-mqtt/config.yaml
-    sed -i "s/#storage: 'data'/storage: '\/config\/insteon-mqtt\/data'/" /config/insteon-mqtt/config.yaml
-    sed -i "s/#file: \/var\/log\/insteon_mqtt.log/file: \/config\/insteon-mqtt\/insteon_mqtt.log/" /config/insteon-mqtt/config.yaml
-    echo "Please edit the file /config/insteon-mqtt/config.yaml"
+    /bin/cp /config/config.yaml.default /config/config.yaml \
+      || echo "Unable to create initial InsteonMQTT config.yaml file"; exit 1;
+    sed -i "s/#storage: 'data'/storage: '\/config\/insteon-mqtt\/data'/" /config/config.yaml
+    sed -i "s/#file: \/var\/log\/insteon_mqtt.log/file: \/config\/insteon_mqtt.log/" /config/config.yaml
+    echo "Please define the required settings in the file /config/config.yaml"
     echo "Then you can start InsteonMQTT."
 else
-    python3 /opt/insteon-mqtt/hassio/start.py /config/insteon-mqtt/config.yaml start
+    python3 /opt/insteon-mqtt/hassio/start.py /config/config.yaml start
 fi

--- a/hassio/entrypoint.sh
+++ b/hassio/entrypoint.sh
@@ -20,9 +20,11 @@ if [ ! -f /config/config.yaml ]; then
     echo "Creating your initial config.yaml file."
     /bin/cp /config/config.yaml.default /config/config.yaml \
       || echo "Unable to create initial InsteonMQTT config.yaml file"; exit 1;
-    sed -i "s/#storage: 'data'/storage: '\/config\/insteon-mqtt\/data'/" /config/config.yaml
-    sed -i "s/#file: \/var\/log\/insteon_mqtt.log/file: \/config\/insteon_mqtt.log/" /config/config.yaml
+    sed -i "s|#storage: 'data'|storage: '/config/data'|" /config/config.yaml
+    sed -i "s|#file: /var/log/insteon_mqtt.log|file: /config/insteon_mqtt.log|" /config/config.yaml
     echo "Please define the required settings in the file /config/config.yaml"
+    echo "(which can be found at '/addons_configs/83fc19e1_insteon-mqtt/config.yaml'"
+    echo "within VSCode or SSH Addon)."
     echo "Then you can start InsteonMQTT."
 else
     python3 /opt/insteon-mqtt/hassio/start.py /config/config.yaml start

--- a/hassio/entrypoint.sh
+++ b/hassio/entrypoint.sh
@@ -6,7 +6,7 @@
 # to the add-on configuration folder.
 # We add a file to the old directory so that hopefully a user
 # doesn't get confused in the future.
-if [ ! -f /config/config.yaml ] && [ -d /homeassistant/insteon-mqtt]; then
+if [ ! -f /config/config.yaml ] && [ -f /homeassistant/insteon-mqtt/config.yaml]; then
     shopt -s dotglob
     mv /homeassistant/insteon-mqtt/* /config/ \
         || echo "Failed to migrate InsteonMQTT configuration"; exit 1;

--- a/hassio/webcli/app.py
+++ b/hassio/webcli/app.py
@@ -88,7 +88,7 @@ def handle_message(message):
             socketio.start_background_task(target=app.config["worker"].do_work)
         # We run it this way to disable buffering
         command = ['python3', '-u', '/opt/insteon-mqtt/scripts/insteon-mqtt',
-                   '/config/insteon-mqtt/config.yaml']
+                   '/config/config.yaml']
         command.extend(user_cmd)
         # Save the user inputed text so we can display it back to the user
         user_text = 'insteon-mqtt config.yaml ' + message

--- a/insteon_mqtt/Modem.py
+++ b/insteon_mqtt/Modem.py
@@ -208,8 +208,12 @@ class Modem:
         # Load the modem database.
         if 'storage' in config_data:
             save_path = config_data['storage']
-            if not os.path.exists(save_path):
-                os.makedirs(save_path)
+            try:
+                os.makedirs(save_path, exist_ok=True)
+            except OSError as error:
+                print("ERROR - Cannot access or create the data directory", save_path)
+                print("Please check your config.yaml file at insteon > storage")
+                exit(1)
 
             self.save_path = save_path
             self.load_db()

--- a/insteon_mqtt/log.py
+++ b/insteon_mqtt/log.py
@@ -86,7 +86,7 @@ def initialize(level=None, screen=None, file=None, config=None):
         try:
             handler = logging.handlers.WatchedFileHandler(file)
         except FileNotFoundError:
-            print("ERROR - Cannot access log file ", file)
+            print("ERROR - Cannot access log file", file)
             print("Please check your config.yaml file under logging > file")
             exit(1)
         handler.setFormatter(formatter)

--- a/insteon_mqtt/log.py
+++ b/insteon_mqtt/log.py
@@ -83,7 +83,12 @@ def initialize(level=None, screen=None, file=None, config=None):
     if file:
         # Use a watched file handler - that way LINUX system log
         # rotation works properly.
-        handler = logging.handlers.WatchedFileHandler(file)
+        try:
+            handler = logging.handlers.WatchedFileHandler(file)
+        except FileNotFoundError:
+            print("ERROR - Cannot access log file ", file)
+            print("Please check your config.yaml file under logging > file")
+            exit(1)
         handler.setFormatter(formatter)
         log_obj.addHandler(handler)
 


### PR DESCRIPTION
## Proposed change
The new location will be backed up by a Home Assistant snapshot and is Home Assistant's preferred location for storing config files going forward.

1. If a `config.yaml` file is __not__ found in the new location; AND
2. A `config.yaml` file is found at the old location; THEN
3. Copy the entire contents of the old config directory to the new one
4. Add a notice file to the old config directory telling users:
- The new location of their config files
- That they can delete these config files if everything is working correctly.

This process should ensure that no data is lost and should provide enough guidance to users on where their config files are located.

## Additional information
- This PR fixes or closes issue: fixes #532 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Code documentation was added where necessary
- [x] Documentation added/updated

I have updated and added comments about the location of the new config files in every location in documentation that I can think of.
