### PR TITLE
Add Supported Color Modes to MQTT Discovery

### DIFF
--- a/docs/discovery_customization_config.md
+++ b/docs/discovery_customization_config.md
@@ -290,6 +290,7 @@ mqtt:
         component: "light"
         config:
           brightness: false
+          sup_clrm: ["onoff"]
           val_tpl: ""
 ```
 

--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -564,6 +564,7 @@ mqtt:
           cmd_t: "{{level_topic}}"
           stat_t: "{{state_topic}}"
           brightness: true
+          sup_clrm: ["brightness"]
           schema: "json"
           device: "{{device_info}}"
           json_attr_t: "{{state_topic}}"
@@ -1406,6 +1407,7 @@ mqtt:
           cmd_t: "{{level_topic}}"
           stat_t: "{{state_topic}}"
           brightness: true
+          sup_clrm: ["brightness"]
           schema: "json"
           device: "{{device_info}}"
           json_attr_t: "{{state_topic}}"
@@ -1582,6 +1584,11 @@ mqtt:
           avty_t: "{{availability_topic}}"
           device: "{{device_info}}"
           brightness: "{{is_dimmable|lower()}}"
+          sup_clrm: "{%- if is_dimmable -%}
+                      brightness
+                    {%- else -%}
+                      onoff
+                    {%- endif -%}"
           cmd_t: "{%- if is_dimmable -%}
                     {{dimmer_level_topic}}
                   {%- else -%}


### PR DESCRIPTION
## Proposed change
Added the `supported_color_modes` attribute to light objects in the discovery templates.

Starting in 2026.3 Home Assistant will require this

Simple change to discovery templates was enough to solve it also updated the switch_as_light example. No other code changes made


## Additional information
- This PR fixes or closes issue: fixes TD22057/insteon-mqtt#549

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
- [ ] Code documentation was added where necessary

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated
