### PR TITLE
Mini remote6

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ what they are and how to interpret messages from them.
 - KeypadLinc on/off and dimmer and scene controller
 - IOLinc relay and sensor module
 - Mini-remotes (4 and 8 button battery powered scene controllers)
-- RemoteLink 2440 (6 button AAA battery powered scene controller)
+- RemoteLinc 2440 (6 button AAA battery powered scene controller)
 - Battery powered sensors (door, hidden door, window, etc.)
 - Leak sensors
 - Motion sensors

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ what they are and how to interpret messages from them.
 - KeypadLinc on/off and dimmer and scene controller
 - IOLinc relay and sensor module
 - Mini-remotes (4 and 8 button battery powered scene controllers)
+- RemoteLink 2440 (6 button AAA battery powered scene controller)
 - Battery powered sensors (door, hidden door, window, etc.)
 - Leak sensors
 - Motion sensors

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -113,6 +113,9 @@ insteon:
     mini_remote4:  # Remotes with 4 Buttons
       - 3f.12.d4: 'remote4'
 
+    mini_remote6:  # Remotes with 6 Buttons
+      - ab.12.cd: 'remote6'
+
     mini_remote8:  # Remotes with 8 Buttons
       - 3f.07.d4: 'remote1'
 

--- a/docs/discovery_customization_config.md
+++ b/docs/discovery_customization_config.md
@@ -26,6 +26,7 @@
     - [Device type 'leak' entities](#device-type-leak-entities)
     - [Device type 'mini_remote1' entities](#device-type-mini_remote1-entities)
     - [Device type 'mini_remote4' entities](#device-type-mini_remote4-entities)
+    - [Device type 'mini_remote6' entities](#device-type-mini_remote6-entities)
     - [Device type 'mini_remote8' entities](#device-type-mini_remote8-entities)
     - [Device type 'motion' entities](#device-type-motion-entities)
     - [Device type 'smoke_bridge' entities](#device-type-smoke_bridge-entities)
@@ -663,6 +664,18 @@ to the buttons.
 |button7|binary_sensor|not usable|
 |button8|binary_sensor|not usable|
 |battery|binary_sensor|battery good/low|
+
+### Device type 'mini_remote6' entities
+
+|Name|Component Type|Purpose|
+|---|---|---|
+|button1|binary_sensor|'a' switch|
+|button2|binary_sensor|'b' switch|
+|button3|binary_sensor|'c' switch|
+|button4|binary_sensor|'d' switch|
+|button5|binary_sensor|'e' switch|
+|button6|binary_sensor|'f' switch|
+|binary_sensor.NAME_battery|battery good/low|
 
 ### Device type 'mini_remote8' entities
 

--- a/docs/discovery_customization_ui.md
+++ b/docs/discovery_customization_ui.md
@@ -20,6 +20,7 @@
     - [Device type 'leak' entities](#device-type-leak-entities)
     - [Device type 'mini_remote1' entities](#device-type-mini_remote1-entities)
     - [Device type 'mini_remote4' entities](#device-type-mini_remote4-entities)
+    - [Device type 'mini_remote6' entities](#device-type-mini_remote6-entities)
     - [Device type 'mini_remote8' entities](#device-type-mini_remote8-entities)
     - [Device type 'motion' entities](#device-type-motion-entities)
     - [Device type 'smoke_bridge' entities](#device-type-smoke_bridge-entities)
@@ -243,6 +244,18 @@ to the buttons.
 |binary_sensor.NAME_btn_6|not usable|
 |binary_sensor.NAME_btn_7|not usable|
 |binary_sensor.NAME_btn_8|not usable|
+|binary_sensor.NAME_battery|battery good/low|
+
+### Device type 'mini_remote6' entities
+
+|Name|Purpose|
+|---|---|
+|binary_sensor.NAME_btn_1|'a' switch|
+|binary_sensor.NAME_btn_2|'b' switch|
+|binary_sensor.NAME_btn_3|'c' switch|
+|binary_sensor.NAME_btn_4|'d' switch|
+|binary_sensor.NAME_btn_5|'e' switch|
+|binary_sensor.NAME_btn_6|'f' switch|
 |binary_sensor.NAME_battery|battery good/low|
 
 ### Device type 'mini_remote8' entities

--- a/insteon_mqtt/config.py
+++ b/insteon_mqtt/config.py
@@ -30,6 +30,7 @@ devices = {
     'leak' : (device.Leak, {}),
     'mini_remote1' : (device.Remote, {'num_button' : 1}),
     'mini_remote4' : (device.Remote, {'num_button' : 4}),
+    'mini_remote6' : (device.Remote, {'num_button' : 6}),
     'mini_remote8' : (device.Remote, {'num_button' : 8}),
     'motion' : (device.Motion, {}),
     'outlet' : (device.Outlet, {}),

--- a/insteon_mqtt/data/config-base.yaml
+++ b/insteon_mqtt/data/config-base.yaml
@@ -98,8 +98,9 @@ insteon:
     # Battery powered mini remotes.
     mini_remote1: []  # Single Button Remotes
 
-
     mini_remote4: []  # Remotes with 4 Buttons
+
+    mini_remote6: []  # Remotes with 6 Buttons - RemoteLinc 2440
 
     mini_remote8: []  # Remotes with 8 Buttons
 

--- a/insteon_mqtt/data/config-schema.yaml
+++ b/insteon_mqtt/data/config-schema.yaml
@@ -88,7 +88,7 @@ insteon:
       keysrules:
         type: string
         allowed: ['switch', 'dimmer', 'battery_sensor', 'hidden_door',
-                  'motion', 'mini_remote1', 'mini_remote4',
+                  'motion', 'mini_remote1', 'mini_remote4', 'mini_remote6',
                   'mini_remote8', 'smoke_bridge', 'fan_linc',
                   'keypad_linc', 'keypad_linc_sw', 'leak', 'io_linc',
                   'outlet', 'thermostat', 'ezio4o']


### PR DESCRIPTION
## Proposed change
Adds support for older 6 button remotes (RemoteLinc 2440).

Users could have previously have used mini_remote8 and a discovery config modification to hide the last two buttons, but this is more user friendly.

I do suspect that the battery entity likely does not function given the age of this device.

No real code was changed, this is mostly an additional config option.

## Additional information
- This PR fixes or closes issue: cleaned up from PR TD22057/insteon-mqtt#550 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
- [x] Code documentation was added where necessary

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated
