### PR TITLE
Remove Support for i386 and armhf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision Change History
 
+## [1.4.0] - Drop Support of armhf and i386
+
+- HomeAssistant no longer supports the armhf and i386 architectures.
+
 ## [1.3.2] - Add Supported_Color_Modes; Add 6 Button Remote
 
 - Starting in HomeAssistant 2026.3 `supported_color_modes` will be a required attribute for all lights.

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "slug": "insteon-mqtt",
     "version": "1.3.2",
     "startup": "services",
-    "arch": ["amd64","armhf","aarch64","i386"],
+    "arch": ["amd64","aarch64"],
     "boot": "auto",
     "uart": true,
     "map": ["addon_config:rw", "homeassistant_config:rw"],


### PR DESCRIPTION
## Breaking change
HomeAssistant has dropped support for the i386 and armhf architectures as of 2026.

The tools used to build the images for addon installation now no longer support compiling the images for these architectures.

As a result, support for these architectures will be removed in version 1.4.0.

If you are still using one of these architectures you will no longer receive updates from HomeAssitant.  As a result, it is best you stay on Insteon-MQTT version 1.3.2 anyways as future releases could require changes that would not be backward compatible with older HomeAssistant versions.

## Proposed change
Simple change to config.json.


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] Tests have been added to verify that the new code works.
- [ ] Code documentation was added where necessary

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated
